### PR TITLE
fix: Startup Message General problem with descriptor entry

### DIFF
--- a/mylyn.commons/org.eclipse.mylyn.commons.identity.core/OSGI-INF/component.xml
+++ b/mylyn.commons/org.eclipse.mylyn.commons.identity.core/OSGI-INF/component.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<scr:component xmlns:scr="https://www.osgi.org/xmlns/scr/v1.1.0" name="org.eclipse.mylyn.commons.identity.core">
+<component name="org.eclipse.mylyn.commons.identity.core">
    <implementation class="org.eclipse.mylyn.internal.commons.identity.core.IdentityService"/>
    <service>
       <provide interface="org.eclipse.mylyn.commons.identity.core.IIdentityService"/>
    </service>
-</scr:component>
+</component>


### PR DESCRIPTION
for "!MESSAGE bundle org.eclipse.mylyn.commons.identity.core:3.26.0.qualifier (608) General problem with descriptor entry '/OSGI-INF/component.xml' "
As a Result we do not see the pictures in UserAttributeEditor