### PR TITLE
Hudson connector needs JAXB-API with Java 11+ #55

### DIFF
--- a/mylyn.builds/org.eclipse.mylyn.builds.sdk-feature/feature.xml
+++ b/mylyn.builds/org.eclipse.mylyn.builds.sdk-feature/feature.xml
@@ -76,25 +76,4 @@
          version="0.0.0"
          unpack="false"/>
 
-   <plugin
-         id="jakarta.xml.bind"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
-         id="com.sun.xml.bind"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
-         id="javax.xml.stream"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
 </feature>

--- a/mylyn.builds/org.eclipse.mylyn.hudson-feature/feature.xml
+++ b/mylyn.builds/org.eclipse.mylyn.hudson-feature/feature.xml
@@ -35,9 +35,6 @@
 
    <requires>
       <import plugin="com.google.gson" version="2.1.0" match="compatible"/>
-      <import plugin="com.sun.xml.bind" version="2.3.3" match="equivalent"/>
-      <import plugin="jakarta.xml.bind" version="2.3.3" match="equivalent"/>
-      <import plugin="javax.xml.stream" version="1.0.1" match="equivalent"/>
       <import feature="org.eclipse.mylyn.builds" version="3.26.0" match="compatible"/>
       <import feature="org.eclipse.mylyn.commons.repositories.http" version="3.26.0" match="compatible"/>
    </requires>

--- a/mylyn.builds/org.eclipse.mylyn.hudson.core/META-INF/MANIFEST.MF
+++ b/mylyn.builds/org.eclipse.mylyn.hudson.core/META-INF/MANIFEST.MF
@@ -23,7 +23,6 @@ Export-Package: org.eclipse.mylyn.hudson.core;x-friends:="org.eclipse.mylyn.huds
 Bundle-Activator: org.eclipse.mylyn.internal.hudson.core.HudsonCorePlugin
 Import-Package: com.google.gson;version="[2.7.0,2.9.2)",
  com.sun.xml.bind;version="2.3.3",
- jakarta.activation;version="2.0.0",
  javax.xml.bind;version="2.3.3",
  javax.xml.bind.annotation;version="2.3.3",
  org.apache.http;version="[4.4.4,4.5.0)",

--- a/mylyn.builds/org.eclipse.mylyn.hudson.core/META-INF/MANIFEST.MF
+++ b/mylyn.builds/org.eclipse.mylyn.hudson.core/META-INF/MANIFEST.MF
@@ -4,9 +4,7 @@ Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.mylyn.hudson.core;singleton:=true
 Bundle-Version: 3.26.0.qualifier
 Bundle-Vendor: %Bundle-Vendor
-Require-Bundle: jakarta.xml.bind;bundle-version="2.3.3",
- jakarta.xml.bind-api;bundle-version="2.3.3",
- org.apache.commons.io;bundle-version="2.8.0",
+Require-Bundle: org.apache.commons.io;bundle-version="2.8.0",
  org.apache.httpcomponents.httpcore;bundle-version="4.4.15",
  org.eclipse.core.runtime;bundle-version="0.0.0",
  org.eclipse.emf.ecore;bundle-version="0.0.0",
@@ -24,8 +22,9 @@ Export-Package: org.eclipse.mylyn.hudson.core;x-friends:="org.eclipse.mylyn.huds
  org.eclipse.mylyn.internal.hudson.model;x-friends:="org.eclipse.mylyn.hudson.ui"
 Bundle-Activator: org.eclipse.mylyn.internal.hudson.core.HudsonCorePlugin
 Import-Package: com.google.gson;version="[2.7.0,2.9.2)",
- com.sun.xml.bind;version="2.3.3",
  jakarta.activation;version="2.0.0",
+ javax.xml.bind;version="2.3.3",
+ javax.xml.bind.annotation;version="2.3.3",
  org.apache.http;version="[4.4.4,4.5.0)",
  org.apache.http.client;version="[4.5.2,4.6.0)",
  org.apache.http.client.entity;version="[4.5.2,4.6.0)",

--- a/mylyn.builds/org.eclipse.mylyn.hudson.core/META-INF/MANIFEST.MF
+++ b/mylyn.builds/org.eclipse.mylyn.hudson.core/META-INF/MANIFEST.MF
@@ -22,6 +22,7 @@ Export-Package: org.eclipse.mylyn.hudson.core;x-friends:="org.eclipse.mylyn.huds
  org.eclipse.mylyn.internal.hudson.model;x-friends:="org.eclipse.mylyn.hudson.ui"
 Bundle-Activator: org.eclipse.mylyn.internal.hudson.core.HudsonCorePlugin
 Import-Package: com.google.gson;version="[2.7.0,2.9.2)",
+ com.sun.xml.bind;version="2.3.3",
  jakarta.activation;version="2.0.0",
  javax.xml.bind;version="2.3.3",
  javax.xml.bind.annotation;version="2.3.3",

--- a/mylyn.commons/org.eclipse.mylyn.commons.notifications-feature/feature.xml
+++ b/mylyn.commons/org.eclipse.mylyn.commons.notifications-feature/feature.xml
@@ -34,9 +34,6 @@
    </license>
 
    <requires>
-      <import plugin="jakarta.xml.bind" version="2.3.3" match="equivalent"/>
-      <import plugin="com.sun.xml.bind" version="2.3.3" match="equivalent"/>
-      <import plugin="javax.xml.stream" version="1.0.1" match="equivalent"/>
       <import feature="org.eclipse.mylyn.commons" version="3.26.0" match="greaterOrEqual"/>
    </requires>
 

--- a/mylyn.commons/org.eclipse.mylyn.commons.notifications.feed/META-INF/MANIFEST.MF
+++ b/mylyn.commons/org.eclipse.mylyn.commons.notifications.feed/META-INF/MANIFEST.MF
@@ -7,7 +7,9 @@ Bundle-Vendor: %Bundle-Vendor
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Export-Package: org.eclipse.mylyn.commons.notifications.feed;x-internal:=true,
  org.eclipse.mylyn.internal.commons.notifications.feed;x-internal:=true
-Import-Package: javax.xml.bind;version="2.3.3",
+Import-Package: com.sun.xml.bind;version="2.3.3",
+ javax.activation;version="1.2.2",
+ javax.xml.bind;version="2.3.3",
  javax.xml.bind.annotation;version="2.3.3"
 Require-Bundle: org.eclipse.core.runtime;bundle-version="0.0.0",
  org.eclipse.mylyn.commons.core;bundle-version="3.26.0",

--- a/mylyn.commons/org.eclipse.mylyn.commons.notifications.feed/META-INF/MANIFEST.MF
+++ b/mylyn.commons/org.eclipse.mylyn.commons.notifications.feed/META-INF/MANIFEST.MF
@@ -7,8 +7,9 @@ Bundle-Vendor: %Bundle-Vendor
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Export-Package: org.eclipse.mylyn.commons.notifications.feed;x-internal:=true,
  org.eclipse.mylyn.internal.commons.notifications.feed;x-internal:=true
-Require-Bundle: jakarta.xml.bind;bundle-version="2.3.3",
- org.eclipse.core.runtime;bundle-version="0.0.0",
+Import-Package: javax.xml.bind;version="2.3.3",
+ javax.xml.bind.annotation;version="2.3.3"
+Require-Bundle: org.eclipse.core.runtime;bundle-version="0.0.0",
  org.eclipse.mylyn.commons.core;bundle-version="3.26.0",
  org.eclipse.mylyn.commons.notifications.core;bundle-version="3.26.0"
 Bundle-ClassPath: .

--- a/mylyn.commons/org.eclipse.mylyn.commons.notifications.tests/META-INF/MANIFEST.MF
+++ b/mylyn.commons/org.eclipse.mylyn.commons.notifications.tests/META-INF/MANIFEST.MF
@@ -4,7 +4,8 @@ Bundle-Name: Mylyn Commons Notifications Tests
 Bundle-SymbolicName: org.eclipse.mylyn.commons.notifications.tests;singleton:=true
 Bundle-Version: 3.26.0.qualifier
 Bundle-Vendor: Eclipse Mylyn
-Require-Bundle: org.eclipse.core.runtime;bundle-version="0.0.0",
+Require-Bundle: com.sun.xml.bind;bundle-version="2.3.3",
+ org.eclipse.core.runtime;bundle-version="0.0.0",
  org.eclipse.mylyn.commons.core;bundle-version="3.26.0",
  org.eclipse.mylyn.commons.sdk.util;bundle-version="3.26.0",
  org.eclipse.mylyn.commons.notifications.core;bundle-version="3.26.0",

--- a/mylyn.commons/org.eclipse.mylyn.commons.notifications.tests/META-INF/MANIFEST.MF
+++ b/mylyn.commons/org.eclipse.mylyn.commons.notifications.tests/META-INF/MANIFEST.MF
@@ -4,8 +4,7 @@ Bundle-Name: Mylyn Commons Notifications Tests
 Bundle-SymbolicName: org.eclipse.mylyn.commons.notifications.tests;singleton:=true
 Bundle-Version: 3.26.0.qualifier
 Bundle-Vendor: Eclipse Mylyn
-Require-Bundle: com.sun.xml.bind;bundle-version="2.3.3",
- org.eclipse.core.runtime;bundle-version="0.0.0",
+Require-Bundle: org.eclipse.core.runtime;bundle-version="0.0.0",
  org.eclipse.mylyn.commons.core;bundle-version="3.26.0",
  org.eclipse.mylyn.commons.sdk.util;bundle-version="3.26.0",
  org.eclipse.mylyn.commons.notifications.core;bundle-version="3.26.0",

--- a/mylyn.commons/org.eclipse.mylyn.commons.sdk-feature/feature.xml
+++ b/mylyn.commons/org.eclipse.mylyn.commons.sdk-feature/feature.xml
@@ -299,25 +299,4 @@
          version="0.0.0"
          unpack="false"/>
 
-   <plugin
-         id="jakarta.xml.bind"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
-         id="com.sun.xml.bind"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
-         id="javax.xml.stream"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
 </feature>

--- a/org.eclipse.mylyn-site/category.xml
+++ b/org.eclipse.mylyn-site/category.xml
@@ -113,6 +113,10 @@
    <feature id="org.eclipse.mylyn.versions.sdk">
       <category name="org.eclipse.mylyn.sdk.category"/>
    </feature>
+   <bundle id="com.sun.xml.bind"/>
+   <bundle id="jakarta.xml.bind"/>
+   <bundle id="javax.xml.stream"/>
+   <bundle id="org.glassfish.hk2.osgi-resource-locator"/>
    <feature id="org.eclipse.mylyn.builds.development">
       <category name="org.eclipse.mylyn.tests.category"/>
    </feature>


### PR DESCRIPTION
Switch from `Require-Bundle` to `Import-Package`for javax.xml 
Switch from includes/requires for feature to providing in repository