### PR TITLE
70 org.eclipse.mylyn.tasks.activity.tests fails

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,7 +8,7 @@ pipeline {
 		label "centos-latest"
 	}
 	tools {
-		maven 'apache-maven-latest'
+		maven 'apache-maven-3.8.6'
 		jdk 'openjdk-jdk17-latest'
 	}
 	stages {

--- a/mylyn.reviews/org.eclipse.mylyn.reviews.ui.tests/src/org/eclipse/mylyn/internal/reviews/ui/annotations/CommentPopupDialogTest.java
+++ b/mylyn.reviews/org.eclipse.mylyn.reviews.ui.tests/src/org/eclipse/mylyn/internal/reviews/ui/annotations/CommentPopupDialogTest.java
@@ -21,7 +21,6 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import java.text.DateFormat;
-import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
@@ -676,7 +675,7 @@ public class CommentPopupDialogTest extends TestCase {
 		String[] commentLabel = ((Label) controls[0]).getText().split("   ");
 		assertEquals(2, commentLabel.length);
 		assertEquals(USER_NAME, commentLabel[0]);
-		DateFormat format = new SimpleDateFormat("MMM d, yyyy, h:mm aa");
+		DateFormat format = DateFormat.getDateTimeInstance(DateFormat.MEDIUM, DateFormat.SHORT);
 		assertEquals(format.format(commentDate), commentLabel[1]);
 
 		if (isDraft) {

--- a/mylyn.tasks/org.eclipse.mylyn-feature/feature.xml
+++ b/mylyn.tasks/org.eclipse.mylyn-feature/feature.xml
@@ -40,9 +40,9 @@
       <import plugin="org.apache.commons.lang" version="2.3.0" match="compatible"/>
       <import plugin="org.apache.commons.logging" version="1.0.4" match="compatible"/>
       <import plugin="org.apache.commons.httpclient" version="3.1.0" match="compatible"/>
-      <import plugin="org.apache.lucene.core" version="6.0.0" match="greaterOrEqual"/>
-      <import plugin="org.apache.lucene.analyzers-common" version="6.0.0" match="greaterOrEqual"/>
-      <import plugin="org.apache.lucene.queryparser" version="6.0.0" match="greaterOrEqual"/>
+      <import plugin="org.apache.lucene.core" version="6.1.0" match="equivalent"/>
+      <import plugin="org.apache.lucene.analyzers-common" version="6.1.0" match="equivalent"/>
+      <import plugin="org.apache.lucene.queryparser" version="6.1.0" match="equivalent"/>
       <import plugin="org.eclipse.mylyn.commons.net" version="3.26.0" match="compatible"/>
       <import feature="org.eclipse.mylyn.commons" version="3.26.0" match="compatible"/>
       <import feature="org.eclipse.mylyn.commons.identity" version="3.26.0" match="compatible"/>

--- a/mylyn.tasks/org.eclipse.mylyn.tasks.index.core/META-INF/MANIFEST.MF
+++ b/mylyn.tasks/org.eclipse.mylyn.tasks.index.core/META-INF/MANIFEST.MF
@@ -4,9 +4,9 @@ Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.mylyn.tasks.index.core
 Bundle-Version: 3.26.0.qualifier
 Bundle-Vendor: %Bundle-Vendor
-Require-Bundle: org.apache.lucene.analyzers-common;bundle-version="6.1.0",
- org.apache.lucene.core;bundle-version="6.1.0",
- org.apache.lucene.queryparser;bundle-version="6.1.0",
+Require-Bundle: org.apache.lucene.analyzers-common;bundle-version="[6.1.0,8.0.0)",
+ org.apache.lucene.core;bundle-version="[6.1.0,8.0.0)",
+ org.apache.lucene.queryparser;bundle-version="[6.1.0,8.0.0)",
  org.eclipse.core.runtime;bundle-version="0.0.0",
  org.eclipse.mylyn.tasks.core;bundle-version="3.26.0",
  org.eclipse.mylyn.commons.core;bundle-version="3.26.0"

--- a/mylyn.tasks/org.eclipse.mylyn.tasks.tests/src/org/eclipse/mylyn/tasks/tests/TasksUiUtilTest.java
+++ b/mylyn.tasks/org.eclipse.mylyn.tasks.tests/src/org/eclipse/mylyn/tasks/tests/TasksUiUtilTest.java
@@ -15,7 +15,6 @@ package org.eclipse.mylyn.tasks.tests;
 
 import java.util.Date;
 
-import org.eclipse.mylyn.commons.ui.PlatformUiUtil;
 import org.eclipse.mylyn.internal.tasks.core.AbstractTask;
 import org.eclipse.mylyn.internal.tasks.core.TaskCategory;
 import org.eclipse.mylyn.internal.tasks.core.TaskList;
@@ -30,7 +29,6 @@ import org.eclipse.mylyn.tests.util.TasksUiTestUtil;
 import org.eclipse.ui.IEditorPart;
 import org.eclipse.ui.IWorkbenchPage;
 import org.eclipse.ui.PlatformUI;
-import org.junit.Ignore;
 
 import junit.framework.TestCase;
 
@@ -96,96 +94,6 @@ public class TasksUiUtilTest extends TestCase {
 		editor = activePage.getEditorReferences()[1].getEditor(true);
 		assertNotNull(editor);
 		assertEquals(TaskEditor.class, editor.getClass());
-	}
-
-	@Ignore
-	public void testOpenTaskFromString() {
-		if (!PlatformUiUtil.hasInternalBrowser()) {
-			return;
-		}
-		//FIXME: AF: not clear why do we expect browser to open with 'null' URL
-		//https://github.com/eclipse-mylyn/org.eclipse.mylyn.tasks/issues/6
-//		TasksUiUtil.openTask((String) null);
-//		assertEquals(1, activePage.getEditorReferences().length);
-//		IEditorPart editor = activePage.getEditorReferences()[0].getEditor(true);
-//		assertEquals(WebBrowserEditor.class, editor.getClass());
-	}
-
-	@Ignore
-	public void testOpenUrl() {
-		if (!PlatformUiUtil.hasInternalBrowser()) {
-			return;
-		}
-
-		//FIXME: AF: not clear why do we expect browser to open with 'null' URL
-		//https://github.com/eclipse-mylyn/org.eclipse.mylyn.tasks/issues/6
-//		TasksUiUtil.openUrl(null);
-//		assertEquals(0, activePage.getEditorReferences().length);
-//		TasksUiUtil.openUrl("http://eclipse.org/mylyn");
-//		assertEquals(1, activePage.getEditorReferences().length);
-//		IEditorPart editor = activePage.getEditorReferences()[0].getEditor(true);
-//		assertEquals(WebBrowserEditor.class, editor.getClass());
-//		assertEquals(WebBrowserEditorInput.class, editor.getEditorInput().getClass());
-//		assertEquals("http://eclipse.org/mylyn", ((WebBrowserEditorInput) editor.getEditorInput()).getURL().toString());
-	}
-
-	@Ignore
-	public void testFlagNoRichEditor() throws Exception {
-		if (!PlatformUiUtil.hasInternalBrowser()) {
-			return;
-		}
-
-		//FIXME: AF: not clear why do we expect browser to open with 'null' URL
-		//https://github.com/eclipse-mylyn/org.eclipse.mylyn.tasks/issues/6
-//		TasksUiUtil.openUrl(null);
-//		assertEquals(1, activePage.getEditorReferences().length);
-//		IEditorPart editor = activePage.getEditorReferences()[0].getEditor(true);
-//		assertEquals(WebBrowserEditor.class, editor.getClass());
-//		assertEquals(WebBrowserEditorInput.class, editor.getEditorInput().getClass());
-//		assertEquals(null, ((WebBrowserEditorInput) editor.getEditorInput()).getURL());
-//		WebBrowserEditorInput input = ((WebBrowserEditorInput) editor.getEditorInput());
-//		Field f = input.getClass().getDeclaredField("style");
-//		f.setAccessible(true);
-//		int style = (Integer) f.get(input);
-//		assertFalse((style & BrowserUtil.NO_RICH_EDITOR) == 0);
-//
-//		TasksUiUtil.openUrl("http://eclipse.org/mylyn");
-//		assertEquals(2, activePage.getEditorReferences().length);
-//		editor = activePage.getEditorReferences()[0].getEditor(true);
-//		assertEquals(WebBrowserEditor.class, editor.getClass());
-//		assertEquals(WebBrowserEditorInput.class, editor.getEditorInput().getClass());
-//		assertEquals(null, ((WebBrowserEditorInput) editor.getEditorInput()).getURL());
-//		input = ((WebBrowserEditorInput) editor.getEditorInput());
-//		f = input.getClass().getDeclaredField("style");
-//		f.setAccessible(true);
-//		style = (Integer) f.get(input);
-//		assertFalse((style & BrowserUtil.NO_RICH_EDITOR) == 0);
-//
-//		IEditorPart editor2 = activePage.getEditorReferences()[1].getEditor(true);
-//		assertEquals(WebBrowserEditor.class, editor2.getClass());
-//		assertEquals(WebBrowserEditorInput.class, editor2.getEditorInput().getClass());
-//		assertNotNull(((WebBrowserEditorInput) editor2.getEditorInput()).getURL());
-//		assertEquals("http://eclipse.org/mylyn",
-//				((WebBrowserEditorInput) editor2.getEditorInput()).getURL().toString());
-//		input = ((WebBrowserEditorInput) editor.getEditorInput());
-//		f = input.getClass().getDeclaredField("style");
-//		f.setAccessible(true);
-//		style = (Integer) f.get(input);
-//		assertFalse((style & BrowserUtil.NO_RICH_EDITOR) == 0);
-//
-//		// open task should not set FLAG_NO_RICH_EDITOR
-//		TasksUiUtil.openTask("http://eclipse.org/mylyn/test");
-//		assertEquals(3, activePage.getEditorReferences().length);
-//		editor = activePage.getEditorReferences()[2].getEditor(true);
-//		assertEquals(WebBrowserEditor.class, editor.getClass());
-//		assertEquals(WebBrowserEditorInput.class, editor.getEditorInput().getClass());
-//		assertEquals("http://eclipse.org/mylyn/test",
-//				((WebBrowserEditorInput) editor.getEditorInput()).getURL().toString());
-//		input = ((WebBrowserEditorInput) editor.getEditorInput());
-//		f = input.getClass().getDeclaredField("style");
-//		f.setAccessible(true);
-//		style = (Integer) f.get(input);
-//		assertTrue((style & BrowserUtil.NO_RICH_EDITOR) == 0);
 	}
 
 	public void testOpenLocalTask() {

--- a/org.eclipse.mylyn-site/category.xml
+++ b/org.eclipse.mylyn-site/category.xml
@@ -107,10 +107,6 @@
    <feature id="org.eclipse.mylyn.versions.sdk">
       <category name="org.eclipse.mylyn.sdk.category"/>
    </feature>
-   <bundle id="com.sun.xml.bind"/>
-   <bundle id="jakarta.xml.bind"/>
-   <bundle id="javax.xml.stream"/>
-   <bundle id="org.glassfish.hk2.osgi-resource-locator"/>
    <feature id="org.eclipse.mylyn.builds.development">
       <category name="org.eclipse.mylyn.tests.category"/>
    </feature>
@@ -132,6 +128,13 @@
    <feature id="org.eclipse.mylyn.github.feature" version="6.2.0.qualifier">
       <category name="github_connector"/>
    </feature>
+   <bundle id="com.sun.xml.bind"/>
+   <bundle id="jakarta.xml.bind"/>
+   <bundle id="javax.xml.stream"/>
+   <bundle id="org.glassfish.hk2.osgi-resource-locator"/>
+   <bundle id="org.apache.lucene.core"/>
+   <bundle id="org.apache.lucene.analyzers-common"/>
+   <bundle id="org.apache.lucene.queryparser"/>
    <category-def name="org.eclipse.mylyn.features.category" label="Mylyn Features">
       <description>
          The Task List and the Task-Focused Interface.


### PR DESCRIPTION
With this we only use org.apache.lucene version to be less then 8.0 so we do not migrate the data and can stay with the tested 6.1 version.

To get the build work I need to switch to apache-maven-3.8.6 (from apache-maven-latest) Maven 3.9 did not work and 3.9.1 is actual not available.