### PR TITLE
Apache Lucene update from 6.1.0 to Apache Lucene 9.5.0 (#82)

### DIFF
--- a/.github/workflows/licensecheck.yml
+++ b/.github/workflows/licensecheck.yml
@@ -18,6 +18,6 @@ jobs:
   call-license-check:
     uses: eclipse/dash-licenses/.github/workflows/mavenLicenseCheck.yml@master
     with:
-      projectId: technology.mylyn
+      projectId: tools.mylyn
     secrets:
       gitlabAPIToken: ${{ secrets.GITLAB_API_TOKEN }}

--- a/mylyn.tasks/connectors/bugzilla/org.eclipse.mylyn.bugzilla.tests/src/org/eclipse/mylyn/bugzilla/tests/BugzillaAttachmentHandlerTest.java
+++ b/mylyn.tasks/connectors/bugzilla/org.eclipse.mylyn.bugzilla.tests/src/org/eclipse/mylyn/bugzilla/tests/BugzillaAttachmentHandlerTest.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
  * Copyright (c) 2009, 2016 Tasktop Technologies and others.
- * 
+ *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
  * https://www.eclipse.org/legal/epl-2.0
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -12,8 +12,6 @@
  *******************************************************************************/
 
 package org.eclipse.mylyn.bugzilla.tests;
-
-import static org.junit.Assume.assumeTrue;
 
 import java.io.BufferedOutputStream;
 import java.io.BufferedWriter;
@@ -311,7 +309,9 @@ public class BugzillaAttachmentHandlerTest extends AbstractBugzillaTest {
 
 	public void testAttachmentWithUnicode() throws Exception {
 		String osName = System.getProperty("os.name").toLowerCase();
-		assumeTrue(!osName.startsWith("mac os x"));
+		if (osName.startsWith("mac os x")) {
+			return;
+		}
 		// macos X with APFS can not handle this
 		testAttachmentWithSpecialCharacters(
 				"\u00E7\u00F1\u00A5\u20AC\u00A3\u00BD\u00BC\u03B2\u03B8\u53F0\u5317\u3096\u3097\uFF73");

--- a/mylyn.tasks/org.eclipse.mylyn-feature/feature.xml
+++ b/mylyn.tasks/org.eclipse.mylyn-feature/feature.xml
@@ -40,9 +40,9 @@
       <import plugin="org.apache.commons.lang" version="2.3.0" match="compatible"/>
       <import plugin="org.apache.commons.logging" version="1.0.4" match="compatible"/>
       <import plugin="org.apache.commons.httpclient" version="3.1.0" match="compatible"/>
-      <import plugin="org.apache.lucene.core" version="6.1.0" match="equivalent"/>
-      <import plugin="org.apache.lucene.analyzers-common" version="6.1.0" match="equivalent"/>
-      <import plugin="org.apache.lucene.queryparser" version="6.1.0" match="equivalent"/>
+      <import plugin="org.apache.lucene.lucene-core" version="9.5.0" match="greaterOrEqual"/>
+      <import plugin="org.apache.lucene.lucene-analyzers-common" version="8.11.2" match="greaterOrEqual"/>
+      <import plugin="org.apache.lucene.lucene-queryparser" version="9.5.0" match="greaterOrEqual"/>
       <import plugin="org.eclipse.mylyn.commons.net" version="3.26.0" match="compatible"/>
       <import feature="org.eclipse.mylyn.commons" version="3.26.0" match="compatible"/>
       <import feature="org.eclipse.mylyn.commons.identity" version="3.26.0" match="compatible"/>

--- a/mylyn.tasks/org.eclipse.mylyn-feature/feature.xml
+++ b/mylyn.tasks/org.eclipse.mylyn-feature/feature.xml
@@ -40,8 +40,8 @@
       <import plugin="org.apache.commons.lang" version="2.3.0" match="compatible"/>
       <import plugin="org.apache.commons.logging" version="1.0.4" match="compatible"/>
       <import plugin="org.apache.commons.httpclient" version="3.1.0" match="compatible"/>
+      <import plugin="org.apache.lucene.lucene-analysis-common" version="9.5.0" match="greaterOrEqual"/>
       <import plugin="org.apache.lucene.lucene-core" version="9.5.0" match="greaterOrEqual"/>
-      <import plugin="org.apache.lucene.lucene-analyzers-common" version="8.11.2" match="greaterOrEqual"/>
       <import plugin="org.apache.lucene.lucene-queryparser" version="9.5.0" match="greaterOrEqual"/>
       <import plugin="org.eclipse.mylyn.commons.net" version="3.26.0" match="compatible"/>
       <import feature="org.eclipse.mylyn.commons" version="3.26.0" match="compatible"/>

--- a/mylyn.tasks/org.eclipse.mylyn.sdk-feature/feature.xml
+++ b/mylyn.tasks/org.eclipse.mylyn.sdk-feature/feature.xml
@@ -67,27 +67,6 @@
          unpack="false"/>
 
    <plugin
-         id="org.apache.lucene.core"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
-         id="org.apache.lucene.analyzers-common"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
-         id="org.apache.lucene.queryparser"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
          id="org.eclipse.mylyn.tests.util"
          download-size="0"
          install-size="0"

--- a/mylyn.tasks/org.eclipse.mylyn.tasks.index.core/META-INF/MANIFEST.MF
+++ b/mylyn.tasks/org.eclipse.mylyn.tasks.index.core/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.mylyn.tasks.index.core
 Bundle-Version: 3.26.0.qualifier
 Bundle-Vendor: %Bundle-Vendor
-Require-Bundle: org.apache.lucene.lucene-analyzers-common;bundle-version="8.11.2",
+Require-Bundle: org.apache.lucene.lucene-analysis-common;bundle-version="9.5.0",
  org.apache.lucene.lucene-core;bundle-version="9.5.0",
  org.apache.lucene.lucene-queryparser;bundle-version="9.5.0",
  org.eclipse.core.runtime;bundle-version="0.0.0",

--- a/mylyn.tasks/org.eclipse.mylyn.tasks.index.core/META-INF/MANIFEST.MF
+++ b/mylyn.tasks/org.eclipse.mylyn.tasks.index.core/META-INF/MANIFEST.MF
@@ -4,9 +4,9 @@ Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.mylyn.tasks.index.core
 Bundle-Version: 3.26.0.qualifier
 Bundle-Vendor: %Bundle-Vendor
-Require-Bundle: org.apache.lucene.analyzers-common;bundle-version="[6.1.0,8.0.0)",
- org.apache.lucene.core;bundle-version="[6.1.0,8.0.0)",
- org.apache.lucene.queryparser;bundle-version="[6.1.0,8.0.0)",
+Require-Bundle: org.apache.lucene.lucene-analyzers-common;bundle-version="8.11.2",
+ org.apache.lucene.lucene-core;bundle-version="9.5.0",
+ org.apache.lucene.lucene-queryparser;bundle-version="9.5.0",
  org.eclipse.core.runtime;bundle-version="0.0.0",
  org.eclipse.mylyn.tasks.core;bundle-version="3.26.0",
  org.eclipse.mylyn.commons.core;bundle-version="3.26.0"

--- a/mylyn.tasks/org.eclipse.mylyn.tasks.index.core/src/org/eclipse/mylyn/internal/tasks/index/core/TaskListIndex.java
+++ b/mylyn.tasks/org.eclipse.mylyn.tasks.index.core/src/org/eclipse/mylyn/internal/tasks/index/core/TaskListIndex.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
  * Copyright (c) 2011, 2015 Tasktop Technologies.
- * 
+ *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
  * https://www.eclipse.org/legal/epl-2.0
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -217,6 +217,10 @@ public class TaskListIndex implements ITaskDataManagerListener, ITaskListChangeL
 		specialFields.add(FIELD_TASK_KEY);
 		specialFields.add(FIELD_ATTACHMENT_NAME);
 		specialFields.add(FIELD_NOTES);
+		specialFields.add(DefaultTaskSchema.getInstance().DATE_COMPLETION);
+		specialFields.add(DefaultTaskSchema.getInstance().DATE_CREATION);
+		specialFields.add(DefaultTaskSchema.getInstance().DATE_DUE);
+		specialFields.add(DefaultTaskSchema.getInstance().DATE_MODIFICATION);
 
 		addIndexedField(FIELD_IDENTIFIER);
 		addIndexedField(FIELD_TASK_KEY);

--- a/mylyn.tasks/org.eclipse.mylyn.tasks.tests/src/org/eclipse/mylyn/tasks/tests/AllTasksTests.java
+++ b/mylyn.tasks/org.eclipse.mylyn.tasks.tests/src/org/eclipse/mylyn/tasks/tests/AllTasksTests.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
  * Copyright (c) 2004, 2016 Tasktop Technologies and others.
- * 
+ *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
  * https://www.eclipse.org/legal/epl-2.0
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -79,6 +79,7 @@ public class AllTasksTests {
 	}
 
 	public static void addTests(TestSuite suite) {
+		suite.addTestSuite(ScheduledTaskContainerTest.class);
 		suite.addTestSuite(TasksUiUtilTest.class);
 		suite.addTestSuite(TaskListUiTest.class);
 		suite.addTestSuite(TaskRepositoryCredentialsTest.class);
@@ -165,7 +166,6 @@ public class AllTasksTests {
 		suite.addTestSuite(AbstractRepositoryConnectorUiTest.class);
 		suite.addTestSuite(SynchronizeTasksJobTest.class);
 		suite.addTestSuite(TaskAttributeTest.class);
-		suite.addTestSuite(ScheduledTaskContainerTest.class);
 		suite.addTestSuite(RepositoryConnectorContributorTest.class);
 		suite.addTestSuite(TaskInitializationDataTest.class);
 		suite.addTestSuite(TaskDataDiffTest.class);

--- a/org.eclipse.mylyn-site/category.xml
+++ b/org.eclipse.mylyn-site/category.xml
@@ -133,8 +133,8 @@
    <bundle id="javax.xml.stream"/>
    <bundle id="org.glassfish.hk2.osgi-resource-locator"/>
    <bundle id="org.apache.lucene.lucene-core"/>
+   <bundle id="org.apache.lucene.lucene-analysis-common"/>
    <bundle id="org.apache.lucene.lucene-queryparser"/>
-   <bundle id="org.apache.lucene.lucene-analyzers-common"/>
    <category-def name="org.eclipse.mylyn.features.category" label="Mylyn Features">
       <description>
          The Task List and the Task-Focused Interface.

--- a/org.eclipse.mylyn-site/category.xml
+++ b/org.eclipse.mylyn-site/category.xml
@@ -132,9 +132,9 @@
    <bundle id="jakarta.xml.bind"/>
    <bundle id="javax.xml.stream"/>
    <bundle id="org.glassfish.hk2.osgi-resource-locator"/>
-   <bundle id="org.apache.lucene.core"/>
-   <bundle id="org.apache.lucene.analyzers-common"/>
-   <bundle id="org.apache.lucene.queryparser"/>
+   <bundle id="org.apache.lucene.lucene-core"/>
+   <bundle id="org.apache.lucene.lucene-queryparser"/>
+   <bundle id="org.apache.lucene.lucene-analyzers-common"/>
    <category-def name="org.eclipse.mylyn.features.category" label="Mylyn Features">
       <description>
          The Task List and the Task-Focused Interface.

--- a/org.eclipse.mylyn-target/mylyn-e4.26.target
+++ b/org.eclipse.mylyn-target/mylyn-e4.26.target
@@ -2,102 +2,78 @@
 <?pde version="3.8"?>
 <target name="mylyn-e4.26">
 	<locations>
-		<location includeAllPlatforms="false" includeConfigurePhase="false"
-			includeMode="planner" includeSource="true" type="InstallableUnit">
-			<repository
-				location="https://download.eclipse.org/cbi/updates/license/" />
-			<unit id="org.eclipse.license.feature.group" version="0.0.0" />
+		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
+			<repository location="https://download.eclipse.org/cbi/updates/license/"/>
+			<unit id="org.eclipse.license.feature.group" version="0.0.0"/>
 		</location>
-		<location includeAllPlatforms="false" includeConfigurePhase="true"
-			includeMode="planner" includeSource="true" type="InstallableUnit">
-			<repository
-				location="https://download.eclipse.org/eclipse/updates/4.26/R-4.26-202211231800/" />
-			<unit id="org.eclipse.equinox.sdk.feature.group" version="0.0.0" />
-			<unit id="org.eclipse.sdk.feature.group" version="0.0.0" />
+		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+			<repository location="https://download.eclipse.org/eclipse/updates/4.26/R-4.26-202211231800/"/>
+			<unit id="org.eclipse.equinox.sdk.feature.group" version="0.0.0"/>
+			<unit id="org.eclipse.sdk.feature.group" version="0.0.0"/>
 		</location>
-		<location includeAllPlatforms="false" includeConfigurePhase="true"
-			includeMode="planner" includeSource="true" type="InstallableUnit">
-			<repository
-				location="https://download.eclipse.org/egit/updates-6.2/" />
-			<unit id="org.eclipse.egit.feature.group"
-				version="6.2.0.202206071550-r" />
-			<unit id="org.eclipse.jgit.feature.group"
-				version="6.2.0.202206071550-r" />
-			<unit id="org.eclipse.jgit.lfs.feature.group"
-				version="6.2.0.202206071550-r" />
+		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+			<repository location="https://download.eclipse.org/egit/updates-6.2/"/>
+			<unit id="org.eclipse.egit.feature.group" version="6.2.0.202206071550-r"/>
+			<unit id="org.eclipse.jgit.feature.group" version="6.2.0.202206071550-r"/>
+			<unit id="org.eclipse.jgit.lfs.feature.group" version="6.2.0.202206071550-r"/>
 		</location>
-		<location includeAllPlatforms="false" includeConfigurePhase="true"
-			includeMode="planner" includeSource="true" type="InstallableUnit">
-			<repository
-				location="https://download.eclipse.org/modeling/emf/emf/builds/release/2.32/" />
-			<unit id="org.eclipse.emf.sdk.feature.group" version="0.0.0" />
+		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+			<repository location="https://download.eclipse.org/modeling/emf/emf/builds/release/2.32/"/>
+			<unit id="org.eclipse.emf.sdk.feature.group" version="0.0.0"/>
 		</location>
-		<location includeAllPlatforms="false" includeConfigurePhase="true"
-			includeMode="planner" includeSource="true" type="InstallableUnit">
-			<repository
-				location="https://download.eclipse.org/rt/ecf/3.14.37/site.p2/3.14.37.v20221119-2038/" />
-			<unit id="org.eclipse.ecf.remoteservice.sdk.feature.feature.group"
-				version="0.0.0" />
+		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+			<repository location="https://download.eclipse.org/rt/ecf/3.14.37/site.p2/3.14.37.v20221119-2038/"/>
+			<unit id="org.eclipse.ecf.remoteservice.sdk.feature.feature.group" version="0.0.0"/>
 		</location>
-		<location includeAllPlatforms="false" includeConfigurePhase="true"
-			includeMode="planner" includeSource="true" type="InstallableUnit">
-			<repository
-				location="https://download.eclipse.org/tools/cdt/releases/11.0/" />
-			<unit id="org.eclipse.cdt.platform.feature.group" version="0.0.0" />
-			<unit id="org.eclipse.cdt.sdk.feature.group" version="0.0.0" />
+		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+			<repository location="https://download.eclipse.org/tools/cdt/releases/11.0/"/>
+			<unit id="org.eclipse.cdt.platform.feature.group" version="0.0.0"/>
+			<unit id="org.eclipse.cdt.sdk.feature.group" version="0.0.0"/>
 		</location>
-		<location includeAllPlatforms="false" includeConfigurePhase="true"
-			includeMode="planner" includeSource="true" type="InstallableUnit">
-			<repository
-				location="https://download.eclipse.org/tools/orbit/downloads/drops/R20180206163158/repository" />
-			<unit id="com.google.gerrit.common" version="0.0.0" />
-			<unit id="com.google.gerrit.prettify" version="0.0.0" />
-			<unit id="com.google.gerrit.reviewdb" version="0.0.0" />
-			<unit id="com.google.guava" version="0.0.0" />
-			<unit id="com.thoughtworks.qdox" version="0.0.0" />
-			<unit id="javax.xml.stream" version="0.0.0" />
+		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+			<repository location="https://download.eclipse.org/tools/orbit/downloads/drops/R20180206163158/repository"/>
+			<unit id="com.google.gerrit.common" version="0.0.0"/>
+			<unit id="com.google.gerrit.prettify" version="0.0.0"/>
+			<unit id="com.google.gerrit.reviewdb" version="0.0.0"/>
+			<unit id="com.google.guava" version="0.0.0"/>
+			<unit id="com.thoughtworks.qdox" version="0.0.0"/>
+			<unit id="javax.xml.stream" version="0.0.0"/>
+<!--
 			<unit id="org.apache.lucene.analyzers-common"
 				version="6.1.0.v20161115-1612" />
 			<unit id="org.apache.lucene.core" version="6.1.0.v20170814-1820" />
 			<unit id="org.apache.lucene.queryparser"
 				version="6.1.0.v20161115-1612" />
-			<unit id="org.hamcrest" version="0.0.0" />
-			<unit id="org.hamcrest.core" version="0.0.0" />
-			<unit id="org.hamcrest.generator" version="0.0.0" />
-			<unit id="org.hamcrest.integration" version="0.0.0" />
-			<unit id="org.hamcrest.library" version="0.0.0" />
-			<unit id="org.hamcrest.text" version="0.0.0" />
-			<unit id="org.mockito" version="0.0.0" />
+-->
+			<unit id="org.hamcrest" version="0.0.0"/>
+			<unit id="org.hamcrest.core" version="0.0.0"/>
+			<unit id="org.hamcrest.generator" version="0.0.0"/>
+			<unit id="org.hamcrest.integration" version="0.0.0"/>
+			<unit id="org.hamcrest.library" version="0.0.0"/>
+			<unit id="org.hamcrest.text" version="0.0.0"/>
+			<unit id="org.mockito" version="0.0.0"/>
 		</location>
-		<location includeAllPlatforms="false" includeConfigurePhase="true"
-			includeMode="planner" includeSource="true" type="InstallableUnit">
-			<repository
-				location="https://download.eclipse.org/tools/orbit/downloads/drops/R20221123021534/repository" />
-			<unit id="com.google.gson" version="0.0.0" />
-			<unit id="com.sun.xml.bind" version="0.0.0" />
-			<unit id="jakarta.activation" version="1.2.2.v20221112-0806" />
-			<unit id="jakarta.servlet" version="0.0.0" />
-			<unit id="org.apache.commons.lang" version="0.0.0" />
-			<unit id="org.apache.httpcomponents.httpclient" version="0.0.0" />
-			<unit id="org.apache.xerces" version="0.0.0" />
-			<unit id="org.apache.xmlrpc.client" version="0.0.0" />
-			<unit id="org.apache.xmlrpc.common" version="0.0.0" />
-			<unit id="org.apache.xmlrpc.server" version="0.0.0" />
-			<unit id="org.mockito.mockito-core" version="0.0.0" />
-			<unit id="org.objenesis" version="0.0.0" />
+		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+			<repository location="https://download.eclipse.org/tools/orbit/downloads/drops/R20221123021534/repository"/>
+			<unit id="com.google.gson" version="0.0.0"/>
+			<unit id="com.sun.xml.bind" version="0.0.0"/>
+			<unit id="jakarta.activation" version="1.2.2.v20221112-0806"/>
+			<unit id="jakarta.servlet" version="0.0.0"/>
+			<unit id="org.apache.commons.lang" version="0.0.0"/>
+			<unit id="org.apache.httpcomponents.httpclient" version="0.0.0"/>
+			<unit id="org.apache.xerces" version="0.0.0"/>
+			<unit id="org.apache.xmlrpc.client" version="0.0.0"/>
+			<unit id="org.apache.xmlrpc.common" version="0.0.0"/>
+			<unit id="org.apache.xmlrpc.server" version="0.0.0"/>
+			<unit id="org.mockito.mockito-core" version="0.0.0"/>
+			<unit id="org.objenesis" version="0.0.0"/>
 		</location>
-		<location includeAllPlatforms="false" includeConfigurePhase="false"
-			includeMode="planner" includeSource="true" type="InstallableUnit">
-			<repository
-				location="https://subclipse.github.io/updates/subclipse/1.8.x/" />
-			<unit id="org.tigris.subversion.clientadapter.feature.feature.group"
-				version="1.8.6" />
-			<unit id="org.tigris.subversion.subclipse.feature.group"
-				version="1.8.22" />
+		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
+			<repository location="https://subclipse.github.io/updates/subclipse/1.8.x/"/>
+			<unit id="org.tigris.subversion.clientadapter.feature.feature.group" version="1.8.6"/>
+			<unit id="org.tigris.subversion.subclipse.feature.group" version="1.8.22"/>
 		</location>
-		<location includeDependencyDepth="infinite"
-			includeDependencyScopes="compile,provided,runtime"
-			includeSource="true" missingManifest="generate" type="Maven">
+		<location includeDependencyDepth="infinite" includeDependencyScopes="compile,provided,runtime" includeSource="true" missingManifest="generate" type="Maven">
 			<dependencies>
 				<dependency>
 					<groupId>org.mockito</groupId>
@@ -134,6 +110,27 @@
 					<version>6.1.0.202203080745-r</version>
 					<type>jar</type>
 				</dependency>
+<!-- https://mvnrepository.com/artifact/org.apache.lucene/lucene-core -->
+<dependency>
+    <groupId>org.apache.lucene</groupId>
+    <artifactId>lucene-core</artifactId>
+    <version>9.5.0</version>
+					<type>jar</type>
+</dependency>
+<!-- https://mvnrepository.com/artifact/org.apache.lucene/lucene-queryparser -->
+<dependency>
+    <groupId>org.apache.lucene</groupId>
+    <artifactId>lucene-queryparser</artifactId>
+    <version>9.5.0</version>
+					<type>jar</type>
+</dependency>
+<!-- https://mvnrepository.com/artifact/org.apache.lucene/lucene-analyzers-common -->
+<dependency>
+    <groupId>org.apache.lucene</groupId>
+    <artifactId>lucene-analyzers-common</artifactId>
+    <version>8.11.2</version>
+					<type>jar</type>
+</dependency>
 			</dependencies>
 			<repositories>
 				<repository>

--- a/org.eclipse.mylyn-target/mylyn-e4.26.target
+++ b/org.eclipse.mylyn-target/mylyn-e4.26.target
@@ -38,13 +38,6 @@
 			<unit id="com.google.guava" version="0.0.0"/>
 			<unit id="com.thoughtworks.qdox" version="0.0.0"/>
 			<unit id="javax.xml.stream" version="0.0.0"/>
-<!--
-			<unit id="org.apache.lucene.analyzers-common"
-				version="6.1.0.v20161115-1612" />
-			<unit id="org.apache.lucene.core" version="6.1.0.v20170814-1820" />
-			<unit id="org.apache.lucene.queryparser"
-				version="6.1.0.v20161115-1612" />
--->
 			<unit id="org.hamcrest" version="0.0.0"/>
 			<unit id="org.hamcrest.core" version="0.0.0"/>
 			<unit id="org.hamcrest.generator" version="0.0.0"/>
@@ -76,9 +69,9 @@
 		<location includeDependencyDepth="infinite" includeDependencyScopes="compile,provided,runtime" includeSource="true" missingManifest="generate" type="Maven">
 			<dependencies>
 				<dependency>
-					<groupId>org.mockito</groupId>
-					<artifactId>mockito-inline</artifactId>
-					<version>4.8.1</version>
+					<groupId>com.sun.activation</groupId>
+					<artifactId>jakarta.activation</artifactId>
+					<version>2.0.1</version>
 					<type>jar</type>
 				</dependency>
 				<dependency>
@@ -94,15 +87,22 @@
 					<type>jar</type>
 				</dependency>
 				<dependency>
-					<groupId>org.glassfish.hk2</groupId>
-					<artifactId>osgi-resource-locator</artifactId>
-					<version>2.4.0</version>
+					<groupId>org.apache.lucene</groupId>
+					<artifactId>lucene-analysis-common</artifactId>
+					<version>9.5.0</version>
 					<type>jar</type>
 				</dependency>
 				<dependency>
-					<groupId>com.sun.activation</groupId>
-					<artifactId>jakarta.activation</artifactId>
-					<version>2.0.1</version>
+					<groupId>org.apache.lucene</groupId>
+					<artifactId>lucene-core</artifactId>
+					<version>9.5.0</version>
+					<type>jar</type>
+				</dependency>
+				<dependency>
+					<groupId>org.apache.lucene</groupId>
+					<artifactId>lucene-queryparser</artifactId>
+					<version>9.5.0</version>
+					<type>jar</type>
 				</dependency>
 				<dependency>
 					<groupId>org.eclipse.mylyn.github</groupId>
@@ -110,27 +110,18 @@
 					<version>6.1.0.202203080745-r</version>
 					<type>jar</type>
 				</dependency>
-<!-- https://mvnrepository.com/artifact/org.apache.lucene/lucene-core -->
-<dependency>
-    <groupId>org.apache.lucene</groupId>
-    <artifactId>lucene-core</artifactId>
-    <version>9.5.0</version>
+				<dependency>
+					<groupId>org.glassfish.hk2</groupId>
+					<artifactId>osgi-resource-locator</artifactId>
+					<version>2.4.0</version>
 					<type>jar</type>
-</dependency>
-<!-- https://mvnrepository.com/artifact/org.apache.lucene/lucene-queryparser -->
-<dependency>
-    <groupId>org.apache.lucene</groupId>
-    <artifactId>lucene-queryparser</artifactId>
-    <version>9.5.0</version>
+				</dependency>
+				<dependency>
+					<groupId>org.mockito</groupId>
+					<artifactId>mockito-inline</artifactId>
+					<version>4.8.1</version>
 					<type>jar</type>
-</dependency>
-<!-- https://mvnrepository.com/artifact/org.apache.lucene/lucene-analyzers-common -->
-<dependency>
-    <groupId>org.apache.lucene</groupId>
-    <artifactId>lucene-analyzers-common</artifactId>
-    <version>8.11.2</version>
-					<type>jar</type>
-</dependency>
+				</dependency>
 			</dependencies>
 			<repositories>
 				<repository>

--- a/org.eclipse.mylyn.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.mylyn.tests/META-INF/MANIFEST.MF
@@ -8,7 +8,7 @@ Export-Package: org.eclipse.mylyn.tests;x-internal:=true,
  org.eclipse.mylyn.tests.integration;x-internal:=true,
  org.eclipse.mylyn.tests.misc;x-internal:=true
 Bundle-ClassPath: .
-Require-Bundle: org.apache.lucene.lucene-analyzers-common;bundle-version="8.11.2",
+Require-Bundle: org.apache.lucene.lucene-analysis-common;bundle-version="9.5.0",
  org.apache.lucene.lucene-core;bundle-version="9.5.0",
  org.apache.lucene.lucene-queryparser;bundle-version="9.5.0",
  org.eclipse.core.resources;bundle-version="0.0.0",

--- a/org.eclipse.mylyn.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.mylyn.tests/META-INF/MANIFEST.MF
@@ -8,9 +8,9 @@ Export-Package: org.eclipse.mylyn.tests;x-internal:=true,
  org.eclipse.mylyn.tests.integration;x-internal:=true,
  org.eclipse.mylyn.tests.misc;x-internal:=true
 Bundle-ClassPath: .
-Require-Bundle: org.apache.lucene.analyzers-common;bundle-version="[6.1.0,8.0.0)",
- org.apache.lucene.core;bundle-version="[6.1.0,8.0.0)",
- org.apache.lucene.queryparser;bundle-version="[6.1.0,8.8.0)",
+Require-Bundle: org.apache.lucene.lucene-analyzers-common;bundle-version="8.11.2",
+ org.apache.lucene.lucene-core;bundle-version="9.5.0",
+ org.apache.lucene.lucene-queryparser;bundle-version="9.5.0",
  org.eclipse.core.resources;bundle-version="0.0.0",
  org.eclipse.core.runtime;bundle-version="0.0.0",
  org.eclipse.mylyn.bugzilla.tests;bundle-version="3.26.0",


### PR DESCRIPTION
I have changed BugzillaAttachmentHandlerTest.java and AllTasksTests.java to get no failures when running on my MacBook with maven.

Please do some tests because I only tried the following cases with eclipse 2022-06 and 2023-03

1. new instance of eclipse and create a query
2. latest released mylyn and  create a query. After this upgrade to the version with Lucene 9.5.0.
(not sure that I have tested all possible cases where we have left some entries with duplicate Date values)


