### PR TITLE
Add in a version of logging that is compatible

### DIFF
--- a/org.eclipse.mylyn-site/category.xml
+++ b/org.eclipse.mylyn-site/category.xml
@@ -144,6 +144,7 @@
    <bundle id="org.apache.xmlrpc.client"/>
    <bundle id="org.apache.xmlrpc.common"/>
    <bundle id="org.apache.xmlrpc.server"/>
+   <bundle id="org.apache.commons.logging"/>
    <category-def name="org.eclipse.mylyn.features.category" label="Mylyn Features">
       <description>
          The Task List and the Task-Focused Interface.

--- a/org.eclipse.mylyn-target/mylyn-e4.26.target
+++ b/org.eclipse.mylyn-target/mylyn-e4.26.target
@@ -45,6 +45,7 @@
 			<unit id="org.hamcrest.library" version="0.0.0"/>
 			<unit id="org.hamcrest.text" version="0.0.0"/>
 			<unit id="org.mockito" version="0.0.0"/>
+			<unit id="org.apache.commons.logging" version="1.1.1.v201101211721"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
 			<repository location="https://download.eclipse.org/tools/orbit/downloads/drops/R20221123021534/repository/"/>


### PR DESCRIPTION
xmlrpc.server requires a logging < 1.2.0

This resolves the immediate issue in SimRel - https://git.eclipse.org/r/c/simrel/org.eclipse.simrel.build/+/201693/comments/cf5c3a34_9e765dd6

I did a `mvn clean package` and then then added `$PWD/org.eclipse.mylyn-site/target/repository` to the simrel.aggr and validated locally.