### PR TITLE
Support a stable repository structure for publishing builds

### DIFF
--- a/org.eclipse.mylyn-site/pom.xml
+++ b/org.eclipse.mylyn-site/pom.xml
@@ -25,4 +25,91 @@
   <artifactId>org.eclipse.mylyn-site</artifactId>
   <packaging>eclipse-repository</packaging>
   <name>Mylyn for Eclipse 4.x</name>
+
+  <properties>
+    <eclipse.repo>https://download.eclipse.org/releases/2023-03</eclipse.repo>
+    <justj.tools.repo>https://download.eclipse.org/justj/tools/updates/nightly/latest</justj.tools.repo>
+    <org.eclipse.storage.user>genie.mylyn</org.eclipse.storage.user>
+    <org.eclipse.justj.p2.manager.args>-remote ${org.eclipse.storage.user}@projects-storage.eclipse.org:/home/data/httpd/download.eclipse.org/mylyn</org.eclipse.justj.p2.manager.args>
+    <org.eclipse.justj.p2.manager.extra.args></org.eclipse.justj.p2.manager.extra.args>
+    <org.eclipse.justj.p2.manager.relative>updates</org.eclipse.justj.p2.manager.relative>
+    <org.eclipse.justj.p2.manager.build.url>http://www.example.com/</org.eclipse.justj.p2.manager.build.url>
+    <build.type>nightly</build.type>
+  </properties>
+
+  <profiles>
+    <profile>
+      <id>promote</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.eclipse.tycho.extras</groupId>
+            <artifactId>tycho-eclipserun-plugin</artifactId>
+            <version>${tycho-version}</version>
+            <configuration>
+              <executionEnvironment>JavaSE-17</executionEnvironment>
+              <dependencies>
+                <dependency>
+                  <artifactId>org.eclipse.justj.p2</artifactId>
+                  <type>eclipse-plugin</type>
+                </dependency>
+                <dependency>
+                  <artifactId>org.apache.felix.scr</artifactId>
+                  <type>eclipse-plugin</type>
+                </dependency>
+              </dependencies>
+              <repositories>
+                <repository>
+                  <id>eclipse.repo</id>
+                  <layout>p2</layout>
+                  <url>${eclipse.repo}</url>
+                </repository>
+                <repository>
+                  <id>justj.tools.repo</id>
+                  <layout>p2</layout>
+                  <url>${justj.tools.repo}</url>
+                </repository>
+              </repositories>
+            </configuration>
+            <executions>
+              <execution>
+                <id>promote</id>
+                <goals>
+                  <goal>eclipse-run</goal>
+                </goals>
+                <phase>package</phase>
+                <configuration>
+                  <argLine></argLine>
+                  <appArgLine>
+                    -consoleLog
+                    -application org.eclipse.justj.p2.manager
+                    -data @None
+                    -nosplash
+                    ${org.eclipse.justj.p2.manager.args}
+                    -retain 5
+                    -label "Mylyn"
+                    -build-url ${org.eclipse.justj.p2.manager.build.url}
+                    -root ${project.build.directory}/mylyn-sync
+                    -relative ${org.eclipse.justj.p2.manager.relative}
+                    -version-iu org.eclipse.mylyn.sdk_feature.
+                    -iu-filter-pattern org.eclipse.mylyn.*
+                    -target-url https://download.eclipse.org/mylyn
+                    -promote ${project.build.directory}/repository
+                    -timestamp ${build.timestamp}
+                    -type ${build.type}
+                    -breadcrumb "Mylyn https://www.eclipse.org/mylyn"
+                    -favicon ${project.baseUri}../mylyn.commons/org.eclipse.mylyn.commons.core/feature.gif
+                    -xtitle-image https://www.eclipse.org/jetty/common/images/jetty-logo.svg
+                    -body-image ${project.baseUri}../mylyn.commons/org.eclipse.mylyn.commons.core/feature.gif
+                    ${org.eclipse.justj.p2.manager.extra.args}
+                  </appArgLine>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+
 </project>


### PR DESCRIPTION
Reuse JustJ's repository publishing infrastructure.

Ensure that only main branch builds are signed and promoted.

https://github.com/eclipse-mylyn/org.eclipse.mylyn/issues/116