### PR TITLE
Support a stable repository structure for publishing builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -47,22 +47,24 @@ pipeline {
 		}
 		stage('Build') {
 			steps {
-				wrap([$class: 'Xvnc', useXauthority: true]) {
-					sh '''
-						mvn \
-						clean \
-						verify \
-						-B \
-						$MAVEN_PROFILES \
-						-Dmaven.repo.local=$WORKSPACE/.m2/repository \
-						-Dmaven.test.failure.ignore=true \
-						-Dmaven.test.error.ignore=true \
-						-Ddash.fail=false \
-						-Dorg.eclipse.justj.p2.manager.build.url=$JOB_URL \
-						-Dbuild.type=$BUILD_TYPE \
-						-Dgit.commit=$GIT_COMMIT \
-						-Dbuild.id=$BUILD_NUMBER 
-					'''
+				sshagent (['projects-storage.eclipse.org-bot-ssh']) {
+					wrap([$class: 'Xvnc', useXauthority: true]) {
+						sh '''
+							mvn \
+							clean \
+							verify \
+							-B \
+							$MAVEN_PROFILES \
+							-Dmaven.repo.local=$WORKSPACE/.m2/repository \
+							-Dmaven.test.failure.ignore=true \
+							-Dmaven.test.error.ignore=true \
+							-Ddash.fail=false \
+							-Dorg.eclipse.justj.p2.manager.build.url=$JOB_URL \
+							-Dbuild.type=$BUILD_TYPE \
+							-Dgit.commit=$GIT_COMMIT \
+							-Dbuild.id=$BUILD_NUMBER 
+						'''
+					}
 				}
 			}
 			post {


### PR DESCRIPTION
Run the mvn build within a sshagent block.

https://github.com/eclipse-mylyn/org.eclipse.mylyn/issues/116