### PR TITLE
The org.eclipse.egit.mylyn feature is missing from the update site

### DIFF
--- a/mylyn.egit/org.eclipse.egit.mylyn-feature/feature.properties
+++ b/mylyn.egit/org.eclipse.egit.mylyn-feature/feature.properties
@@ -8,7 +8,7 @@
 # SPDX-License-Identifier: EPL-2.0
 ###############################################################################
 
-featureName=Eclipse Git integration - Task focused interface
+featureName=Mylyn Git integration - Task focused interface
 providerName=Eclipse Mylyn
 
 updateSiteName=Eclipse EGit Update Site

--- a/org.eclipse.mylyn-site/category.xml
+++ b/org.eclipse.mylyn-site/category.xml
@@ -128,6 +128,9 @@
    <feature id="org.eclipse.mylyn.github.feature" version="6.2.0.qualifier">
       <category name="github_connector"/>
    </feature>
+   <feature id="org.eclipse.egit.mylyn">
+      <category name="org.eclipse.mylyn.integrations.category"/>
+   </feature>
    <bundle id="com.sun.xml.bind"/>
    <bundle id="jakarta.xml.bind"/>
    <bundle id="javax.activation" version="1.2.2.v20221203-1659"/>

--- a/org.eclipse.mylyn-site/pom.xml
+++ b/org.eclipse.mylyn-site/pom.xml
@@ -93,7 +93,7 @@
                     -root ${project.build.directory}/mylyn-sync
                     -relative ${org.eclipse.justj.p2.manager.relative}
                     -version-iu org.eclipse.mylyn.sdk_feature.
-                    -iu-filter-pattern org.eclipse.mylyn.*
+                    -iu-filter-pattern org.eclipse.mylyn.*|org.eclipse.egit.mylyn.*|org.eclipse.egit.github.*|org.eclipse.cdt.mylyn|org.eclipse.cdt.mylyn.*
                     -commit https://github.com/eclipse-mylyn/org.eclipse.mylyn/commit/${git.commit}
                     -target-url https://download.eclipse.org/mylyn
                     -promote ${project.build.directory}/repository


### PR DESCRIPTION
The generated update site index omits  Mylyn bundles that doesn't start with org.eclipse.mylyn.

The feature name should start with Mylyn.

https://github.com/eclipse-mylyn/org.eclipse.mylyn/issues/128 
https://github.com/eclipse-mylyn/org.eclipse.mylyn/issues/134