### PR TITLE
Remove org.eclipse.mylyn.commons.tck from the site

### DIFF
--- a/org.eclipse.mylyn-site/category.xml
+++ b/org.eclipse.mylyn-site/category.xml
@@ -77,9 +77,6 @@
    <feature id="org.eclipse.mylyn.commons.sdk">
       <category name="org.eclipse.mylyn.sdk.category"/>
    </feature>
-   <feature id="org.eclipse.mylyn.commons.tck">
-      <category name="org.eclipse.mylyn.sdk.category"/>
-   </feature>
    <feature id="org.eclipse.mylyn.context.sdk">
       <category name="org.eclipse.mylyn.sdk.category"/>
    </feature>


### PR DESCRIPTION
This appears just to have various dependencies for tests

https://github.com/eclipse-mylyn/org.eclipse.mylyn/issues/131