### PR TITLE
[#150] Startup problems

### DIFF
--- a/mylyn.reviews/org.eclipse.mylyn.reviews.ui/META-INF/MANIFEST.MF
+++ b/mylyn.reviews/org.eclipse.mylyn.reviews.ui/META-INF/MANIFEST.MF
@@ -8,6 +8,11 @@ Require-Bundle: com.google.guava;bundle-version="0.0.0",
  org.eclipse.core.runtime;bundle-version="0.0.0",
  org.eclipse.core.resources;bundle-version="0.0.0",
  org.eclipse.core.expressions;bundle-version="0.0.0",
+ org.eclipse.e4.core.di.annotations;bundle-version="0.0.0",
+ org.eclipse.e4.core.di.extensions;bundle-version="0.0.0",
+ org.eclipse.e4.core.services;bundle-version="0.0.0",
+ org.eclipse.e4.ui.model.workbench;bundle-version="0.0.0",
+ org.eclipse.e4.ui.workbench;bundle-version="0.0.0",
  org.eclipse.emf.ecore;bundle-version="0.0.0",
  org.eclipse.emf.ecore.xmi;bundle-version="0.0.0",
  org.eclipse.emf.edit;bundle-version="0.0.0",
@@ -44,6 +49,9 @@ Export-Package: org.eclipse.mylyn.internal.reviews.ui;x-internal:=true,
  org.eclipse.mylyn.reviews.ui.spi.editor;x-internal:=true,
  org.eclipse.mylyn.reviews.ui.spi.factories;x-internal:=true,
  org.eclipse.mylyn.reviews.ui.spi.remote;x-internal:=true
-Import-Package: org.apache.commons.io;version="1.4.0",
- org.apache.commons.lang;version="[2.6.0,3.0.0)"
+Import-Package: javax.inject;version="1.0.0",
+ org.apache.commons.io;version="1.4.0",
+ org.apache.commons.lang;version="[2.6.0,3.0.0)",
+ org.osgi.service.event;version="1.4.1"
 Bundle-Activator: org.eclipse.mylyn.internal.reviews.ui.ReviewsUiPlugin
+Model-Fragment: fragment.e4xmi

--- a/mylyn.reviews/org.eclipse.mylyn.reviews.ui/build.properties
+++ b/mylyn.reviews/org.eclipse.mylyn.reviews.ui/build.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2015 Tasktop Technologies and others.
+# Copyright (c) 2015, 2023 Tasktop Technologies and others.
 # 
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License v. 2.0 which is available at
@@ -9,12 +9,14 @@
 #
 # Contributors:
 #      Tasktop Technologies - initial API and implementation
+#      ArSysOp - ActiveReviewManager startup code rework
 ###############################################################################
-source.. = src/
-output.. = bin/
 bin.includes = META-INF/,\
                .,\
                plugin.xml,\
                icons/,\
-               about.html
+               about.html,\
+               fragment.e4xmi
+source.. = src/
 src.includes = about.html
+output.. = bin/

--- a/mylyn.reviews/org.eclipse.mylyn.reviews.ui/fragment.e4xmi
+++ b/mylyn.reviews/org.eclipse.mylyn.reviews.ui/fragment.e4xmi
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="ASCII"?>
+<fragment:ModelFragments xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:application="http://www.eclipse.org/ui/2010/UIModel/application" xmlns:fragment="http://www.eclipse.org/ui/2010/UIModel/fragment" xmi:id="_pzE6sPV6Ee2ONeZ4h4MeXQ">
+  <fragments xsi:type="fragment:StringModelFragment" xmi:id="_qpzHUPV6Ee2ONeZ4h4MeXQ" featurename="addons" parentElementId="org.eclipse.e4.legacy.ide.application">
+    <elements xsi:type="application:Addon" xmi:id="_shdMgPV6Ee2ONeZ4h4MeXQ" elementId="org.eclipse.mylyn.reviews.ui.addon.0" contributionURI="bundleclass://org.eclipse.mylyn.reviews.ui/org.eclipse.mylyn.internal.reviews.ui.ActiveReviewsAddon"/>
+  </fragments>
+</fragment:ModelFragments>

--- a/mylyn.reviews/org.eclipse.mylyn.reviews.ui/src/org/eclipse/mylyn/internal/reviews/ui/ActiveReviewManager.java
+++ b/mylyn.reviews/org.eclipse.mylyn.reviews.ui/src/org/eclipse/mylyn/internal/reviews/ui/ActiveReviewManager.java
@@ -1,13 +1,14 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2015 Tasktop Technologies and others.
- * 
+ * Copyright (c) 2014, 2023 Tasktop Technologies and others.
+ *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
  * https://www.eclipse.org/legal/epl-2.0
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  *     Tasktop Technologies - initial API and implementation
+ *     ArSysOp - ActiveReviewManager startup code rework
  *******************************************************************************/
 
 package org.eclipse.mylyn.internal.reviews.ui;
@@ -20,10 +21,10 @@ import org.eclipse.mylyn.tasks.ui.editors.TaskEditor;
 import org.eclipse.ui.IPageListener;
 import org.eclipse.ui.IPartListener;
 import org.eclipse.ui.IWindowListener;
+import org.eclipse.ui.IWorkbench;
 import org.eclipse.ui.IWorkbenchPage;
 import org.eclipse.ui.IWorkbenchPart;
 import org.eclipse.ui.IWorkbenchWindow;
-import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.forms.editor.IFormPage;
 
 import com.google.common.collect.Lists;
@@ -109,12 +110,12 @@ public class ActiveReviewManager {
 		}
 	};
 
-	public ActiveReviewManager() {
-		PlatformUI.getWorkbench().addWindowListener(windowListener);
-		IWorkbenchWindow activeWorkbenchWindow = PlatformUI.getWorkbench().getActiveWorkbenchWindow();
-		if (activeWorkbenchWindow != null) {
-			activeWorkbenchWindow.addPageListener(pageListener);
-			windowListener.windowActivated(activeWorkbenchWindow);
+	void startup(IWorkbench workbench) {
+		workbench.addWindowListener(windowListener);
+		IWorkbenchWindow active = workbench.getActiveWorkbenchWindow();
+		if (active != null) {
+			active.addPageListener(pageListener);
+			windowListener.windowActivated(active);
 		}
 	}
 

--- a/mylyn.reviews/org.eclipse.mylyn.reviews.ui/src/org/eclipse/mylyn/internal/reviews/ui/ActiveReviewsAddon.java
+++ b/mylyn.reviews/org.eclipse.mylyn.reviews.ui/src/org/eclipse/mylyn/internal/reviews/ui/ActiveReviewsAddon.java
@@ -1,0 +1,32 @@
+/*******************************************************************************
+ * Copyright (c) 2023 ArSysOp
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     ArSysOp - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.mylyn.internal.reviews.ui;
+
+import javax.inject.Inject;
+
+import org.eclipse.e4.core.di.annotations.Optional;
+import org.eclipse.e4.core.di.extensions.EventTopic;
+import org.eclipse.e4.ui.workbench.UIEvents;
+import org.eclipse.ui.IWorkbench;
+import org.osgi.service.event.Event;
+
+public final class ActiveReviewsAddon {
+
+	@Inject
+	@Optional
+	public void applicationStarted(@EventTopic(UIEvents.UILifeCycle.APP_STARTUP_COMPLETE)
+	Event event, IWorkbench workbench) {
+		ReviewsUiPlugin.getDefault().getReviewManager().startup(workbench);
+	}
+
+}


### PR DESCRIPTION
Move ActiveReviewManager startup to happen after `APP_STARTUP_COMPLETE`

Fixes https://github.com/eclipse-mylyn/org.eclipse.mylyn/issues/150