### PR TITLE
[#150] Startup problems

### DIFF
--- a/mylyn.reviews/org.eclipse.mylyn.reviews.ui/src/org/eclipse/mylyn/internal/reviews/ui/ReviewsUiPlugin.java
+++ b/mylyn.reviews/org.eclipse.mylyn.reviews.ui/src/org/eclipse/mylyn/internal/reviews/ui/ReviewsUiPlugin.java
@@ -46,8 +46,8 @@ public class ReviewsUiPlugin extends AbstractUIPlugin {
 		//We need to schedule initialization otherwise TasksUiPlugin hasn't finished initialization.
 		UIJob job = new UIJob(Messages.ReviewsUiPlugin_Updating_task_review_mapping) {
 			@Override
-			reviewManager = new ActiveReviewManager();
 			public IStatus runInUIThread(IProgressMonitor monitor) {
+				reviewManager = new ActiveReviewManager();
 				taskReviewsMappingStore = new TaskReviewsMappingsStore(TasksUiPlugin.getTaskList(),
 						TasksUiPlugin.getRepositoryManager());
 				TaskReviewsMappingsStore.setInstance(taskReviewsMappingStore);


### PR DESCRIPTION
In some cases the init of the reviews plugin came to soon causing a widget disposed exception which was caused by the Display being null.

The initialization has been moved to the already existing UIJob.