### PR TITLE
[#157] Ensure proper "License vetting status check" configuration

### DIFF
--- a/.github/workflows/licensecheck.yml
+++ b/.github/workflows/licensecheck.yml
@@ -15,9 +15,24 @@ on:
     types: [created]
 
 jobs:
-  call-license-check:
-    uses: eclipse/dash-licenses/.github/workflows/mavenLicenseCheck.yml@master
-    with:
-      projectId: tools.mylyn
-    secrets:
-      gitlabAPIToken: ${{ secrets.GITLAB_API_TOKEN }}
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up JDK 17
+      uses: actions/setup-java@v3
+      with:
+        java-version: '17'
+        distribution: 'adopt'
+    - name: Cache local Maven repository
+      uses: actions/cache@v3
+      with:
+        path: ~/.m2/repository
+        key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+        restore-keys: |
+          ${{ runner.os }}-maven-
+    - name: License check
+      run: | 
+        mvn -U -V -e -B -ntp -DexcludeGroupIds=org.apache.lucene org.eclipse.dash:license-tool-plugin:license-check --file pom.xml

--- a/mylyn.releng/org.eclipse.mylyn.parent/pom.xml
+++ b/mylyn.releng/org.eclipse.mylyn.parent/pom.xml
@@ -113,6 +113,18 @@
     <name>Eclipse Foundation</name>
     <url>https://www.eclipse.org/</url>
   </organization>
+  <pluginRepositories>
+    <pluginRepository>
+      <id>eclipse-dash</id>
+      <url>https://repo.eclipse.org/content/repositories/dash-licenses/</url>
+      <releases>
+            <enabled>true</enabled>
+      </releases>
+      <snapshots>
+            <enabled>true</enabled>
+      </snapshots>
+    </pluginRepository>
+  </pluginRepositories>
   <profiles>
     <!-- Target definition profiles -->
     <!-- Needs to be specified first to allow target profiles to override settings -->


### PR DESCRIPTION
Exclude "org.apache.lucene" from the check, while we are waiting for the IP review results:

* https://gitlab.eclipse.org/eclipsefdn/emo-team/iplab/-/issues/8492 
* https://gitlab.eclipse.org/eclipsefdn/emo-team/iplab/-/issues/8493

Fixes https://github.com/eclipse-mylyn/org.eclipse.mylyn/issues/157