### PR TITLE
Ensure that 3rd party dependencies are available in the update site

### DIFF
--- a/mylyn.commons/org.eclipse.mylyn.commons.sdk-feature/feature.xml
+++ b/mylyn.commons/org.eclipse.mylyn.commons.sdk-feature/feature.xml
@@ -292,11 +292,4 @@
          version="0.0.0"
          unpack="false"/>
 
-   <plugin
-         id="com.google.guava"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
 </feature>

--- a/mylyn.tasks/org.eclipse.mylyn-feature/feature.xml
+++ b/mylyn.tasks/org.eclipse.mylyn-feature/feature.xml
@@ -35,7 +35,6 @@
    </url>
 
    <requires>
-      <import plugin="com.google.guava" version="15.0.0" match="greaterOrEqual"/>
       <import plugin="org.apache.commons.codec" version="1.3.0" match="compatible"/>
       <import plugin="org.apache.commons.lang" version="2.3.0" match="compatible"/>
       <import plugin="org.apache.commons.logging" version="1.0.4" match="compatible"/>

--- a/mylyn.versions/org.eclipse.mylyn.versions.sdk-feature/feature.xml
+++ b/mylyn.versions/org.eclipse.mylyn.versions.sdk-feature/feature.xml
@@ -33,10 +33,6 @@
       %license
    </license>
 
-   <requires>
-      <import plugin="com.google.guava" version="15.0.0" match="greaterOrEqual"/>
-   </requires>
-
    <includes
          id="org.eclipse.mylyn.git"
          version="0.0.0"/>
@@ -44,13 +40,6 @@
    <includes
          id="org.eclipse.mylyn.versions"
          version="0.0.0"/>
-
-   <plugin
-         id="com.google.guava"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
 
    <plugin
          id="org.eclipse.mylyn.versions.core.source"

--- a/org.eclipse.mylyn-site/category.xml
+++ b/org.eclipse.mylyn-site/category.xml
@@ -126,7 +126,9 @@
    <bundle id="org.apache.xmlrpc.client"/>
    <bundle id="org.apache.xmlrpc.common"/>
    <bundle id="org.apache.xmlrpc.server"/>
-   <bundle id="org.apache.commons.logging"/>
+   <bundle id="org.apache.commons.logging" version="1.1.1.v201101211721"/>
+   <bundle id="com.google.guava"/>
+   <bundle id="com.google.guava.failureaccess"/>
    <category-def name="org.eclipse.mylyn.features.category" label="Mylyn Features">
       <description>
          The Task List and the Task-Focused Interface.

--- a/org.eclipse.mylyn-target/mylyn-e4.26.target
+++ b/org.eclipse.mylyn-target/mylyn-e4.26.target
@@ -43,6 +43,7 @@
 			<unit id="org.hamcrest.integration" version="0.0.0"/>
 			<unit id="org.hamcrest.library" version="0.0.0"/>
 			<unit id="org.hamcrest.text" version="0.0.0"/>
+			<unit id="org.apache.commons.logging" version="1.1.1.v201101211721"/>>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
 			<repository location="https://download.eclipse.org/tools/orbit/downloads/drops/R20221123021534/repository/"/>


### PR DESCRIPTION
This is to ensure that all of Mylyn's features install with a minimal set of other update sites available.

Fixes https://github.com/eclipse-mylyn/org.eclipse.mylyn/issues/159