### PR TITLE
Provide a p2.inf to handle the renaming of egit.mylyn to mylyn.egit

### DIFF
--- a/mylyn.egit/org.eclipse.mylyn.egit.feature/build.properties
+++ b/mylyn.egit/org.eclipse.mylyn.egit.feature/build.properties
@@ -1,2 +1,3 @@
 bin.includes = feature.xml,\
-	feature.properties
+               feature.properties,\
+               p2.inf

--- a/mylyn.egit/org.eclipse.mylyn.egit.feature/p2.inf
+++ b/mylyn.egit/org.eclipse.mylyn.egit.feature/p2.inf
@@ -1,0 +1,6 @@
+update.id=org.eclipse.egit.mylyn.feature.group
+update.range=[0,4)
+update.matchExp = providedCapabilities.exists(pc | \
+   pc.namespace == 'org.eclipse.equinox.p2.iu' && \
+     (pc.name == 'org.eclipse.mylyn.egit.feature.feature.group' || \
+       (pc.name == 'org.eclipse.egit.mylyn.feature.group' && pc.version ~= range('[0.0.0,$version$)'))))


### PR DESCRIPTION
I.e., so that org.eclipse.egit.mylyn.feature.group to can update to org.eclipse.mylyn.egit.feature.feature.group

https://github.com/eclipse-mylyn/org.eclipse.mylyn/issues/165