### PR TITLE
Remove bugzilla from Mylyn IDE feature

### DIFF
--- a/mylyn.context/org.eclipse.mylyn.ide-feature/feature.xml
+++ b/mylyn.context/org.eclipse.mylyn.ide-feature/feature.xml
@@ -39,13 +39,6 @@
    </requires>
 
    <plugin
-         id="org.eclipse.mylyn.bugzilla.ide"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
          id="org.eclipse.mylyn.ide.ui"
          download-size="0"
          install-size="0"


### PR DESCRIPTION
It used to be that the Mylyn IDE feature didn't really pull in any connectors, but just IDE features. However there was a log message about bugzilla as repored in #168

The current fix for #168 pulls in more of bugzilla when the ide_feature is installed.

Therefore this change is to not pull in bugzilla at all when installing IDE feature.

Fixes https://github.com/eclipse-mylyn/org.eclipse.mylyn/issues/168