### PR TITLE
Don't transform surefire report when skipTests is true

### DIFF
--- a/org.eclipse.mylyn.tests/pom.xml
+++ b/org.eclipse.mylyn.tests/pom.xml
@@ -52,6 +52,7 @@
           </execution>
         </executions>
         <configuration>
+          <skip>${skipTests}</skip>
           <transformationSets>
             <!-- append @x.y.z to repository test cases to differentiate test fixtures -->
             <transformationSet>


### PR DESCRIPTION
When running with -DskipTests=true, there are no generated reports and then trying to transform them fails.