### PR TITLE
[#190] Remove references to Resource Navigator

### DIFF
--- a/mylyn.commons/org.eclipse.mylyn.commons.sdk.util/src/org/eclipse/mylyn/commons/sdk/util/UiTestUtil.java
+++ b/mylyn.commons/org.eclipse.mylyn.commons.sdk.util/src/org/eclipse/mylyn/commons/sdk/util/UiTestUtil.java
@@ -1,13 +1,14 @@
 /*******************************************************************************
- * Copyright (c) 2004, 2012 Tasktop Technologies and others.
- * 
+ * Copyright (c) 2004, 2023 Tasktop Technologies and others.
+ *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
  * https://www.eclipse.org/legal/epl-2.0
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  *     Tasktop Technologies - initial API and implementation
+ *     ArSysOp - adapt to SimRel 2023-06
  *******************************************************************************/
 
 package org.eclipse.mylyn.commons.sdk.util;
@@ -69,10 +70,6 @@ public class UiTestUtil {
 				return;
 			}
 		}
-	}
-
-	public static IViewPart openResourceNavigator() throws PartInitException {
-		return openView("org.eclipse.ui.views.ResourceNavigator");
 	}
 
 	public static IViewPart openView(String id) throws PartInitException {

--- a/mylyn.context/org.eclipse.mylyn.context.sdk.util/META-INF/MANIFEST.MF
+++ b/mylyn.context/org.eclipse.mylyn.context.sdk.util/META-INF/MANIFEST.MF
@@ -16,6 +16,8 @@ Require-Bundle: org.eclipse.core.resources;bundle-version="0.0.0",
  org.eclipse.mylyn.resources.ui;bundle-version="3.26.1",
  org.eclipse.ui;bundle-version="0.0.0",
  org.eclipse.ui.ide;bundle-version="0.0.0",
+ org.eclipse.ui.navigator;bundle-version="0.0.0";visibility:=reexport,
+ org.eclipse.ui.navigator.resources;bundle-version="0.0.0";visibility:=reexport,
  org.junit;bundle-version="4.8.2"
 Export-Package: org.eclipse.mylyn.context.sdk.util;x-internal:=true,
  org.eclipse.mylyn.context.sdk.util.search;x-internal:=true

--- a/mylyn.context/org.eclipse.mylyn.context.sdk.util/src/org/eclipse/mylyn/context/sdk/util/AbstractResourceContextTest.java
+++ b/mylyn.context/org.eclipse.mylyn.context.sdk.util/src/org/eclipse/mylyn/context/sdk/util/AbstractResourceContextTest.java
@@ -1,13 +1,14 @@
 /*******************************************************************************
- * Copyright (c) 2004, 2014 Tasktop Technologies and others.
- * 
+ * Copyright (c) 2004, 2023 Tasktop Technologies and others.
+ *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
  * https://www.eclipse.org/legal/epl-2.0
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  *     Tasktop Technologies - initial API and implementation
+ *     ArSysOp - adapt to SimRel 2023-06
  *******************************************************************************/
 
 package org.eclipse.mylyn.context.sdk.util;
@@ -24,13 +25,11 @@ import org.eclipse.mylyn.internal.ide.ui.IdeUiBridgePlugin;
 import org.eclipse.mylyn.internal.ide.ui.IdeUiUtil;
 import org.eclipse.mylyn.internal.resources.ui.ResourceInteractionMonitor;
 import org.eclipse.mylyn.internal.resources.ui.ResourceStructureBridge;
-import org.eclipse.ui.views.navigator.ResourceNavigator;
+import org.eclipse.ui.navigator.resources.ProjectExplorer;
 
 /**
  * @author Mik Kersten
  */
-// TODO e3.5
-@SuppressWarnings("deprecation")
 public abstract class AbstractResourceContextTest extends AbstractContextTest {
 
 	protected InteractionContextManager manager = ContextCorePlugin.getContextManager();
@@ -47,7 +46,7 @@ public abstract class AbstractResourceContextTest extends AbstractContextTest {
 
 	protected String taskId = this.getClass().getName();
 
-	protected ResourceNavigator navigator;
+	protected ProjectExplorer navigator;
 
 	@Override
 	protected void setUp() throws Exception {
@@ -59,7 +58,7 @@ public abstract class AbstractResourceContextTest extends AbstractContextTest {
 		context.reset();
 		manager.internalActivateContext(context);
 		ContextUiPlugin.getViewerManager().setSyncRefreshMode(true);
-		navigator = (ResourceNavigator) UiTestUtil.openView(IdeUiUtil.ID_NAVIGATOR);
+		navigator = (ProjectExplorer) UiTestUtil.openView(IdeUiUtil.ID_NAVIGATOR);
 		assertNotNull(navigator);
 	}
 

--- a/mylyn.context/org.eclipse.mylyn.ide.ui/META-INF/MANIFEST.MF
+++ b/mylyn.context/org.eclipse.mylyn.ide.ui/META-INF/MANIFEST.MF
@@ -16,7 +16,8 @@ Require-Bundle: org.eclipse.core.resources;bundle-version="0.0.0",
  org.eclipse.mylyn.resources.ui;bundle-version="3.26.1",
  org.eclipse.search;bundle-version="0.0.0",
  org.eclipse.ui.ide;bundle-version="0.0.0",
- org.eclipse.ui.navigator;bundle-version="0.0.0"
+ org.eclipse.ui.navigator;bundle-version="0.0.0",
+ org.eclipse.ui.navigator.resources;bundle-version="0.0.0"
 Bundle-ActivationPolicy: lazy
 Export-Package: org.eclipse.mylyn.ide.ui,
  org.eclipse.mylyn.internal.ide.ui;x-internal:=true,

--- a/mylyn.context/org.eclipse.mylyn.ide.ui/src/org/eclipse/mylyn/internal/ide/ui/IdeUiUtil.java
+++ b/mylyn.context/org.eclipse.mylyn.ide.ui/src/org/eclipse/mylyn/internal/ide/ui/IdeUiUtil.java
@@ -1,31 +1,32 @@
 /*******************************************************************************
- * Copyright (c) 2004, 2013 Tasktop Technologies and others.
- * 
+ * Copyright (c) 2004, 2023 Tasktop Technologies and others.
+ *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
  * https://www.eclipse.org/legal/epl-2.0
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  *     Tasktop Technologies - initial API and implementation
+ *     ArSysOp - adapt to SimRel 2023-06
  *******************************************************************************/
 
 package org.eclipse.mylyn.internal.ide.ui;
 
+import org.eclipse.ui.IPageLayout;
 import org.eclipse.ui.IViewPart;
 import org.eclipse.ui.IWorkbenchPage;
 import org.eclipse.ui.PlatformUI;
-import org.eclipse.ui.views.navigator.ResourceNavigator;
+import org.eclipse.ui.navigator.resources.ProjectExplorer;
 
 /**
  * @author Mik Kersten
  */
-@SuppressWarnings("deprecation")
 public class IdeUiUtil {
 
 	public static final String ID_VIEW_SYNCHRONIZE = "org.eclipse.team.sync.views.SynchronizeView"; //$NON-NLS-1$
 
-	public static final String ID_NAVIGATOR = "org.eclipse.ui.views.ResourceNavigator"; //$NON-NLS-1$
+	public static final String ID_NAVIGATOR = IPageLayout.ID_PROJECT_EXPLORER;
 
 	public static IViewPart getView(String id) {
 		IWorkbenchPage activePage = PlatformUI.getWorkbench().getActiveWorkbenchWindow().getActivePage();
@@ -36,7 +37,7 @@ public class IdeUiUtil {
 		return view;
 	}
 
-	public static ResourceNavigator getNavigatorFromActivePage() {
+	public static ProjectExplorer getNavigatorFromActivePage() {
 		if (PlatformUI.getWorkbench() == null || PlatformUI.getWorkbench().getActiveWorkbenchWindow() == null) {
 			return null;
 		}
@@ -45,8 +46,8 @@ public class IdeUiUtil {
 			return null;
 		}
 		IViewPart view = activePage.findView(ID_NAVIGATOR);
-		if (view instanceof ResourceNavigator) {
-			return (ResourceNavigator) view;
+		if (view instanceof ProjectExplorer) {
+			return (ProjectExplorer) view;
 		}
 		return null;
 	}

--- a/mylyn.context/org.eclipse.mylyn.ide.ui/src/org/eclipse/mylyn/internal/ide/ui/actions/FocusResourceNavigatorAction.java
+++ b/mylyn.context/org.eclipse.mylyn.ide.ui/src/org/eclipse/mylyn/internal/ide/ui/actions/FocusResourceNavigatorAction.java
@@ -1,13 +1,14 @@
 /*******************************************************************************
- * Copyright (c) 2004, 2009 Tasktop Technologies and others.
- * 
+ * Copyright (c) 2004, 2023 Tasktop Technologies and others.
+ *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
  * https://www.eclipse.org/legal/epl-2.0
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  *     Tasktop Technologies - initial API and implementation
+ *     ArSysOp - adapt to SimRel 2023-06
  *******************************************************************************/
 
 package org.eclipse.mylyn.internal.ide.ui.actions;
@@ -28,16 +29,11 @@ import org.eclipse.mylyn.context.ui.InterestFilter;
 import org.eclipse.ui.IEditorInput;
 import org.eclipse.ui.IEditorPart;
 import org.eclipse.ui.IViewPart;
-import org.eclipse.ui.views.navigator.FilterSelectionAction;
-import org.eclipse.ui.views.navigator.IResourceNavigator;
-import org.eclipse.ui.views.navigator.ResourceNavigator;
-import org.eclipse.ui.views.navigator.ToggleLinkingAction;
+import org.eclipse.ui.navigator.resources.ProjectExplorer;
 
 /**
  * @author Mik Kersten
  */
-// TODO e3.5
-@SuppressWarnings("deprecation")
 public class FocusResourceNavigatorAction extends AbstractAutoFocusViewAction {
 
 	public FocusResourceNavigatorAction() {
@@ -48,8 +44,9 @@ public class FocusResourceNavigatorAction extends AbstractAutoFocusViewAction {
 	public List<StructuredViewer> getViewers() {
 		List<StructuredViewer> viewers = new ArrayList<StructuredViewer>();
 		IViewPart part = super.getPartForAction();
-		if (part instanceof ResourceNavigator) {
-			viewers.add(((ResourceNavigator) part).getTreeViewer());
+		if (part instanceof ProjectExplorer) {
+			ProjectExplorer explorer = (ProjectExplorer) part;
+			viewers.add(explorer.getCommonViewer());
 		}
 		return viewers;
 	}
@@ -67,29 +64,31 @@ public class FocusResourceNavigatorAction extends AbstractAutoFocusViewAction {
 	}
 
 	// TODO: should have better way of doing this
+	@SuppressWarnings("restriction")
 	@Override
 	protected void setManualFilteringAndLinkingEnabled(boolean on) {
 		IViewPart part = super.getPartForAction();
-		if (part instanceof IResourceNavigator) {
-			for (IContributionItem item : ((IResourceNavigator) part).getViewSite()
+		if (part instanceof ProjectExplorer) {
+			for (IContributionItem item : ((ProjectExplorer) part).getViewSite()
 					.getActionBars()
 					.getToolBarManager()
 					.getItems()) {
 				if (item instanceof ActionContributionItem) {
 					ActionContributionItem actionItem = (ActionContributionItem) item;
-					if (actionItem.getAction() instanceof ToggleLinkingAction) {
+					if (actionItem.getAction() instanceof org.eclipse.ui.internal.navigator.actions.LinkEditorAction) {
 						actionItem.getAction().setEnabled(on);
 					}
 				}
 			}
-			for (IContributionItem item : ((IResourceNavigator) part).getViewSite()
+			for (IContributionItem item : ((ProjectExplorer) part).getViewSite()
 					.getActionBars()
 					.getMenuManager()
 					.getItems()) {
 				if (item instanceof ActionContributionItem) {
 					ActionContributionItem actionItem = (ActionContributionItem) item;
 					// TODO: consider filing bug asking for extensibility
-					if (actionItem.getAction() instanceof FilterSelectionAction) {
+					if (actionItem
+							.getAction() instanceof org.eclipse.ui.internal.navigator.filters.SelectFiltersAction) {
 						actionItem.getAction().setEnabled(on);
 					}
 				}
@@ -100,16 +99,16 @@ public class FocusResourceNavigatorAction extends AbstractAutoFocusViewAction {
 	@Override
 	protected void setDefaultLinkingEnabled(boolean on) {
 		IViewPart part = super.getPartForAction();
-		if (part instanceof IResourceNavigator) {
-			((IResourceNavigator) part).setLinkingEnabled(on);
+		if (part instanceof ProjectExplorer) {
+			((ProjectExplorer) part).setLinkingEnabled(on);
 		}
 	}
 
 	@Override
 	protected boolean isDefaultLinkingEnabled() {
 		IViewPart part = super.getPartForAction();
-		if (part instanceof IResourceNavigator) {
-			return ((IResourceNavigator) part).isLinkingEnabled();
+		if (part instanceof ProjectExplorer) {
+			return ((ProjectExplorer) part).isLinkingEnabled();
 		}
 		return false;
 	}

--- a/mylyn.context/org.eclipse.mylyn.java.tests/META-INF/MANIFEST.MF
+++ b/mylyn.context/org.eclipse.mylyn.java.tests/META-INF/MANIFEST.MF
@@ -32,6 +32,8 @@ Require-Bundle: org.eclipse.core.resources,
  org.eclipse.ui;bundle-version="0.0.0",
  org.eclipse.ui.editors;bundle-version="0.0.0",
  org.eclipse.ui.ide;bundle-version="0.0.0",
+ org.eclipse.ui.navigator;bundle-version="0.0.0",
+ org.eclipse.ui.navigator.resources;bundle-version="0.0.0",
  org.eclipse.ui.workbench;bundle-version="0.0.0",
  org.eclipse.ui.workbench.texteditor;bundle-version="0.0.0",
  org.junit;bundle-version="4.8.2"

--- a/mylyn.context/org.eclipse.mylyn.java.tests/src/org/eclipse/mylyn/java/tests/InterestManipulationTest.java
+++ b/mylyn.context/org.eclipse.mylyn.java.tests/src/org/eclipse/mylyn/java/tests/InterestManipulationTest.java
@@ -1,13 +1,14 @@
 /*******************************************************************************
- * Copyright (c) 2004, 2014 Tasktop Technologies and others.
- * 
+ * Copyright (c) 2004, 2023 Tasktop Technologies and others.
+ *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
  * https://www.eclipse.org/legal/epl-2.0
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  *     Tasktop Technologies - initial API and implementation
+ *     ArSysOp - adapt to SimRel 2023-06
  *******************************************************************************/
 
 package org.eclipse.mylyn.java.tests;
@@ -22,12 +23,12 @@ import org.eclipse.jdt.core.IPackageFragment;
 import org.eclipse.jdt.core.IType;
 import org.eclipse.jdt.core.JavaModelException;
 import org.eclipse.jface.viewers.StructuredSelection;
-import org.eclipse.mylyn.commons.sdk.util.UiTestUtil;
 import org.eclipse.mylyn.context.core.ContextCore;
 import org.eclipse.mylyn.context.core.IInteractionElement;
 import org.eclipse.mylyn.context.sdk.java.AbstractJavaContextTest;
 import org.eclipse.mylyn.internal.context.core.ContextCorePlugin;
 import org.eclipse.mylyn.internal.context.ui.actions.AbstractInterestManipulationAction;
+import org.eclipse.mylyn.internal.ide.ui.IdeUiUtil;
 import org.eclipse.mylyn.internal.resources.ui.ResourceInteractionMonitor;
 import org.eclipse.mylyn.internal.resources.ui.ResourceStructureBridge;
 import org.eclipse.mylyn.monitor.core.InteractionEvent;
@@ -65,7 +66,7 @@ public class InterestManipulationTest extends AbstractJavaContextTest {
 		javaType = (IType) javaMethod.getParent();
 		javaCu = (ICompilationUnit) javaType.getParent();
 		javaPackage = (IPackageFragment) javaCu.getParent();
-		part = UiTestUtil.openResourceNavigator();
+		part = IdeUiUtil.getNavigatorFromActivePage();
 		resourceMonitor = new ResourceInteractionMonitor();
 	}
 

--- a/mylyn.context/org.eclipse.mylyn.java.tests/src/org/eclipse/mylyn/java/tests/JavaStructureTest.java
+++ b/mylyn.context/org.eclipse.mylyn.java.tests/src/org/eclipse/mylyn/java/tests/JavaStructureTest.java
@@ -1,13 +1,14 @@
 /*******************************************************************************
- * Copyright (c) 2004, 2014 Tasktop Technologies and others.
- * 
+ * Copyright (c) 2004, 2023 Tasktop Technologies and others.
+ *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
  * https://www.eclipse.org/legal/epl-2.0
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  *     Tasktop Technologies - initial API and implementation
+ *     ArSysOp - adapt to SimRel 2023-06
  *******************************************************************************/
 
 package org.eclipse.mylyn.java.tests;
@@ -22,7 +23,6 @@ import org.eclipse.jface.text.Document;
 import org.eclipse.jface.text.TextSelection;
 import org.eclipse.jface.viewers.StructuredSelection;
 import org.eclipse.mylyn.commons.sdk.util.ResourceTestUtil;
-import org.eclipse.mylyn.commons.sdk.util.UiTestUtil;
 import org.eclipse.mylyn.context.core.IInteractionElement;
 import org.eclipse.mylyn.context.sdk.java.AbstractJavaContextTest;
 import org.eclipse.mylyn.context.sdk.java.TestJavaProject;
@@ -30,6 +30,7 @@ import org.eclipse.mylyn.internal.context.core.ContextCorePlugin;
 import org.eclipse.mylyn.internal.context.core.InteractionContext;
 import org.eclipse.mylyn.internal.context.core.InteractionContextManager;
 import org.eclipse.mylyn.internal.context.core.InteractionContextScaling;
+import org.eclipse.mylyn.internal.ide.ui.IdeUiUtil;
 import org.eclipse.mylyn.internal.java.ui.JavaEditingMonitor;
 import org.eclipse.ui.IWorkbenchPart;
 import org.eclipse.ui.PartInitException;
@@ -71,7 +72,7 @@ public class JavaStructureTest extends AbstractJavaContextTest {
 		taskscape = new InteractionContext("12312", scaling);
 		manager.internalActivateContext(taskscape);
 
-		part = UiTestUtil.openResourceNavigator();
+		part = IdeUiUtil.getNavigatorFromActivePage();
 	}
 
 	@Override

--- a/mylyn.context/org.eclipse.mylyn.java.tests/src/org/eclipse/mylyn/java/tests/ResourceStructureMappingTest.java
+++ b/mylyn.context/org.eclipse.mylyn.java.tests/src/org/eclipse/mylyn/java/tests/ResourceStructureMappingTest.java
@@ -1,14 +1,15 @@
 /*******************************************************************************
- * Copyright (c) 2004, 2012 Tasktop Technologies and others.
- * 
+ * Copyright (c) 2004, 2023 Tasktop Technologies and others.
+ *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
  * https://www.eclipse.org/legal/epl-2.0
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  *     Tasktop Technologies - initial API and implementation
  *     Yatta Solutions -  WorkingSet tests (bug 334024)
+ *     ArSysOp - adapt to SimRel 2023-06
  *******************************************************************************/
 
 package org.eclipse.mylyn.java.tests;
@@ -18,11 +19,11 @@ import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IAdaptable;
 import org.eclipse.jdt.core.IMethod;
 import org.eclipse.jface.viewers.StructuredSelection;
-import org.eclipse.mylyn.commons.sdk.util.UiTestUtil;
 import org.eclipse.mylyn.context.core.AbstractContextStructureBridge;
 import org.eclipse.mylyn.context.core.ContextCore;
 import org.eclipse.mylyn.context.core.IInteractionElement;
 import org.eclipse.mylyn.context.sdk.java.AbstractJavaContextTest;
+import org.eclipse.mylyn.internal.ide.ui.IdeUiUtil;
 import org.eclipse.mylyn.internal.resources.ui.ResourcesUiBridgePlugin;
 import org.eclipse.ui.IWorkbenchPart;
 import org.eclipse.ui.IWorkingSet;
@@ -39,7 +40,7 @@ public class ResourceStructureMappingTest extends AbstractJavaContextTest {
 	protected void setUp() throws Exception {
 		super.setUp();
 		// make sure some part is active
-		UiTestUtil.openResourceNavigator();
+		IdeUiUtil.getNavigatorFromActivePage();
 	}
 
 	@Override

--- a/mylyn.context/org.eclipse.mylyn.resources.tests/src/org/eclipse/mylyn/resources/tests/AbstractResourceContextTest.java
+++ b/mylyn.context/org.eclipse.mylyn.resources.tests/src/org/eclipse/mylyn/resources/tests/AbstractResourceContextTest.java
@@ -1,13 +1,14 @@
 /*******************************************************************************
- * Copyright (c) 2004, 2009 Tasktop Technologies and others.
- * 
+ * Copyright (c) 2004, 2023 Tasktop Technologies and others.
+ *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
  * https://www.eclipse.org/legal/epl-2.0
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  *     Tasktop Technologies - initial API and implementation
+ *     ArSysOp - adapt to SimRel 2023-06
  *******************************************************************************/
 
 package org.eclipse.mylyn.resources.tests;
@@ -23,7 +24,7 @@ import org.eclipse.mylyn.internal.ide.ui.IdeUiBridgePlugin;
 import org.eclipse.mylyn.internal.ide.ui.IdeUiUtil;
 import org.eclipse.mylyn.internal.resources.ui.ResourceInteractionMonitor;
 import org.eclipse.mylyn.internal.resources.ui.ResourceStructureBridge;
-import org.eclipse.ui.views.navigator.ResourceNavigator;
+import org.eclipse.ui.navigator.resources.ProjectExplorer;
 
 /**
  * @author Mik Kersten
@@ -46,7 +47,7 @@ public abstract class AbstractResourceContextTest extends AbstractContextTest {
 
 	protected String taskId = this.getClass().getName();
 
-	protected ResourceNavigator navigator;
+	protected ProjectExplorer navigator;
 
 	@Override
 	protected void setUp() throws Exception {
@@ -58,7 +59,7 @@ public abstract class AbstractResourceContextTest extends AbstractContextTest {
 		context.reset();
 		manager.internalActivateContext(context);
 		ContextUiPlugin.getViewerManager().setSyncRefreshMode(true);
-		navigator = (ResourceNavigator) UiTestUtil.openView(IdeUiUtil.ID_NAVIGATOR);
+		navigator = (ProjectExplorer) UiTestUtil.openView(IdeUiUtil.ID_NAVIGATOR);
 		assertNotNull(navigator);
 	}
 

--- a/mylyn.tasks/org.eclipse.mylyn.tasks.ui/src/org/eclipse/mylyn/internal/tasks/ui/PlanningPerspectiveFactory.java
+++ b/mylyn.tasks/org.eclipse.mylyn.tasks.ui/src/org/eclipse/mylyn/internal/tasks/ui/PlanningPerspectiveFactory.java
@@ -1,14 +1,15 @@
 /*******************************************************************************
- * Copyright (c) 2004, 2011 Tasktop Technologies and others.
- * 
+ * Copyright (c) 2004, 2023 Tasktop Technologies and others.
+ *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
  * https://www.eclipse.org/legal/epl-2.0
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *     Tasktop Technologies - initial API and implementation
+ *     ArSysOp - adapt to SimRel 2023-06
  *******************************************************************************/
 
 package org.eclipse.mylyn.internal.tasks.ui;
@@ -32,7 +33,7 @@ public class PlanningPerspectiveFactory implements IPerspectiveFactory {
 	}
 
 	public void defineActions(IPageLayout layout) {
-		layout.addShowViewShortcut(IPageLayout.ID_RES_NAV);
+		layout.addShowViewShortcut(IPageLayout.ID_PROJECT_EXPLORER);
 		layout.addShowViewShortcut(IPageLayout.ID_PROP_SHEET);
 		layout.addShowViewShortcut(ITasksUiConstants.ID_VIEW_TASKS);
 		// layout.addShowViewShortcut(TaskActivityView.ID);
@@ -51,12 +52,12 @@ public class PlanningPerspectiveFactory implements IPerspectiveFactory {
 		// "bottomLeft", IPageLayout.BOTTOM, (float) 0.50,//$NON-NLS-1$
 		// "topLeft");//$NON-NLS-1$
 		// bottomLeft.addView(TaskActivityView.ID);
-		topRight.addPlaceholder(IPageLayout.ID_RES_NAV);
+		topRight.addPlaceholder(IPageLayout.ID_PROJECT_EXPLORER);
 
 		// IFolderLayout bottomRight = layout.createFolder(
 		// "bottomRight", IPageLayout.BOTTOM, (float) 0.66,//$NON-NLS-1$
 		// editorArea);
-		//		
+		//
 		// bottomRight.addView(IPageLayout.ID_TASK_LIST);
 
 	}


### PR DESCRIPTION
Switch to Project Explorer

Fixing https://github.com/eclipse-mylyn/org.eclipse.mylyn/issues/190