### PR TITLE
fix some small problems for final eclipse 4.28

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 **/.DS_Store
 **/org.eclipse*/bin
 **/org.eclipse*/target
+**/.polyglot.*

--- a/org.eclipse.mylyn-target/mylyn-e4.28.target
+++ b/org.eclipse.mylyn-target/mylyn-e4.28.target
@@ -7,7 +7,7 @@
 			<unit id="org.eclipse.license.feature.group" version="0.0.0"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<repository location="https://download.eclipse.org/eclipse/updates/4.28-I-builds/I20230601-1220/"/>
+			<repository location="https://download.eclipse.org/eclipse/updates/4.28/R-4.28-202306050440/"/>
 			<unit id="org.eclipse.equinox.sdk.feature.group" version="0.0.0"/>
 			<unit id="org.eclipse.sdk.feature.group" version="0.0.0"/>
 		</location>

--- a/org.eclipse.mylyn.releng/oomph/Mylyn.setup
+++ b/org.eclipse.mylyn.releng/oomph/Mylyn.setup
@@ -160,7 +160,7 @@
     <setupTask
         xsi:type="pde:TargetPlatformTask"
         predecessor="mylyn.workingsets"
-        name="mylyn-e4.26">
+        name="mylyn-e4.28">
       <description>Active Mylyn Target Platform</description>
     </setupTask>
     <setupTask


### PR DESCRIPTION
The following was changed

- mylyn-e4.28.target
4.28-I-builds/I20230601-1220 no longer exists we now use 4.28/R-4.28-202306050440
- Mylyn.setup
use mylyn-e4.28.target as the target platform instead of mylyn-e4.26.target
- add .polyglot.* to gitignore