### PR TITLE
[#228] org.eclipse.mylyn.versions -> org.eclipse.mylyn.versions.feature

### DIFF
--- a/mylyn.builds/org.eclipse.mylyn.builds-feature/feature.xml
+++ b/mylyn.builds/org.eclipse.mylyn.builds-feature/feature.xml
@@ -36,7 +36,7 @@
    <requires>
       <import feature="org.eclipse.mylyn.tasks.feature" version="4.0.0" match="compatible"/>
       <import feature="org.eclipse.mylyn.team_feature" version="4.0.0" match="compatible"/>
-      <import feature="org.eclipse.mylyn.versions" version="4.0.0" match="compatible"/>
+      <import feature="org.eclipse.mylyn.versions.feature" version="4.0.0" match="compatible"/>
    </requires>
 
    <plugin

--- a/mylyn.versions/org.eclipse.mylyn.cvs-feature/feature.xml
+++ b/mylyn.versions/org.eclipse.mylyn.cvs-feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2010 Tasktop Technologies and others.
+    Copyright (c) 2010, 2023 Tasktop Technologies and others.
  
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0 which is available at
@@ -10,6 +10,7 @@
 
     Contributors:
          Tasktop Technologies - initial API and implementation
+         ArSysOp - ongoing support
  -->
 <feature
       id="org.eclipse.mylyn.cvs"
@@ -33,7 +34,7 @@
    </license>
 
    <requires>
-      <import feature="org.eclipse.mylyn.versions" version="4.0.0" match="compatible"/>
+      <import feature="org.eclipse.mylyn.versions.feature" version="4.0.0" match="compatible"/>
    </requires>
 
    <plugin

--- a/mylyn.versions/org.eclipse.mylyn.git-feature/feature.xml
+++ b/mylyn.versions/org.eclipse.mylyn.git-feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2011, 2022 Tasktop Technologies and others.
+    Copyright (c) 2011, 2023 Tasktop Technologies and others.
  
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0 which is available at
@@ -10,7 +10,7 @@
 
     Contributors:
          Tasktop Technologies - initial API and implementation
-         ArSysOp - porting to SimRel 2022-12
+         ArSysOp - ongoing support
  -->
 <feature
       id="org.eclipse.mylyn.git"
@@ -34,7 +34,7 @@
    </license>
 
    <requires>
-      <import feature="org.eclipse.mylyn.versions" version="4.0.0" match="compatible"/>
+      <import feature="org.eclipse.mylyn.versions.feature" version="4.0.0" match="compatible"/>
       <import feature="org.eclipse.egit" version="1.0.0" match="greaterOrEqual"/>
    </requires>
 

--- a/mylyn.versions/org.eclipse.mylyn.subclipse-feature/feature.xml
+++ b/mylyn.versions/org.eclipse.mylyn.subclipse-feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2010, 2022 Tasktop Technologies and others.
+    Copyright (c) 2010, 2023 Tasktop Technologies and others.
  
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0 which is available at
@@ -10,7 +10,7 @@
 
     Contributors:
          Tasktop Technologies - initial API and implementation
-         ArSysOp - porting to SimRel 2022-12
+         ArSysOp - ongoing support
  -->
 <feature
       id="org.eclipse.mylyn.subclipse"
@@ -34,7 +34,7 @@
    </license>
 
    <requires>
-      <import feature="org.eclipse.mylyn.versions" version="4.0.0" match="compatible"/>
+      <import feature="org.eclipse.mylyn.versions.feature" version="4.0.0" match="compatible"/>
       <import plugin="org.tigris.subversion.subclipse.core" version="1.6.17" match="greaterOrEqual"/>
    </requires>
 

--- a/mylyn.versions/org.eclipse.mylyn.versions-feature/build.properties
+++ b/mylyn.versions/org.eclipse.mylyn.versions-feature/build.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2009, 2010 Tasktop Technologies and others.
+# Copyright (c) 2009, 2023 Tasktop Technologies and others.
 # 
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License v. 2.0 which is available at
@@ -9,6 +9,8 @@
 #
 # Contributors:
 #      Tasktop Technologies - initial API and implementation
+#      ArSysOp - ongoing support
 ###############################################################################
 bin.includes = feature.properties,\
-               feature.xml
+               feature.xml,\
+               p2.inf

--- a/mylyn.versions/org.eclipse.mylyn.versions-feature/feature.xml
+++ b/mylyn.versions/org.eclipse.mylyn.versions-feature/feature.xml
@@ -13,7 +13,7 @@
          ArSysOp - ongoing support
  -->
 <feature
-      id="org.eclipse.mylyn.versions"
+      id="org.eclipse.mylyn.versions.feature"
       label="%featureName"
       version="4.0.0.qualifier"
       provider-name="%providerName"

--- a/mylyn.versions/org.eclipse.mylyn.versions-feature/p2.inf
+++ b/mylyn.versions/org.eclipse.mylyn.versions-feature/p2.inf
@@ -1,0 +1,6 @@
+update.id=org.eclipse.mylyn.versions.feature.group
+update.range=[0,4)
+update.matchExp = providedCapabilities.exists(pc | \
+   pc.namespace == 'org.eclipse.equinox.p2.iu' && \
+     (pc.name == 'org.eclipse.mylyn.versions.feature.group' || \
+       (pc.name == 'org.eclipse.mylyn.versions.feature.group' && pc.version ~= range('[0.0.0,$version$)'))))

--- a/mylyn.versions/org.eclipse.mylyn.versions.sdk-feature/feature.xml
+++ b/mylyn.versions/org.eclipse.mylyn.versions.sdk-feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2011, 2022 Tasktop Technologies and others.
+    Copyright (c) 2011, 2023 Tasktop Technologies and others.
  
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0 which is available at
@@ -10,7 +10,7 @@
 
     Contributors:
          Tasktop Technologies - initial API and implementation
-         ArSysOp - porting to SimRel 2022-12
+         ArSysOp - ongoing support
  -->
 <feature
       id="org.eclipse.mylyn.versions.sdk"
@@ -38,7 +38,7 @@
          version="0.0.0"/>
 
    <includes
-         id="org.eclipse.mylyn.versions"
+         id="org.eclipse.mylyn.versions.feature"
          version="0.0.0"/>
 
    <plugin

--- a/org.eclipse.mylyn-site/category.xml
+++ b/org.eclipse.mylyn-site/category.xml
@@ -89,7 +89,7 @@
    <feature id="org.eclipse.mylyn.tasks.index">
       <category name="org.eclipse.mylyn.framework.category"/>
    </feature>
-   <feature id="org.eclipse.mylyn.versions">
+   <feature id="org.eclipse.mylyn.versions.feature">
       <category name="org.eclipse.mylyn.framework.category"/>
    </feature>
    <feature id="org.eclipse.mylyn.builds.sdk">


### PR DESCRIPTION
Change feature identifier and provide migration during update.

Fixes #228 