### PR TITLE
[#211] org.eclipse.mylyn.commons.activity -> *.commons.activity.feature

### DIFF
--- a/mylyn.commons/org.eclipse.mylyn.commons.activity-feature/build.properties
+++ b/mylyn.commons/org.eclipse.mylyn.commons.activity-feature/build.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2004, 2014 Tasktop Technologies and others.
+# Copyright (c) 2004, 2023 Tasktop Technologies and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -7,4 +7,5 @@
 ###############################################################################
 
 bin.includes = feature.properties,\
-               feature.xml
+               feature.xml,\
+               p2.inf

--- a/mylyn.commons/org.eclipse.mylyn.commons.activity-feature/feature.xml
+++ b/mylyn.commons/org.eclipse.mylyn.commons.activity-feature/feature.xml
@@ -11,7 +11,7 @@
          ArSysOp - ongoing support
  -->
 <feature
-      id="org.eclipse.mylyn.commons.activity"
+      id="org.eclipse.mylyn.commons.activity.feature"
       label="%featureName"
       version="4.0.0.qualifier"
       provider-name="%providerName"

--- a/mylyn.commons/org.eclipse.mylyn.commons.activity-feature/p2.inf
+++ b/mylyn.commons/org.eclipse.mylyn.commons.activity-feature/p2.inf
@@ -1,0 +1,6 @@
+update.id=org.eclipse.mylyn.commons.activity.feature.group
+update.range=[0,4)
+update.matchExp = providedCapabilities.exists(pc | \
+   pc.namespace == 'org.eclipse.equinox.p2.iu' && \
+     (pc.name == 'org.eclipse.mylyn.commons.activity.feature.group' || \
+       (pc.name == 'org.eclipse.mylyn.commons.activity.feature.group' && pc.version ~= range('[0.0.0,$version$)'))))

--- a/org.eclipse.mylyn-site/category.xml
+++ b/org.eclipse.mylyn-site/category.xml
@@ -62,7 +62,7 @@
    <feature id="org.eclipse.mylyn.commons.feature">
       <category name="org.eclipse.mylyn.framework.category"/>
    </feature>
-   <feature id="org.eclipse.mylyn.commons.activity">
+   <feature id="org.eclipse.mylyn.commons.activity.feature">
       <category name="org.eclipse.mylyn.framework.category"/>
    </feature>
    <feature id="org.eclipse.mylyn.commons.identity">


### PR DESCRIPTION
Change feature identifier and provide migration during update.

Fixes #211 