### PR TITLE
Revert "[#204] Normalize feature identifiers to simplify support"

### DIFF
--- a/mylyn.egit/org.eclipse.mylyn.egit.feature/p2.inf
+++ b/mylyn.egit/org.eclipse.mylyn.egit.feature/p2.inf
@@ -1,4 +1,6 @@
+update.id=org.eclipse.egit.mylyn.feature.group
+update.range=[0,4)
 update.matchExp = providedCapabilities.exists(pc | \
    pc.namespace == 'org.eclipse.equinox.p2.iu' && \
-     (pc.name == 'org.eclipse.egit.mylyn.feature.group' || \
-       (pc.name == 'org.eclipse.mylyn.egit.feature.feature.group' && pc.version ~= range('[0.0.0,3.26.1)'))))
+     (pc.name == 'org.eclipse.mylyn.egit.feature.feature.group' || \
+       (pc.name == 'org.eclipse.egit.mylyn.feature.group' && pc.version ~= range('[0.0.0,$version$)'))))


### PR DESCRIPTION
Remove changes to p2.inf that prevented org.eclipse.mylyn.egit.feature

This reverts commit 1a6608db45b4db4f114a852847dc9d0d9c429f19.

Fixes #245