### PR TITLE
[#252] JUnit's assertThat is deprecated

### DIFF
--- a/mylyn.reviews/org.eclipse.mylyn.gerrit.core.tests/src/org/eclipse/mylyn/internal/gerrit/core/egit/GerritToGitMappingTest.java
+++ b/mylyn.reviews/org.eclipse.mylyn.gerrit.core.tests/src/org/eclipse/mylyn/internal/gerrit/core/egit/GerritToGitMappingTest.java
@@ -13,10 +13,10 @@
 
 package org.eclipse.mylyn.internal.gerrit.core.egit;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.matches;

--- a/mylyn.reviews/org.eclipse.mylyn.gerrit.tests/src/org/eclipse/mylyn/gerrit/tests/core/GerritSynchronizationTest.java
+++ b/mylyn.reviews/org.eclipse.mylyn.gerrit.tests/src/org/eclipse/mylyn/gerrit/tests/core/GerritSynchronizationTest.java
@@ -12,11 +12,11 @@
 
 package org.eclipse.mylyn.gerrit.tests.core;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
-import static org.junit.Assert.assertThat;
 
 import java.io.File;
 import java.util.Collections;

--- a/mylyn.reviews/org.eclipse.mylyn.gerrit.tests/src/org/eclipse/mylyn/gerrit/tests/core/client/rest/ChangeInfoTest.java
+++ b/mylyn.reviews/org.eclipse.mylyn.gerrit.tests/src/org/eclipse/mylyn/gerrit/tests/core/client/rest/ChangeInfoTest.java
@@ -16,12 +16,12 @@ package org.eclipse.mylyn.gerrit.tests.core.client.rest;
 import static org.eclipse.mylyn.gerrit.tests.core.client.rest.IsEmpty.empty;
 import static org.eclipse.mylyn.internal.gerrit.core.client.rest.ApprovalUtil.CRVW;
 import static org.eclipse.mylyn.internal.gerrit.core.client.rest.ApprovalUtil.toNameWithDash;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.core.IsNot.not;
-import static org.junit.Assert.assertThat;
 
 import java.io.File;
 import java.io.IOException;

--- a/mylyn.reviews/org.eclipse.mylyn.gerrit.tests/src/org/eclipse/mylyn/internal/gerrit/core/remote/GerritDataLocatorTest.java
+++ b/mylyn.reviews/org.eclipse.mylyn.gerrit.tests/src/org/eclipse/mylyn/internal/gerrit/core/remote/GerritDataLocatorTest.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
  * Copyright (c) 2013, 2015 Tasktop Technologies and others.
- * 
+ *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
  * https://www.eclipse.org/legal/epl-2.0
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  *     Tasktop Technologies - initial API and implementation
@@ -12,16 +12,14 @@
 
 package org.eclipse.mylyn.internal.gerrit.core.remote;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.sameInstance;
-import static org.junit.Assert.assertThat;
 
 import java.io.File;
-
-import junit.framework.TestCase;
 
 import org.apache.commons.io.FileUtils;
 import org.eclipse.emf.ecore.EObject;
@@ -32,6 +30,8 @@ import org.eclipse.mylyn.reviews.spi.edit.remote.review.ReviewsRemoteEditFactory
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+
+import junit.framework.TestCase;
 
 public class GerritDataLocatorTest extends TestCase {
 

--- a/mylyn.reviews/org.eclipse.mylyn.gerrit.tests/src/org/eclipse/mylyn/internal/gerrit/core/remote/GerritReviewRemoteFactoryJUnit3Test.java
+++ b/mylyn.reviews/org.eclipse.mylyn.gerrit.tests/src/org/eclipse/mylyn/internal/gerrit/core/remote/GerritReviewRemoteFactoryJUnit3Test.java
@@ -16,6 +16,7 @@ import static org.eclipse.mylyn.internal.gerrit.core.client.rest.ApprovalUtil.CR
 import static org.eclipse.mylyn.internal.gerrit.core.client.rest.ApprovalUtil.toNameWithDash;
 import static org.eclipse.mylyn.internal.gerrit.core.remote.TestRemoteObserverConsumer.retrieveForLocalKey;
 import static org.eclipse.mylyn.internal.gerrit.core.remote.TestRemoteObserverConsumer.retrieveForRemoteKey;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.endsWith;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.is;
@@ -24,7 +25,6 @@ import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.sameInstance;
 import static org.hamcrest.Matchers.startsWith;
 import static org.hamcrest.core.IsNot.not;
-import static org.junit.Assert.assertThat;
 
 import java.util.Arrays;
 import java.util.Collections;

--- a/mylyn.reviews/org.eclipse.mylyn.gerrit.tests/src/org/eclipse/mylyn/internal/gerrit/core/remote/PatchSetDetailRemoteFactoryTest.java
+++ b/mylyn.reviews/org.eclipse.mylyn.gerrit.tests/src/org/eclipse/mylyn/internal/gerrit/core/remote/PatchSetDetailRemoteFactoryTest.java
@@ -13,13 +13,11 @@
 package org.eclipse.mylyn.internal.gerrit.core.remote;
 
 import static org.eclipse.mylyn.internal.gerrit.core.remote.TestRemoteObserverConsumer.retrieveForLocalKey;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
-import static org.junit.Assert.assertThat;
 
 import java.util.List;
-
-import junit.framework.TestCase;
 
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.jgit.api.CommitCommand;
@@ -38,6 +36,8 @@ import com.google.common.collect.ImmutableList;
 import com.google.gerrit.common.data.PatchSetDetail;
 import com.google.gerrit.reviewdb.Change;
 import com.google.gerrit.reviewdb.PatchSet;
+
+import junit.framework.TestCase;
 
 public class PatchSetDetailRemoteFactoryTest extends TestCase {
 

--- a/mylyn.reviews/org.eclipse.mylyn.gerrit.tests/src/org/eclipse/mylyn/internal/gerrit/core/remote/PatchSetRemoteFactoryTest.java
+++ b/mylyn.reviews/org.eclipse.mylyn.gerrit.tests/src/org/eclipse/mylyn/internal/gerrit/core/remote/PatchSetRemoteFactoryTest.java
@@ -14,12 +14,12 @@ package org.eclipse.mylyn.internal.gerrit.core.remote;
 
 import static org.eclipse.mylyn.internal.gerrit.core.remote.TestRemoteObserverConsumer.retrieveForLocalKey;
 import static org.eclipse.mylyn.internal.gerrit.core.remote.TestRemoteObserverConsumer.retrieveForRemoteKey;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
-import static org.junit.Assert.assertThat;
 
 import java.io.ByteArrayOutputStream;
 import java.io.File;

--- a/mylyn.reviews/org.eclipse.mylyn.gerrit.tests/src/org/eclipse/mylyn/internal/gerrit/core/remote/ReviewHarness.java
+++ b/mylyn.reviews/org.eclipse.mylyn.gerrit.tests/src/org/eclipse/mylyn/internal/gerrit/core/remote/ReviewHarness.java
@@ -12,11 +12,11 @@
 
 package org.eclipse.mylyn.internal.gerrit.core.remote;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.sameInstance;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 
 import java.io.File;

--- a/mylyn.reviews/org.eclipse.mylyn.gerrit.tests/src/org/eclipse/mylyn/internal/gerrit/core/remote/TestRemoteObserver.java
+++ b/mylyn.reviews/org.eclipse.mylyn.gerrit.tests/src/org/eclipse/mylyn/internal/gerrit/core/remote/TestRemoteObserver.java
@@ -12,8 +12,8 @@
 
 package org.eclipse.mylyn.internal.gerrit.core.remote;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
 
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.mylyn.reviews.core.spi.remote.emf.AbstractRemoteEmfFactory;

--- a/mylyn.reviews/org.eclipse.mylyn.gerrit.ui.tests/src/org/eclipse/mylyn/internal/gerrit/ui/editor/GerritTaskEditorPageTest.java
+++ b/mylyn.reviews/org.eclipse.mylyn.gerrit.ui.tests/src/org/eclipse/mylyn/internal/gerrit/ui/editor/GerritTaskEditorPageTest.java
@@ -12,15 +12,13 @@
 
 package org.eclipse.mylyn.internal.gerrit.ui.editor;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
-import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
 import java.util.List;
-
-import junit.framework.TestCase;
 
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.mylyn.internal.gerrit.core.GerritConnector;
@@ -49,6 +47,8 @@ import com.google.common.base.Predicate;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
+
+import junit.framework.TestCase;
 
 @SuppressWarnings("restriction")
 public class GerritTaskEditorPageTest extends TestCase {

--- a/mylyn.reviews/org.eclipse.mylyn.reviews.core.tests/src/org/eclipse/mylyn/reviews/core/model/CommentContainerTest.java
+++ b/mylyn.reviews/org.eclipse.mylyn.reviews.core.tests/src/org/eclipse/mylyn/reviews/core/model/CommentContainerTest.java
@@ -1,23 +1,23 @@
 /**
  * Copyright (c) 2012, 2014 Tasktop Technologies and others.
- * 
+ *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
  * https://www.eclipse.org/legal/epl-2.0
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  *     Tasktop Technologies - initial API and implementation
  */
 package org.eclipse.mylyn.reviews.core.model;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.sameInstance;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 import java.util.Date;
@@ -37,7 +37,7 @@ import org.junit.Test;
  * <em>Create Comment Comment</em>}</li>
  * </ul>
  * </p>
- * 
+ *
  * @generated NOT
  */
 public class CommentContainerTest {

--- a/mylyn.reviews/org.eclipse.mylyn.reviews.core.tests/src/org/eclipse/mylyn/reviews/core/model/IndexedTest.java
+++ b/mylyn.reviews/org.eclipse.mylyn.reviews.core.tests/src/org/eclipse/mylyn/reviews/core/model/IndexedTest.java
@@ -11,9 +11,9 @@
  */
 package org.eclipse.mylyn.reviews.core.model;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.sameInstance;
-import static org.junit.Assert.assertThat;
 
 import java.util.ArrayList;
 import java.util.Collections;

--- a/mylyn.reviews/org.eclipse.mylyn.reviews.core.tests/src/org/eclipse/mylyn/reviews/core/spi/remote/AbstractDataLocatorTest.java
+++ b/mylyn.reviews/org.eclipse.mylyn.reviews.core.tests/src/org/eclipse/mylyn/reviews/core/spi/remote/AbstractDataLocatorTest.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
  * Copyright (c) 2011, 2013 GitHub Inc. and others.
- * 
+ *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
  * https://www.eclipse.org/legal/epl-2.0
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  *     GitHub Inc. - initial API and implementation
@@ -12,8 +12,8 @@
  *******************************************************************************/
 package org.eclipse.mylyn.reviews.core.spi.remote;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
 
 import java.io.File;
 

--- a/mylyn.reviews/org.eclipse.mylyn.reviews.core.tests/src/org/eclipse/mylyn/reviews/core/spi/remote/ReviewsDataLocatorTest.java
+++ b/mylyn.reviews/org.eclipse.mylyn.reviews.core.tests/src/org/eclipse/mylyn/reviews/core/spi/remote/ReviewsDataLocatorTest.java
@@ -12,8 +12,8 @@
  *******************************************************************************/
 package org.eclipse.mylyn.reviews.core.spi.remote;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
 
 import java.io.File;
 import java.io.IOException;

--- a/mylyn.reviews/org.eclipse.mylyn.reviews.core.tests/src/org/eclipse/mylyn/reviews/core/spi/remote/emf/RemoteEmfFactoryTest.java
+++ b/mylyn.reviews/org.eclipse.mylyn.reviews.core.tests/src/org/eclipse/mylyn/reviews/core/spi/remote/emf/RemoteEmfFactoryTest.java
@@ -12,12 +12,12 @@
  *******************************************************************************/
 package org.eclipse.mylyn.reviews.core.spi.remote.emf;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.sameInstance;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 
 import java.util.List;

--- a/mylyn.reviews/org.eclipse.mylyn.reviews.core.tests/src/org/eclipse/mylyn/reviews/core/spi/remote/emf/RemoteEmfObserverTest.java
+++ b/mylyn.reviews/org.eclipse.mylyn.reviews.core.tests/src/org/eclipse/mylyn/reviews/core/spi/remote/emf/RemoteEmfObserverTest.java
@@ -12,11 +12,11 @@
  *******************************************************************************/
 package org.eclipse.mylyn.reviews.core.spi.remote.emf;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.sameInstance;
-import static org.junit.Assert.assertThat;
 
 import org.eclipse.emf.ecore.EClass;
 import org.eclipse.emf.ecore.EPackage;

--- a/mylyn.reviews/org.eclipse.mylyn.reviews.core.tests/src/org/eclipse/mylyn/reviews/core/spi/remote/emf/RemoteServiceTest.java
+++ b/mylyn.reviews/org.eclipse.mylyn.reviews.core.tests/src/org/eclipse/mylyn/reviews/core/spi/remote/emf/RemoteServiceTest.java
@@ -12,10 +12,10 @@
  *******************************************************************************/
 package org.eclipse.mylyn.reviews.core.spi.remote.emf;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
-import static org.junit.Assert.assertThat;
 
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;

--- a/mylyn.reviews/org.eclipse.mylyn.reviews.core.tests/src/org/eclipse/mylyn/reviews/core/spi/remote/emf/TestRemoteEmfObserver.java
+++ b/mylyn.reviews/org.eclipse.mylyn.reviews.core.tests/src/org/eclipse/mylyn/reviews/core/spi/remote/emf/TestRemoteEmfObserver.java
@@ -12,8 +12,8 @@
 
 package org.eclipse.mylyn.reviews.core.spi.remote.emf;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
 
 import java.util.Collection;
 

--- a/mylyn.reviews/org.eclipse.mylyn.reviews.tests/src/org/eclipse/mylyn/reviews/spi/edit/remote/AbstractRemoteEditFactoryProviderTest.java
+++ b/mylyn.reviews/org.eclipse.mylyn.reviews.tests/src/org/eclipse/mylyn/reviews/spi/edit/remote/AbstractRemoteEditFactoryProviderTest.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
  * Copyright (c) 2012, 2013 Tasktop Technologies and others.
- * 
+ *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
  * https://www.eclipse.org/legal/epl-2.0
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  *     Tasktop Technologies - initial API and implementation
@@ -12,13 +12,13 @@
 
 package org.eclipse.mylyn.reviews.spi.edit.remote;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.sameInstance;
 import static org.hamcrest.Matchers.startsWith;
-import static org.junit.Assert.assertThat;
 
 import java.io.BufferedReader;
 import java.io.BufferedWriter;
@@ -26,8 +26,6 @@ import java.io.File;
 import java.io.FileReader;
 import java.io.FileWriter;
 import java.io.IOException;
-
-import junit.framework.TestCase;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang.StringUtils;
@@ -46,6 +44,8 @@ import org.eclipse.mylyn.reviews.core.spi.remote.AbstractDataLocator;
 import org.eclipse.mylyn.reviews.core.spi.remote.JobRemoteService;
 import org.junit.Before;
 import org.junit.Test;
+
+import junit.framework.TestCase;
 
 /**
  * @author Miles Parker

--- a/mylyn.reviews/org.eclipse.mylyn.reviews.tests/src/org/eclipse/mylyn/reviews/tests/ui/UiDataLocatorTest.java
+++ b/mylyn.reviews/org.eclipse.mylyn.reviews.tests/src/org/eclipse/mylyn/reviews/tests/ui/UiDataLocatorTest.java
@@ -12,18 +12,18 @@
 
 package org.eclipse.mylyn.reviews.tests.ui;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
 
 import java.io.File;
-
-import junit.framework.TestCase;
 
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.mylyn.reviews.core.spi.remote.ReviewsDataLocator;
 import org.eclipse.mylyn.reviews.ui.spi.factories.ReviewsUiDataLocator;
 import org.junit.Test;
+
+import junit.framework.TestCase;
 
 /**
  * @author Miles Parker

--- a/mylyn.tasks/connectors/bugzilla-rest/org.eclipse.mylyn.bugzilla.rest.core.tests/src/org/eclipse/mylyn/bugzilla/rest/core/tests/BugzillaRestClientTest.java
+++ b/mylyn.tasks/connectors/bugzilla-rest/org.eclipse.mylyn.bugzilla.rest.core.tests/src/org/eclipse/mylyn/bugzilla/rest/core/tests/BugzillaRestClientTest.java
@@ -14,11 +14,11 @@
 package org.eclipse.mylyn.bugzilla.rest.core.tests;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 

--- a/mylyn.tasks/connectors/bugzilla-rest/org.eclipse.mylyn.bugzilla.rest.core.tests/src/org/eclipse/mylyn/bugzilla/rest/core/tests/BugzillaRestConnectorNoFixtureTest.java
+++ b/mylyn.tasks/connectors/bugzilla-rest/org.eclipse.mylyn.bugzilla.rest.core.tests/src/org/eclipse/mylyn/bugzilla/rest/core/tests/BugzillaRestConnectorNoFixtureTest.java
@@ -1,8 +1,8 @@
 package org.eclipse.mylyn.bugzilla.rest.core.tests;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 import java.util.Date;

--- a/mylyn.tasks/connectors/bugzilla-rest/org.eclipse.mylyn.bugzilla.rest.core.tests/src/org/eclipse/mylyn/bugzilla/rest/core/tests/BugzillaRestConnectorTest.java
+++ b/mylyn.tasks/connectors/bugzilla-rest/org.eclipse.mylyn.bugzilla.rest.core.tests/src/org/eclipse/mylyn/bugzilla/rest/core/tests/BugzillaRestConnectorTest.java
@@ -1,11 +1,11 @@
 package org.eclipse.mylyn.bugzilla.rest.core.tests;
 
 import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
 
 import java.util.concurrent.TimeUnit;
 

--- a/mylyn.tasks/connectors/bugzilla-rest/org.eclipse.mylyn.bugzilla.rest.core.tests/src/org/eclipse/mylyn/bugzilla/rest/core/tests/BugzillaRestFlagMapperTest.java
+++ b/mylyn.tasks/connectors/bugzilla-rest/org.eclipse.mylyn.bugzilla.rest.core.tests/src/org/eclipse/mylyn/bugzilla/rest/core/tests/BugzillaRestFlagMapperTest.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
  * Copyright (c) 2016 Frank Becker and others.
- * 
+ *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
  * https://www.eclipse.org/legal/epl-2.0
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -14,9 +14,9 @@
 package org.eclipse.mylyn.bugzilla.rest.core.tests;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
 
 import java.io.IOException;
 

--- a/mylyn.tasks/connectors/bugzilla-rest/org.eclipse.mylyn.bugzilla.rest.core.tests/src/org/eclipse/mylyn/bugzilla/rest/test/support/BugzillaRestHarness.java
+++ b/mylyn.tasks/connectors/bugzilla-rest/org.eclipse.mylyn.bugzilla.rest.core.tests/src/org/eclipse/mylyn/bugzilla/rest/test/support/BugzillaRestHarness.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
  * Copyright (c) 2015 Frank Becker and others.
- * 
+ *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
  * https://www.eclipse.org/legal/epl-2.0
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -14,8 +14,8 @@
 package org.eclipse.mylyn.bugzilla.rest.test.support;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThat;
 
 import java.util.ArrayList;
 import java.util.HashMap;


### PR DESCRIPTION
replaced all imports of ```org.junit.Assert.assertThat``` with
```org.hamcrest.MatcherAssert.assertThat```