### PR TITLE
switch to global commit template #260

### DIFF
--- a/mylyn.builds/org.eclipse.mylyn.builds-feature/.settings/org.eclipse.mylyn.team.ui.prefs
+++ b/mylyn.builds/org.eclipse.mylyn.builds-feature/.settings/org.eclipse.mylyn.team.ui.prefs
@@ -1,2 +1,0 @@
-commit.comment.template=${task.key}\: ${task.description}\n\nTask-Url\: ${task.url}
-eclipse.preferences.version=1

--- a/mylyn.builds/org.eclipse.mylyn.builds.core/.settings/org.eclipse.mylyn.team.ui.prefs
+++ b/mylyn.builds/org.eclipse.mylyn.builds.core/.settings/org.eclipse.mylyn.team.ui.prefs
@@ -1,2 +1,0 @@
-commit.comment.template=${task.key}\: ${task.description}\n\nTask-Url\: ${task.url}
-eclipse.preferences.version=1

--- a/mylyn.builds/org.eclipse.mylyn.builds.tests/.settings/org.eclipse.mylyn.team.ui.prefs
+++ b/mylyn.builds/org.eclipse.mylyn.builds.tests/.settings/org.eclipse.mylyn.team.ui.prefs
@@ -1,2 +1,0 @@
-commit.comment.template=${task.key}\: ${task.description}\n\nTask-Url\: ${task.url}
-eclipse.preferences.version=1

--- a/mylyn.builds/org.eclipse.mylyn.builds.ui/.settings/org.eclipse.mylyn.team.ui.prefs
+++ b/mylyn.builds/org.eclipse.mylyn.builds.ui/.settings/org.eclipse.mylyn.team.ui.prefs
@@ -1,2 +1,0 @@
-commit.comment.template=${task.key}\: ${task.description}\n\nTask-Url\: ${task.url}
-eclipse.preferences.version=1

--- a/mylyn.builds/org.eclipse.mylyn.jenkins-feature/.settings/org.eclipse.mylyn.team.ui.prefs
+++ b/mylyn.builds/org.eclipse.mylyn.jenkins-feature/.settings/org.eclipse.mylyn.team.ui.prefs
@@ -1,2 +1,0 @@
-commit.comment.template=${task.key}\: ${task.description}\n\nTask-Url\: ${task.url}
-eclipse.preferences.version=1

--- a/mylyn.builds/org.eclipse.mylyn.jenkins.core/.settings/org.eclipse.mylyn.team.ui.prefs
+++ b/mylyn.builds/org.eclipse.mylyn.jenkins.core/.settings/org.eclipse.mylyn.team.ui.prefs
@@ -1,2 +1,0 @@
-commit.comment.template=${task.key}\: ${task.description}\n\nTask-Url\: ${task.url}
-eclipse.preferences.version=1

--- a/mylyn.builds/org.eclipse.mylyn.jenkins.tests/.settings/org.eclipse.mylyn.team.ui.prefs
+++ b/mylyn.builds/org.eclipse.mylyn.jenkins.tests/.settings/org.eclipse.mylyn.team.ui.prefs
@@ -1,2 +1,0 @@
-commit.comment.template=${task.key}\: ${task.description}\n\nTask-Url\: ${task.url}
-eclipse.preferences.version=1

--- a/mylyn.builds/org.eclipse.mylyn.jenkins.ui/.settings/org.eclipse.mylyn.team.ui.prefs
+++ b/mylyn.builds/org.eclipse.mylyn.jenkins.ui/.settings/org.eclipse.mylyn.team.ui.prefs
@@ -1,2 +1,0 @@
-commit.comment.template=${task.key}\: ${task.description}\n\nTask-Url\: ${task.url}
-eclipse.preferences.version=1

--- a/mylyn.commons/org.eclipse.mylyn.commons-feature/.settings/org.eclipse.mylyn.team.ui.prefs
+++ b/mylyn.commons/org.eclipse.mylyn.commons-feature/.settings/org.eclipse.mylyn.team.ui.prefs
@@ -1,2 +1,0 @@
-commit.comment.template=${task.key}\: ${task.description}\n\nTask-Url\: ${task.url}
-eclipse.preferences.version=1

--- a/mylyn.commons/org.eclipse.mylyn.commons.activity-feature/.settings/org.eclipse.mylyn.team.ui.prefs
+++ b/mylyn.commons/org.eclipse.mylyn.commons.activity-feature/.settings/org.eclipse.mylyn.team.ui.prefs
@@ -1,2 +1,0 @@
-commit.comment.template=${task.key}\: ${task.description}\n\nTask-Url\: ${task.url}
-eclipse.preferences.version=1

--- a/mylyn.commons/org.eclipse.mylyn.commons.activity.tests/.settings/org.eclipse.mylyn.team.ui.prefs
+++ b/mylyn.commons/org.eclipse.mylyn.commons.activity.tests/.settings/org.eclipse.mylyn.team.ui.prefs
@@ -1,2 +1,0 @@
-commit.comment.template=${task.key}\: ${task.description}\n\nTask-Url\: ${task.url}
-eclipse.preferences.version=1

--- a/mylyn.commons/org.eclipse.mylyn.commons.activity.ui/.settings/org.eclipse.mylyn.team.ui.prefs
+++ b/mylyn.commons/org.eclipse.mylyn.commons.activity.ui/.settings/org.eclipse.mylyn.team.ui.prefs
@@ -1,2 +1,0 @@
-commit.comment.template=${task.key}\: ${task.description}\n\nTask-Url\: ${task.url}
-eclipse.preferences.version=1

--- a/mylyn.commons/org.eclipse.mylyn.commons.core/.settings/org.eclipse.mylyn.team.ui.prefs
+++ b/mylyn.commons/org.eclipse.mylyn.commons.core/.settings/org.eclipse.mylyn.team.ui.prefs
@@ -1,2 +1,0 @@
-commit.comment.template=${task.key}\: ${task.description}\n\nTask-Url\: ${task.url}
-eclipse.preferences.version=1

--- a/mylyn.commons/org.eclipse.mylyn.commons.identity-feature/.settings/org.eclipse.mylyn.team.ui.prefs
+++ b/mylyn.commons/org.eclipse.mylyn.commons.identity-feature/.settings/org.eclipse.mylyn.team.ui.prefs
@@ -1,2 +1,0 @@
-commit.comment.template=${task.key}\: ${task.description}\n\nTask-Url\: ${task.url}
-eclipse.preferences.version=1

--- a/mylyn.commons/org.eclipse.mylyn.commons.identity.core/.settings/org.eclipse.mylyn.team.ui.prefs
+++ b/mylyn.commons/org.eclipse.mylyn.commons.identity.core/.settings/org.eclipse.mylyn.team.ui.prefs
@@ -1,2 +1,0 @@
-commit.comment.template=${task.key}\: ${task.description}\n\nTask-Url\: ${task.url}
-eclipse.preferences.version=1

--- a/mylyn.commons/org.eclipse.mylyn.commons.identity.ui/.settings/org.eclipse.mylyn.team.ui.prefs
+++ b/mylyn.commons/org.eclipse.mylyn.commons.identity.ui/.settings/org.eclipse.mylyn.team.ui.prefs
@@ -1,2 +1,0 @@
-commit.comment.template=${task.key}\: ${task.description}\n\nTask-Url\: ${task.url}
-eclipse.preferences.version=1

--- a/mylyn.commons/org.eclipse.mylyn.commons.net/.settings/org.eclipse.mylyn.team.ui.prefs
+++ b/mylyn.commons/org.eclipse.mylyn.commons.net/.settings/org.eclipse.mylyn.team.ui.prefs
@@ -1,2 +1,0 @@
-commit.comment.template=${task.key}\: ${task.description}\n\nTask-Url\: ${task.url}
-eclipse.preferences.version=1

--- a/mylyn.commons/org.eclipse.mylyn.commons.notifications-feature/.settings/org.eclipse.mylyn.team.ui.prefs
+++ b/mylyn.commons/org.eclipse.mylyn.commons.notifications-feature/.settings/org.eclipse.mylyn.team.ui.prefs
@@ -1,2 +1,0 @@
-commit.comment.template=${task.key}\: ${task.description}\n\nTask-Url\: ${task.url}
-eclipse.preferences.version=1

--- a/mylyn.commons/org.eclipse.mylyn.commons.notifications.core/.settings/org.eclipse.mylyn.team.ui.prefs
+++ b/mylyn.commons/org.eclipse.mylyn.commons.notifications.core/.settings/org.eclipse.mylyn.team.ui.prefs
@@ -1,2 +1,0 @@
-commit.comment.template=${task.key}\: ${task.description}\n\nTask-Url\: ${task.url}
-eclipse.preferences.version=1

--- a/mylyn.commons/org.eclipse.mylyn.commons.notifications.feed/.settings/org.eclipse.mylyn.team.ui.prefs
+++ b/mylyn.commons/org.eclipse.mylyn.commons.notifications.feed/.settings/org.eclipse.mylyn.team.ui.prefs
@@ -1,2 +1,0 @@
-commit.comment.template=${task.key}\: ${task.description}\n\nTask-Url\: ${task.url}
-eclipse.preferences.version=1

--- a/mylyn.commons/org.eclipse.mylyn.commons.notifications.tests/.settings/org.eclipse.mylyn.team.ui.prefs
+++ b/mylyn.commons/org.eclipse.mylyn.commons.notifications.tests/.settings/org.eclipse.mylyn.team.ui.prefs
@@ -1,2 +1,0 @@
-commit.comment.template=${task.key}\: ${task.description}\n\nTask-Url\: ${task.url}
-eclipse.preferences.version=1

--- a/mylyn.commons/org.eclipse.mylyn.commons.notifications.ui/.settings/org.eclipse.mylyn.team.ui.prefs
+++ b/mylyn.commons/org.eclipse.mylyn.commons.notifications.ui/.settings/org.eclipse.mylyn.team.ui.prefs
@@ -1,2 +1,0 @@
-commit.comment.template=${task.key}\: ${task.description}\n\nTask-Url\: ${task.url}
-eclipse.preferences.version=1

--- a/mylyn.commons/org.eclipse.mylyn.commons.repositories-feature/.settings/org.eclipse.mylyn.team.ui.prefs
+++ b/mylyn.commons/org.eclipse.mylyn.commons.repositories-feature/.settings/org.eclipse.mylyn.team.ui.prefs
@@ -1,2 +1,0 @@
-commit.comment.template=${task.key}\: ${task.description}\n\nTask-Url\: ${task.url}
-eclipse.preferences.version=1

--- a/mylyn.commons/org.eclipse.mylyn.commons.repositories.core/.settings/org.eclipse.mylyn.team.ui.prefs
+++ b/mylyn.commons/org.eclipse.mylyn.commons.repositories.core/.settings/org.eclipse.mylyn.team.ui.prefs
@@ -1,2 +1,0 @@
-commit.comment.template=${task.key}\: ${task.description}\n\nTask-Url\: ${task.url}
-eclipse.preferences.version=1

--- a/mylyn.commons/org.eclipse.mylyn.commons.repositories.http.core/.settings/org.eclipse.mylyn.team.ui.prefs
+++ b/mylyn.commons/org.eclipse.mylyn.commons.repositories.http.core/.settings/org.eclipse.mylyn.team.ui.prefs
@@ -1,2 +1,0 @@
-commit.comment.template=${task.key}\: ${task.description}\n\nTask-Url\: ${task.url}
-eclipse.preferences.version=1

--- a/mylyn.commons/org.eclipse.mylyn.commons.repositories.http.tests/.settings/org.eclipse.mylyn.team.ui.prefs
+++ b/mylyn.commons/org.eclipse.mylyn.commons.repositories.http.tests/.settings/org.eclipse.mylyn.team.ui.prefs
@@ -1,2 +1,0 @@
-commit.comment.template=${task.key}\: ${task.description}\n\nTask-Url\: ${task.url}
-eclipse.preferences.version=1

--- a/mylyn.commons/org.eclipse.mylyn.commons.repositories.tests/.settings/org.eclipse.mylyn.team.ui.prefs
+++ b/mylyn.commons/org.eclipse.mylyn.commons.repositories.tests/.settings/org.eclipse.mylyn.team.ui.prefs
@@ -1,2 +1,0 @@
-commit.comment.template=${task.key}\: ${task.description}\n\nTask-Url\: ${task.url}
-eclipse.preferences.version=1

--- a/mylyn.commons/org.eclipse.mylyn.commons.repositories.ui/.settings/org.eclipse.mylyn.team.ui.prefs
+++ b/mylyn.commons/org.eclipse.mylyn.commons.repositories.ui/.settings/org.eclipse.mylyn.team.ui.prefs
@@ -1,2 +1,0 @@
-commit.comment.template=${task.key}\: ${task.description}\n\nTask-Url\: ${task.url}
-eclipse.preferences.version=1

--- a/mylyn.commons/org.eclipse.mylyn.commons.screenshots/.settings/org.eclipse.mylyn.team.ui.prefs
+++ b/mylyn.commons/org.eclipse.mylyn.commons.screenshots/.settings/org.eclipse.mylyn.team.ui.prefs
@@ -1,2 +1,0 @@
-commit.comment.template=${task.key}\: ${task.description}\n\nTask-Url\: ${task.url}
-eclipse.preferences.version=1

--- a/mylyn.commons/org.eclipse.mylyn.commons.sdk.util/.settings/org.eclipse.mylyn.team.ui.prefs
+++ b/mylyn.commons/org.eclipse.mylyn.commons.sdk.util/.settings/org.eclipse.mylyn.team.ui.prefs
@@ -1,2 +1,0 @@
-commit.comment.template=${task.key}\: ${task.description}\n\nTask-Url\: ${task.url}
-eclipse.preferences.version=1

--- a/mylyn.commons/org.eclipse.mylyn.commons.tests/.settings/org.eclipse.mylyn.team.ui.prefs
+++ b/mylyn.commons/org.eclipse.mylyn.commons.tests/.settings/org.eclipse.mylyn.team.ui.prefs
@@ -1,2 +1,0 @@
-commit.comment.template=${task.key}\: ${task.description}\n\nTask-Url\: ${task.url}
-eclipse.preferences.version=1

--- a/mylyn.commons/org.eclipse.mylyn.commons.ui.tests/.settings/org.eclipse.mylyn.team.ui.prefs
+++ b/mylyn.commons/org.eclipse.mylyn.commons.ui.tests/.settings/org.eclipse.mylyn.team.ui.prefs
@@ -1,2 +1,0 @@
-commit.comment.template=${task.key}\: ${task.description}\n\nTask-Url\: ${task.url}
-eclipse.preferences.version=1

--- a/mylyn.commons/org.eclipse.mylyn.commons.ui/.settings/org.eclipse.mylyn.team.ui.prefs
+++ b/mylyn.commons/org.eclipse.mylyn.commons.ui/.settings/org.eclipse.mylyn.team.ui.prefs
@@ -1,2 +1,0 @@
-commit.comment.template=${task.key}\: ${task.description}\n\nTask-Url\: ${task.url}
-eclipse.preferences.version=1

--- a/mylyn.commons/org.eclipse.mylyn.commons.workbench/.settings/org.eclipse.mylyn.team.ui.prefs
+++ b/mylyn.commons/org.eclipse.mylyn.commons.workbench/.settings/org.eclipse.mylyn.team.ui.prefs
@@ -1,2 +1,0 @@
-commit.comment.template=${task.key}\: ${task.description}\n\nTask-Url\: ${task.url}
-eclipse.preferences.version=1

--- a/mylyn.commons/org.eclipse.mylyn.commons.xmlrpc/.settings/org.eclipse.mylyn.team.ui.prefs
+++ b/mylyn.commons/org.eclipse.mylyn.commons.xmlrpc/.settings/org.eclipse.mylyn.team.ui.prefs
@@ -1,2 +1,0 @@
-commit.comment.template=${task.key}\: ${task.description}\n\nTask-Url\: ${task.url}
-eclipse.preferences.version=1

--- a/mylyn.commons/org.eclipse.mylyn.discovery-feature/.settings/org.eclipse.mylyn.team.ui.prefs
+++ b/mylyn.commons/org.eclipse.mylyn.discovery-feature/.settings/org.eclipse.mylyn.team.ui.prefs
@@ -1,2 +1,0 @@
-commit.comment.template=${task.key}\: ${task.description}\n\nTask-Url\: ${task.url}
-eclipse.preferences.version=1

--- a/mylyn.commons/org.eclipse.mylyn.discovery.core/.settings/org.eclipse.mylyn.team.ui.prefs
+++ b/mylyn.commons/org.eclipse.mylyn.discovery.core/.settings/org.eclipse.mylyn.team.ui.prefs
@@ -1,2 +1,0 @@
-commit.comment.template=${task.key}\: ${task.description}\n\nTask-Url\: ${task.url}
-eclipse.preferences.version=1

--- a/mylyn.commons/org.eclipse.mylyn.discovery.tests/.settings/org.eclipse.mylyn.team.ui.prefs
+++ b/mylyn.commons/org.eclipse.mylyn.discovery.tests/.settings/org.eclipse.mylyn.team.ui.prefs
@@ -1,2 +1,0 @@
-commit.comment.template=${task.key}\: ${task.description}\n\nTask-Url\: ${task.url}
-eclipse.preferences.version=1

--- a/mylyn.commons/org.eclipse.mylyn.discovery.ui/.settings/org.eclipse.mylyn.team.ui.prefs
+++ b/mylyn.commons/org.eclipse.mylyn.discovery.ui/.settings/org.eclipse.mylyn.team.ui.prefs
@@ -1,2 +1,0 @@
-commit.comment.template=${task.key}\: ${task.description}\n\nTask-Url\: ${task.url}
-eclipse.preferences.version=1

--- a/mylyn.commons/org.eclipse.mylyn.monitor-feature/.settings/org.eclipse.mylyn.team.ui.prefs
+++ b/mylyn.commons/org.eclipse.mylyn.monitor-feature/.settings/org.eclipse.mylyn.team.ui.prefs
@@ -1,2 +1,0 @@
-commit.comment.template=${task.key}\: ${task.description}\n\nTask-Url\: ${task.url}
-eclipse.preferences.version=1

--- a/mylyn.commons/org.eclipse.mylyn.monitor.core/.settings/org.eclipse.mylyn.team.ui.prefs
+++ b/mylyn.commons/org.eclipse.mylyn.monitor.core/.settings/org.eclipse.mylyn.team.ui.prefs
@@ -1,2 +1,0 @@
-commit.comment.template=${task.key}\: ${task.description}\n\nTask-Url\: ${task.url}
-eclipse.preferences.version=1

--- a/mylyn.commons/org.eclipse.mylyn.monitor.tests/.settings/org.eclipse.mylyn.team.ui.prefs
+++ b/mylyn.commons/org.eclipse.mylyn.monitor.tests/.settings/org.eclipse.mylyn.team.ui.prefs
@@ -1,2 +1,0 @@
-commit.comment.template=${task.key}\: ${task.description}\n\nTask-Url\: ${task.url}
-eclipse.preferences.version=1

--- a/mylyn.commons/org.eclipse.mylyn.monitor.ui/.settings/org.eclipse.mylyn.team.ui.prefs
+++ b/mylyn.commons/org.eclipse.mylyn.monitor.ui/.settings/org.eclipse.mylyn.team.ui.prefs
@@ -1,2 +1,0 @@
-commit.comment.template=${task.key}\: ${task.description}\n\nTask-Url\: ${task.url}
-eclipse.preferences.version=1

--- a/mylyn.context/org.eclipse.mylyn.bugzilla.ide/.settings/org.eclipse.mylyn.team.ui.prefs
+++ b/mylyn.context/org.eclipse.mylyn.bugzilla.ide/.settings/org.eclipse.mylyn.team.ui.prefs
@@ -1,2 +1,0 @@
-commit.comment.template=${task.key}\: ${task.description}\n\nTask-Url\: ${task.url}
-eclipse.preferences.version=1

--- a/mylyn.context/org.eclipse.mylyn.cdt-feature/.settings/org.eclipse.mylyn.team.ui.prefs
+++ b/mylyn.context/org.eclipse.mylyn.cdt-feature/.settings/org.eclipse.mylyn.team.ui.prefs
@@ -1,2 +1,0 @@
-commit.comment.template=${task.key}\: ${task.description}\n\nTask-Url\: ${task.url}
-eclipse.preferences.version=1

--- a/mylyn.context/org.eclipse.mylyn.cdt.tests/.settings/org.eclipse.mylyn.team.ui.prefs
+++ b/mylyn.context/org.eclipse.mylyn.cdt.tests/.settings/org.eclipse.mylyn.team.ui.prefs
@@ -1,2 +1,0 @@
-commit.comment.template=${task.key}\: ${task.description}\n\nTask-Url\: ${task.url}
-eclipse.preferences.version=1

--- a/mylyn.context/org.eclipse.mylyn.cdt.ui/.settings/org.eclipse.mylyn.team.ui.prefs
+++ b/mylyn.context/org.eclipse.mylyn.cdt.ui/.settings/org.eclipse.mylyn.team.ui.prefs
@@ -1,2 +1,0 @@
-commit.comment.template=${task.key}\: ${task.description}\n\nTask-Url\: ${task.url}
-eclipse.preferences.version=1

--- a/mylyn.context/org.eclipse.mylyn.context-feature/.settings/org.eclipse.mylyn.team.ui.prefs
+++ b/mylyn.context/org.eclipse.mylyn.context-feature/.settings/org.eclipse.mylyn.team.ui.prefs
@@ -1,2 +1,0 @@
-commit.comment.template=${task.key}\: ${task.description}\n\nTask-Url\: ${task.url}
-eclipse.preferences.version=1

--- a/mylyn.context/org.eclipse.mylyn.context.core/.settings/org.eclipse.mylyn.team.ui.prefs
+++ b/mylyn.context/org.eclipse.mylyn.context.core/.settings/org.eclipse.mylyn.team.ui.prefs
@@ -1,2 +1,0 @@
-commit.comment.template=${task.key}\: ${task.description}\n\nTask-Url\: ${task.url}
-eclipse.preferences.version=1

--- a/mylyn.context/org.eclipse.mylyn.context.sdk.java/.settings/org.eclipse.mylyn.team.ui.prefs
+++ b/mylyn.context/org.eclipse.mylyn.context.sdk.java/.settings/org.eclipse.mylyn.team.ui.prefs
@@ -1,2 +1,0 @@
-commit.comment.template=${task.key}\: ${task.description}\n\nTask-Url\: ${task.url}
-eclipse.preferences.version=1

--- a/mylyn.context/org.eclipse.mylyn.context.sdk.util/.settings/org.eclipse.mylyn.team.ui.prefs
+++ b/mylyn.context/org.eclipse.mylyn.context.sdk.util/.settings/org.eclipse.mylyn.team.ui.prefs
@@ -1,2 +1,0 @@
-commit.comment.template=${task.key}\: ${task.description}\n\nTask-Url\: ${task.url}
-eclipse.preferences.version=1

--- a/mylyn.context/org.eclipse.mylyn.context.tasks.tests/.settings/org.eclipse.mylyn.team.ui.prefs
+++ b/mylyn.context/org.eclipse.mylyn.context.tasks.tests/.settings/org.eclipse.mylyn.team.ui.prefs
@@ -1,2 +1,0 @@
-commit.comment.template=${task.key}\: ${task.description}\n\nTask-Url\: ${task.url}
-eclipse.preferences.version=1

--- a/mylyn.context/org.eclipse.mylyn.context.tasks.ui.tests/.settings/org.eclipse.mylyn.team.ui.prefs
+++ b/mylyn.context/org.eclipse.mylyn.context.tasks.ui.tests/.settings/org.eclipse.mylyn.team.ui.prefs
@@ -1,2 +1,0 @@
-commit.comment.template=${task.key}\: ${task.description}\n\nTask-Url\: ${task.url}
-eclipse.preferences.version=1

--- a/mylyn.context/org.eclipse.mylyn.context.tasks.ui/.settings/org.eclipse.mylyn.team.ui.prefs
+++ b/mylyn.context/org.eclipse.mylyn.context.tasks.ui/.settings/org.eclipse.mylyn.team.ui.prefs
@@ -1,2 +1,0 @@
-commit.comment.template=${task.key}\: ${task.description}\n\nTask-Url\: ${task.url}
-eclipse.preferences.version=1

--- a/mylyn.context/org.eclipse.mylyn.context.tests/.settings/org.eclipse.mylyn.team.ui.prefs
+++ b/mylyn.context/org.eclipse.mylyn.context.tests/.settings/org.eclipse.mylyn.team.ui.prefs
@@ -1,2 +1,0 @@
-commit.comment.template=${task.key}\: ${task.description}\n\nTask-Url\: ${task.url}
-eclipse.preferences.version=1

--- a/mylyn.context/org.eclipse.mylyn.context.ui/.settings/org.eclipse.mylyn.team.ui.prefs
+++ b/mylyn.context/org.eclipse.mylyn.context.ui/.settings/org.eclipse.mylyn.team.ui.prefs
@@ -1,2 +1,0 @@
-commit.comment.template=${task.key}\: ${task.description}\n\nTask-Url\: ${task.url}
-eclipse.preferences.version=1

--- a/mylyn.context/org.eclipse.mylyn.debug.tests/.settings/org.eclipse.mylyn.team.ui.prefs
+++ b/mylyn.context/org.eclipse.mylyn.debug.tests/.settings/org.eclipse.mylyn.team.ui.prefs
@@ -1,2 +1,0 @@
-commit.comment.template=${task.key}\: ${task.description}\n\nTask-Url\: ${task.url}
-eclipse.preferences.version=1

--- a/mylyn.context/org.eclipse.mylyn.debug.ui/.settings/org.eclipse.mylyn.team.ui.prefs
+++ b/mylyn.context/org.eclipse.mylyn.debug.ui/.settings/org.eclipse.mylyn.team.ui.prefs
@@ -1,2 +1,0 @@
-commit.comment.template=${task.key}\: ${task.description}\n\nTask-Url\: ${task.url}
-eclipse.preferences.version=1

--- a/mylyn.context/org.eclipse.mylyn.ide-feature/.settings/org.eclipse.mylyn.team.ui.prefs
+++ b/mylyn.context/org.eclipse.mylyn.ide-feature/.settings/org.eclipse.mylyn.team.ui.prefs
@@ -1,2 +1,0 @@
-commit.comment.template=${task.key}\: ${task.description}\n\nTask-Url\: ${task.url}
-eclipse.preferences.version=1

--- a/mylyn.context/org.eclipse.mylyn.ide.ant/.settings/org.eclipse.mylyn.team.ui.prefs
+++ b/mylyn.context/org.eclipse.mylyn.ide.ant/.settings/org.eclipse.mylyn.team.ui.prefs
@@ -1,2 +1,0 @@
-commit.comment.template=${task.key}\: ${task.description}\n\nTask-Url\: ${task.url}
-eclipse.preferences.version=1

--- a/mylyn.context/org.eclipse.mylyn.ide.tests/.settings/org.eclipse.mylyn.team.ui.prefs
+++ b/mylyn.context/org.eclipse.mylyn.ide.tests/.settings/org.eclipse.mylyn.team.ui.prefs
@@ -1,2 +1,0 @@
-commit.comment.template=${task.key}\: ${task.description}\n\nTask-Url\: ${task.url}
-eclipse.preferences.version=1

--- a/mylyn.context/org.eclipse.mylyn.ide.ui/.settings/org.eclipse.mylyn.team.ui.prefs
+++ b/mylyn.context/org.eclipse.mylyn.ide.ui/.settings/org.eclipse.mylyn.team.ui.prefs
@@ -1,2 +1,0 @@
-commit.comment.template=${task.key}\: ${task.description}\n\nTask-Url\: ${task.url}
-eclipse.preferences.version=1

--- a/mylyn.context/org.eclipse.mylyn.java-feature/.settings/org.eclipse.mylyn.team.ui.prefs
+++ b/mylyn.context/org.eclipse.mylyn.java-feature/.settings/org.eclipse.mylyn.team.ui.prefs
@@ -1,2 +1,0 @@
-commit.comment.template=${task.key}\: ${task.description}\n\nTask-Url\: ${task.url}
-eclipse.preferences.version=1

--- a/mylyn.context/org.eclipse.mylyn.java.tasks/.settings/org.eclipse.mylyn.team.ui.prefs
+++ b/mylyn.context/org.eclipse.mylyn.java.tasks/.settings/org.eclipse.mylyn.team.ui.prefs
@@ -1,2 +1,0 @@
-commit.comment.template=${task.key}\: ${task.description}\n\nTask-Url\: ${task.url}
-eclipse.preferences.version=1

--- a/mylyn.context/org.eclipse.mylyn.java.tests/.settings/org.eclipse.mylyn.team.ui.prefs
+++ b/mylyn.context/org.eclipse.mylyn.java.tests/.settings/org.eclipse.mylyn.team.ui.prefs
@@ -1,2 +1,0 @@
-commit.comment.template=${task.key}\: ${task.description}\n\nTask-Url\: ${task.url}
-eclipse.preferences.version=1

--- a/mylyn.context/org.eclipse.mylyn.java.ui/.settings/org.eclipse.mylyn.team.ui.prefs
+++ b/mylyn.context/org.eclipse.mylyn.java.ui/.settings/org.eclipse.mylyn.team.ui.prefs
@@ -1,2 +1,0 @@
-commit.comment.template=${task.key}\: ${task.description}\n\nTask-Url\: ${task.url}
-eclipse.preferences.version=1

--- a/mylyn.context/org.eclipse.mylyn.pde-feature/.settings/org.eclipse.mylyn.team.ui.prefs
+++ b/mylyn.context/org.eclipse.mylyn.pde-feature/.settings/org.eclipse.mylyn.team.ui.prefs
@@ -1,2 +1,0 @@
-commit.comment.template=${task.key}\: ${task.description}\n\nTask-Url\: ${task.url}
-eclipse.preferences.version=1

--- a/mylyn.context/org.eclipse.mylyn.pde.ui/.settings/org.eclipse.mylyn.team.ui.prefs
+++ b/mylyn.context/org.eclipse.mylyn.pde.ui/.settings/org.eclipse.mylyn.team.ui.prefs
@@ -1,2 +1,0 @@
-commit.comment.template=${task.key}\: ${task.description}\n\nTask-Url\: ${task.url}
-eclipse.preferences.version=1

--- a/mylyn.context/org.eclipse.mylyn.resources.tests/.settings/org.eclipse.mylyn.team.ui.prefs
+++ b/mylyn.context/org.eclipse.mylyn.resources.tests/.settings/org.eclipse.mylyn.team.ui.prefs
@@ -1,2 +1,0 @@
-commit.comment.template=${task.key}\: ${task.description}\n\nTask-Url\: ${task.url}
-eclipse.preferences.version=1

--- a/mylyn.context/org.eclipse.mylyn.resources.ui/.settings/org.eclipse.mylyn.team.ui.prefs
+++ b/mylyn.context/org.eclipse.mylyn.resources.ui/.settings/org.eclipse.mylyn.team.ui.prefs
@@ -1,2 +1,0 @@
-commit.comment.template=${task.key}\: ${task.description}\n\nTask-Url\: ${task.url}
-eclipse.preferences.version=1

--- a/mylyn.context/org.eclipse.mylyn.team-feature/.settings/org.eclipse.mylyn.team.ui.prefs
+++ b/mylyn.context/org.eclipse.mylyn.team-feature/.settings/org.eclipse.mylyn.team.ui.prefs
@@ -1,2 +1,0 @@
-commit.comment.template=${task.key}\: ${task.description}\n\nTask-Url\: ${task.url}
-eclipse.preferences.version=1

--- a/mylyn.context/org.eclipse.mylyn.team.tests/.settings/org.eclipse.mylyn.team.ui.prefs
+++ b/mylyn.context/org.eclipse.mylyn.team.tests/.settings/org.eclipse.mylyn.team.ui.prefs
@@ -1,2 +1,0 @@
-commit.comment.template=${task.key}\: ${task.description}\n\nTask-Url\: ${task.url}
-eclipse.preferences.version=1

--- a/mylyn.context/org.eclipse.mylyn.team.ui/.settings/org.eclipse.mylyn.team.ui.prefs
+++ b/mylyn.context/org.eclipse.mylyn.team.ui/.settings/org.eclipse.mylyn.team.ui.prefs
@@ -1,2 +1,0 @@
-commit.comment.template=${task.key}\: ${task.description}\n\nTask-Url\: ${task.url}
-eclipse.preferences.version=1

--- a/mylyn.egit/org.eclipse.mylyn.egit.feature/.settings/org.eclipse.mylyn.team.ui.prefs
+++ b/mylyn.egit/org.eclipse.mylyn.egit.feature/.settings/org.eclipse.mylyn.team.ui.prefs
@@ -1,3 +1,0 @@
-#Tue Jul 19 20:11:28 CEST 2011
-commit.comment.template=${task.description}\n\nBug\: ${task.key}
-eclipse.preferences.version=1

--- a/mylyn.egit/org.eclipse.mylyn.egit.ui.tests/.settings/org.eclipse.mylyn.team.ui.prefs
+++ b/mylyn.egit/org.eclipse.mylyn.egit.ui.tests/.settings/org.eclipse.mylyn.team.ui.prefs
@@ -1,3 +1,0 @@
-#Tue Jul 19 20:11:28 CEST 2011
-commit.comment.template=${task.description}\n\nBug\: ${task.key}
-eclipse.preferences.version=1

--- a/mylyn.egit/org.eclipse.mylyn.egit.ui/.settings/org.eclipse.mylyn.team.ui.prefs
+++ b/mylyn.egit/org.eclipse.mylyn.egit.ui/.settings/org.eclipse.mylyn.team.ui.prefs
@@ -1,3 +1,0 @@
-#Tue Jul 19 20:11:28 CEST 2011
-commit.comment.template=${task.description}\n\nBug\: ${task.key}
-eclipse.preferences.version=1

--- a/mylyn.github/org.eclipse.mylyn.github-feature/.settings/org.eclipse.mylyn.team.ui.prefs
+++ b/mylyn.github/org.eclipse.mylyn.github-feature/.settings/org.eclipse.mylyn.team.ui.prefs
@@ -1,3 +1,0 @@
-#Tue Jul 19 20:11:28 CEST 2011
-commit.comment.template=${task.description}\n\nBug\: ${task.key}
-eclipse.preferences.version=1

--- a/mylyn.github/org.eclipse.mylyn.github.core/.settings/org.eclipse.mylyn.team.ui.prefs
+++ b/mylyn.github/org.eclipse.mylyn.github.core/.settings/org.eclipse.mylyn.team.ui.prefs
@@ -1,3 +1,0 @@
-#Tue Jul 19 20:11:28 CEST 2011
-commit.comment.template=${task.description}\n\nBug\: ${task.key}
-eclipse.preferences.version=1

--- a/mylyn.github/org.eclipse.mylyn.github.doc/.settings/org.eclipse.mylyn.team.ui.prefs
+++ b/mylyn.github/org.eclipse.mylyn.github.doc/.settings/org.eclipse.mylyn.team.ui.prefs
@@ -1,3 +1,0 @@
-#Tue Jul 19 20:11:28 CEST 2011
-commit.comment.template=${task.description}\n\nBug\: ${task.key}
-eclipse.preferences.version=1

--- a/mylyn.github/org.eclipse.mylyn.github.tests/.settings/org.eclipse.mylyn.team.ui.prefs
+++ b/mylyn.github/org.eclipse.mylyn.github.tests/.settings/org.eclipse.mylyn.team.ui.prefs
@@ -1,3 +1,0 @@
-#Tue Jul 19 20:11:28 CEST 2011
-commit.comment.template=${task.description}\n\nBug\: ${task.key}
-eclipse.preferences.version=1

--- a/mylyn.github/org.eclipse.mylyn.github.ui/.settings/org.eclipse.mylyn.team.ui.prefs
+++ b/mylyn.github/org.eclipse.mylyn.github.ui/.settings/org.eclipse.mylyn.team.ui.prefs
@@ -1,3 +1,0 @@
-#Tue Jul 19 20:11:28 CEST 2011
-commit.comment.template=${task.description}\n\nBug\: ${task.key}
-eclipse.preferences.version=1

--- a/mylyn.reviews/org.eclipse.mylyn.gerrit.core.tests/.settings/org.eclipse.mylyn.team.ui.prefs
+++ b/mylyn.reviews/org.eclipse.mylyn.gerrit.core.tests/.settings/org.eclipse.mylyn.team.ui.prefs
@@ -1,2 +1,0 @@
-commit.comment.template=${task.key}\: ${task.description}\n\nTask-Url\: ${task.url}
-eclipse.preferences.version=1

--- a/mylyn.reviews/org.eclipse.mylyn.gerrit.core/.settings/org.eclipse.mylyn.team.ui.prefs
+++ b/mylyn.reviews/org.eclipse.mylyn.gerrit.core/.settings/org.eclipse.mylyn.team.ui.prefs
@@ -1,2 +1,0 @@
-commit.comment.template=${task.key}\: ${task.description}\n\nTask-Url\: ${task.url}
-eclipse.preferences.version=1

--- a/mylyn.reviews/org.eclipse.mylyn.gerrit.dashboard.core/.settings/org.eclipse.mylyn.team.ui.prefs
+++ b/mylyn.reviews/org.eclipse.mylyn.gerrit.dashboard.core/.settings/org.eclipse.mylyn.team.ui.prefs
@@ -1,2 +1,0 @@
-commit.comment.template=${task.key}\: ${task.description}\n\nTask-Url\: ${task.url}
-eclipse.preferences.version=1

--- a/mylyn.reviews/org.eclipse.mylyn.gerrit.dashboard.ui/.settings/org.eclipse.mylyn.team.ui.prefs
+++ b/mylyn.reviews/org.eclipse.mylyn.gerrit.dashboard.ui/.settings/org.eclipse.mylyn.team.ui.prefs
@@ -1,2 +1,0 @@
-commit.comment.template=${task.key}\: ${task.description}\n\nTask-Url\: ${task.url}
-eclipse.preferences.version=1

--- a/mylyn.reviews/org.eclipse.mylyn.gerrit.feature/.settings/org.eclipse.mylyn.team.ui.prefs
+++ b/mylyn.reviews/org.eclipse.mylyn.gerrit.feature/.settings/org.eclipse.mylyn.team.ui.prefs
@@ -1,2 +1,0 @@
-commit.comment.template=${task.key}\: ${task.description}\n\nTask-Url\: ${task.url}
-eclipse.preferences.version=1

--- a/mylyn.reviews/org.eclipse.mylyn.gerrit.releng/.settings/org.eclipse.mylyn.team.ui.prefs
+++ b/mylyn.reviews/org.eclipse.mylyn.gerrit.releng/.settings/org.eclipse.mylyn.team.ui.prefs
@@ -1,2 +1,0 @@
-commit.comment.template=${task.key}\: ${task.description}\n\nTask-Url\: ${task.url}
-eclipse.preferences.version=1

--- a/mylyn.reviews/org.eclipse.mylyn.gerrit.tests/.settings/org.eclipse.mylyn.team.ui.prefs
+++ b/mylyn.reviews/org.eclipse.mylyn.gerrit.tests/.settings/org.eclipse.mylyn.team.ui.prefs
@@ -1,2 +1,0 @@
-commit.comment.template=${task.key}\: ${task.description}\n\nTask-Url\: ${task.url}
-eclipse.preferences.version=1

--- a/mylyn.reviews/org.eclipse.mylyn.gerrit.ui.tests/.settings/org.eclipse.mylyn.team.ui.prefs
+++ b/mylyn.reviews/org.eclipse.mylyn.gerrit.ui.tests/.settings/org.eclipse.mylyn.team.ui.prefs
@@ -1,2 +1,0 @@
-commit.comment.template=${task.key}\: ${task.description}\n\nTask-Url\: ${task.url}
-eclipse.preferences.version=1

--- a/mylyn.reviews/org.eclipse.mylyn.gerrit.ui/.settings/org.eclipse.mylyn.team.ui.prefs
+++ b/mylyn.reviews/org.eclipse.mylyn.gerrit.ui/.settings/org.eclipse.mylyn.team.ui.prefs
@@ -1,2 +1,0 @@
-commit.comment.template=${task.key}\: ${task.description}\n\nTask-Url\: ${task.url}
-eclipse.preferences.version=1

--- a/mylyn.reviews/org.eclipse.mylyn.reviews.core.tests/.settings/org.eclipse.mylyn.team.ui.prefs
+++ b/mylyn.reviews/org.eclipse.mylyn.reviews.core.tests/.settings/org.eclipse.mylyn.team.ui.prefs
@@ -1,2 +1,0 @@
-commit.comment.template=${task.key}\: ${task.description}\n\nTask-Url\: ${task.url}
-eclipse.preferences.version=1

--- a/mylyn.reviews/org.eclipse.mylyn.reviews.core/.settings/org.eclipse.mylyn.team.ui.prefs
+++ b/mylyn.reviews/org.eclipse.mylyn.reviews.core/.settings/org.eclipse.mylyn.team.ui.prefs
@@ -1,2 +1,0 @@
-commit.comment.template=${task.key}\: ${task.description}\n\nTask-Url\: ${task.url}
-eclipse.preferences.version=1

--- a/mylyn.reviews/org.eclipse.mylyn.reviews.edit/.settings/org.eclipse.mylyn.team.ui.prefs
+++ b/mylyn.reviews/org.eclipse.mylyn.reviews.edit/.settings/org.eclipse.mylyn.team.ui.prefs
@@ -1,2 +1,0 @@
-commit.comment.template=${task.key}\: ${task.description}\n\nTask-Url\: ${task.url}
-eclipse.preferences.version=1

--- a/mylyn.reviews/org.eclipse.mylyn.reviews.feature/.settings/org.eclipse.mylyn.team.ui.prefs
+++ b/mylyn.reviews/org.eclipse.mylyn.reviews.feature/.settings/org.eclipse.mylyn.team.ui.prefs
@@ -1,2 +1,0 @@
-commit.comment.template=${task.key}\: ${task.description}\n\nTask-Url\: ${task.url}
-eclipse.preferences.version=1

--- a/mylyn.reviews/org.eclipse.mylyn.reviews.tests/.settings/org.eclipse.mylyn.team.ui.prefs
+++ b/mylyn.reviews/org.eclipse.mylyn.reviews.tests/.settings/org.eclipse.mylyn.team.ui.prefs
@@ -1,2 +1,0 @@
-commit.comment.template=${task.key}\: ${task.description}\n\nTask-Url\: ${task.url}
-eclipse.preferences.version=1

--- a/mylyn.reviews/org.eclipse.mylyn.reviews.ui.tests/.settings/org.eclipse.mylyn.team.ui.prefs
+++ b/mylyn.reviews/org.eclipse.mylyn.reviews.ui.tests/.settings/org.eclipse.mylyn.team.ui.prefs
@@ -1,2 +1,0 @@
-commit.comment.template=${task.key}\: ${task.description}\n\nTask-Url\: ${task.url}
-eclipse.preferences.version=1

--- a/mylyn.reviews/org.eclipse.mylyn.reviews.ui/.settings/org.eclipse.mylyn.team.ui.prefs
+++ b/mylyn.reviews/org.eclipse.mylyn.reviews.ui/.settings/org.eclipse.mylyn.team.ui.prefs
@@ -1,2 +1,0 @@
-commit.comment.template=${task.key}\: ${task.description}\n\nTask-Url\: ${task.url}
-eclipse.preferences.version=1

--- a/mylyn.reviews/tbr/org.eclipse.mylyn.reviews.tasks.core/.settings/org.eclipse.mylyn.team.ui.prefs
+++ b/mylyn.reviews/tbr/org.eclipse.mylyn.reviews.tasks.core/.settings/org.eclipse.mylyn.team.ui.prefs
@@ -1,2 +1,0 @@
-commit.comment.template=${task.key}\: ${task.description}\n\nTask-Url\: ${task.url}
-eclipse.preferences.version=1

--- a/mylyn.reviews/tbr/org.eclipse.mylyn.reviews.tasks.dsl/.settings/org.eclipse.mylyn.team.ui.prefs
+++ b/mylyn.reviews/tbr/org.eclipse.mylyn.reviews.tasks.dsl/.settings/org.eclipse.mylyn.team.ui.prefs
@@ -1,2 +1,0 @@
-commit.comment.template=${task.key}\: ${task.description}\n\nTask-Url\: ${task.url}
-eclipse.preferences.version=1

--- a/mylyn.reviews/tbr/org.eclipse.mylyn.reviews.tasks.ui/.settings/org.eclipse.mylyn.team.ui.prefs
+++ b/mylyn.reviews/tbr/org.eclipse.mylyn.reviews.tasks.ui/.settings/org.eclipse.mylyn.team.ui.prefs
@@ -1,2 +1,0 @@
-commit.comment.template=${task.key}\: ${task.description}\n\nTask-Url\: ${task.url}
-eclipse.preferences.version=1

--- a/mylyn.reviews/tbr/org.eclipse.mylyn.reviews.tasks/.settings/org.eclipse.mylyn.team.ui.prefs
+++ b/mylyn.reviews/tbr/org.eclipse.mylyn.reviews.tasks/.settings/org.eclipse.mylyn.team.ui.prefs
@@ -1,2 +1,0 @@
-commit.comment.template=${task.key}\: ${task.description}\n\nTask-Url\: ${task.url}
-eclipse.preferences.version=1

--- a/mylyn.reviews/tbr/org.eclipse.mylyn.versions.tasks.core/.settings/org.eclipse.mylyn.team.ui.prefs
+++ b/mylyn.reviews/tbr/org.eclipse.mylyn.versions.tasks.core/.settings/org.eclipse.mylyn.team.ui.prefs
@@ -1,2 +1,0 @@
-commit.comment.template=${task.key}\: ${task.description}\n\nTask-Url\: ${task.url}
-eclipse.preferences.version=1

--- a/mylyn.reviews/tbr/org.eclipse.mylyn.versions.tasks.mapper.generic.tests/.settings/org.eclipse.mylyn.team.ui.prefs
+++ b/mylyn.reviews/tbr/org.eclipse.mylyn.versions.tasks.mapper.generic.tests/.settings/org.eclipse.mylyn.team.ui.prefs
@@ -1,2 +1,0 @@
-commit.comment.template=${task.key}\: ${task.description}\n\nTask-Url\: ${task.url}
-eclipse.preferences.version=1

--- a/mylyn.reviews/tbr/org.eclipse.mylyn.versions.tasks.mapper.generic/.settings/org.eclipse.mylyn.team.ui.prefs
+++ b/mylyn.reviews/tbr/org.eclipse.mylyn.versions.tasks.mapper.generic/.settings/org.eclipse.mylyn.team.ui.prefs
@@ -1,2 +1,0 @@
-commit.comment.template=${task.key}\: ${task.description}\n\nTask-Url\: ${task.url}
-eclipse.preferences.version=1

--- a/mylyn.reviews/tbr/org.eclipse.mylyn.versions.tasks.ui/.settings/org.eclipse.mylyn.team.ui.prefs
+++ b/mylyn.reviews/tbr/org.eclipse.mylyn.versions.tasks.ui/.settings/org.eclipse.mylyn.team.ui.prefs
@@ -1,2 +1,0 @@
-commit.comment.template=${task.key}\: ${task.description}\n\nTask-Url\: ${task.url}
-eclipse.preferences.version=1

--- a/mylyn.tasks/connectors/bugzilla-rest/org.eclipse.mylyn.bugzilla.rest.core.tests/.settings/org.eclipse.mylyn.team.ui.prefs
+++ b/mylyn.tasks/connectors/bugzilla-rest/org.eclipse.mylyn.bugzilla.rest.core.tests/.settings/org.eclipse.mylyn.team.ui.prefs
@@ -1,2 +1,0 @@
-commit.comment.template=${task.key}\: ${task.description}\n\nTask-Url\: ${task.url}
-eclipse.preferences.version=1

--- a/mylyn.tasks/connectors/bugzilla-rest/org.eclipse.mylyn.bugzilla.rest.feature/.settings/org.eclipse.mylyn.team.ui.prefs
+++ b/mylyn.tasks/connectors/bugzilla-rest/org.eclipse.mylyn.bugzilla.rest.feature/.settings/org.eclipse.mylyn.team.ui.prefs
@@ -1,2 +1,0 @@
-commit.comment.template=${task.key}\: ${task.description}\n\nTask-Url\: ${task.url}
-eclipse.preferences.version=1

--- a/mylyn.tasks/connectors/bugzilla-rest/org.eclipse.mylyn.bugzilla.rest.tests/.settings/org.eclipse.mylyn.team.ui.prefs
+++ b/mylyn.tasks/connectors/bugzilla-rest/org.eclipse.mylyn.bugzilla.rest.tests/.settings/org.eclipse.mylyn.team.ui.prefs
@@ -1,2 +1,0 @@
-commit.comment.template=${task.key}\: ${task.description}\n\nTask-Url\: ${task.url}
-eclipse.preferences.version=1

--- a/mylyn.tasks/connectors/bugzilla-rest/org.eclipse.mylyn.bugzilla.rest.ui.tests/.settings/org.eclipse.mylyn.team.ui.prefs
+++ b/mylyn.tasks/connectors/bugzilla-rest/org.eclipse.mylyn.bugzilla.rest.ui.tests/.settings/org.eclipse.mylyn.team.ui.prefs
@@ -1,2 +1,0 @@
-commit.comment.template=${task.key}\: ${task.description}\n\nTask-Url\: ${task.url}
-eclipse.preferences.version=1

--- a/mylyn.tasks/connectors/bugzilla/org.eclipse.mylyn.bugzilla-feature/.settings/org.eclipse.mylyn.team.ui.prefs
+++ b/mylyn.tasks/connectors/bugzilla/org.eclipse.mylyn.bugzilla-feature/.settings/org.eclipse.mylyn.team.ui.prefs
@@ -1,2 +1,0 @@
-commit.comment.template=${task.key}\: ${task.description}\n\nTask-Url\: ${task.url}
-eclipse.preferences.version=1

--- a/mylyn.tasks/connectors/bugzilla/org.eclipse.mylyn.bugzilla.core/.settings/org.eclipse.mylyn.team.ui.prefs
+++ b/mylyn.tasks/connectors/bugzilla/org.eclipse.mylyn.bugzilla.core/.settings/org.eclipse.mylyn.team.ui.prefs
@@ -1,2 +1,0 @@
-commit.comment.template=${task.key}\: ${task.description}\n\nTask-Url\: ${task.url}
-eclipse.preferences.version=1

--- a/mylyn.tasks/connectors/bugzilla/org.eclipse.mylyn.bugzilla.releng/.settings/org.eclipse.mylyn.team.ui.prefs
+++ b/mylyn.tasks/connectors/bugzilla/org.eclipse.mylyn.bugzilla.releng/.settings/org.eclipse.mylyn.team.ui.prefs
@@ -1,2 +1,0 @@
-commit.comment.template=${task.key}\: ${task.description}\n\nTask-Url\: ${task.url}
-eclipse.preferences.version=1

--- a/mylyn.tasks/connectors/bugzilla/org.eclipse.mylyn.bugzilla.tests/.settings/org.eclipse.mylyn.team.ui.prefs
+++ b/mylyn.tasks/connectors/bugzilla/org.eclipse.mylyn.bugzilla.tests/.settings/org.eclipse.mylyn.team.ui.prefs
@@ -1,2 +1,0 @@
-commit.comment.template=${task.key}\: ${task.description}\n\nTask-Url\: ${task.url}
-eclipse.preferences.version=1

--- a/mylyn.tasks/connectors/bugzilla/org.eclipse.mylyn.bugzilla.ui/.settings/org.eclipse.mylyn.team.ui.prefs
+++ b/mylyn.tasks/connectors/bugzilla/org.eclipse.mylyn.bugzilla.ui/.settings/org.eclipse.mylyn.team.ui.prefs
@@ -1,2 +1,0 @@
-commit.comment.template=${task.key}\: ${task.description}\n\nTask-Url\: ${task.url}
-eclipse.preferences.version=1

--- a/mylyn.tasks/connectors/trac/org.eclipse.mylyn.trac-feature/.settings/org.eclipse.mylyn.team.ui.prefs
+++ b/mylyn.tasks/connectors/trac/org.eclipse.mylyn.trac-feature/.settings/org.eclipse.mylyn.team.ui.prefs
@@ -1,2 +1,0 @@
-commit.comment.template=${task.key}\: ${task.description}\n\nTask-Url\: ${task.url}
-eclipse.preferences.version=1

--- a/mylyn.tasks/connectors/trac/org.eclipse.mylyn.trac.core.tests/.settings/org.eclipse.mylyn.team.ui.prefs
+++ b/mylyn.tasks/connectors/trac/org.eclipse.mylyn.trac.core.tests/.settings/org.eclipse.mylyn.team.ui.prefs
@@ -1,2 +1,0 @@
-commit.comment.template=${task.key}\: ${task.description}\n\nTask-Url\: ${task.url}
-eclipse.preferences.version=1

--- a/mylyn.tasks/connectors/trac/org.eclipse.mylyn.trac.core/.settings/org.eclipse.mylyn.team.ui.prefs
+++ b/mylyn.tasks/connectors/trac/org.eclipse.mylyn.trac.core/.settings/org.eclipse.mylyn.team.ui.prefs
@@ -1,2 +1,0 @@
-commit.comment.template=${task.key}\: ${task.description}\n\nTask-Url\: ${task.url}
-eclipse.preferences.version=1

--- a/mylyn.tasks/connectors/trac/org.eclipse.mylyn.trac.releng/.settings/org.eclipse.mylyn.team.ui.prefs
+++ b/mylyn.tasks/connectors/trac/org.eclipse.mylyn.trac.releng/.settings/org.eclipse.mylyn.team.ui.prefs
@@ -1,2 +1,0 @@
-commit.comment.template=${task.key}\: ${task.description}\n\nTask-Url\: ${task.url}
-eclipse.preferences.version=1

--- a/mylyn.tasks/connectors/trac/org.eclipse.mylyn.trac.tests/.settings/org.eclipse.mylyn.team.ui.prefs
+++ b/mylyn.tasks/connectors/trac/org.eclipse.mylyn.trac.tests/.settings/org.eclipse.mylyn.team.ui.prefs
@@ -1,2 +1,0 @@
-commit.comment.template=${task.key}\: ${task.description}\n\nTask-Url\: ${task.url}
-eclipse.preferences.version=1

--- a/mylyn.tasks/connectors/trac/org.eclipse.mylyn.trac.ui.tests/.settings/org.eclipse.mylyn.team.ui.prefs
+++ b/mylyn.tasks/connectors/trac/org.eclipse.mylyn.trac.ui.tests/.settings/org.eclipse.mylyn.team.ui.prefs
@@ -1,2 +1,0 @@
-commit.comment.template=${task.key}\: ${task.description}\n\nTask-Url\: ${task.url}
-eclipse.preferences.version=1

--- a/mylyn.tasks/connectors/trac/org.eclipse.mylyn.trac.ui/.settings/org.eclipse.mylyn.team.ui.prefs
+++ b/mylyn.tasks/connectors/trac/org.eclipse.mylyn.trac.ui/.settings/org.eclipse.mylyn.team.ui.prefs
@@ -1,2 +1,0 @@
-commit.comment.template=${task.key}\: ${task.description}\n\nTask-Url\: ${task.url}
-eclipse.preferences.version=1

--- a/mylyn.tasks/org.eclipse.mylyn-feature/.settings/org.eclipse.mylyn.team.ui.prefs
+++ b/mylyn.tasks/org.eclipse.mylyn-feature/.settings/org.eclipse.mylyn.team.ui.prefs
@@ -1,2 +1,0 @@
-commit.comment.template=${task.key}\: ${task.description}\n\nTask-Url\: ${task.url}
-eclipse.preferences.version=1

--- a/mylyn.tasks/org.eclipse.mylyn.help.sdk/.settings/org.eclipse.mylyn.team.ui.prefs
+++ b/mylyn.tasks/org.eclipse.mylyn.help.sdk/.settings/org.eclipse.mylyn.team.ui.prefs
@@ -1,2 +1,0 @@
-commit.comment.template=${task.key}\: ${task.description}\n\nTask-Url\: ${task.url}
-eclipse.preferences.version=1

--- a/mylyn.tasks/org.eclipse.mylyn.help.ui/.settings/org.eclipse.mylyn.team.ui.prefs
+++ b/mylyn.tasks/org.eclipse.mylyn.help.ui/.settings/org.eclipse.mylyn.team.ui.prefs
@@ -1,2 +1,0 @@
-commit.comment.template=${task.key}\: ${task.description}\n\nTask-Url\: ${task.url}
-eclipse.preferences.version=1

--- a/mylyn.tasks/org.eclipse.mylyn.tasks.activity.core/.settings/org.eclipse.mylyn.team.ui.prefs
+++ b/mylyn.tasks/org.eclipse.mylyn.tasks.activity.core/.settings/org.eclipse.mylyn.team.ui.prefs
@@ -1,2 +1,0 @@
-commit.comment.template=${task.key}\: ${task.description}\n\nTask-Url\: ${task.url}
-eclipse.preferences.version=1

--- a/mylyn.tasks/org.eclipse.mylyn.tasks.activity.tests/.settings/org.eclipse.mylyn.team.ui.prefs
+++ b/mylyn.tasks/org.eclipse.mylyn.tasks.activity.tests/.settings/org.eclipse.mylyn.team.ui.prefs
@@ -1,2 +1,0 @@
-commit.comment.template=${task.key}\: ${task.description}\n\nTask-Url\: ${task.url}
-eclipse.preferences.version=1

--- a/mylyn.tasks/org.eclipse.mylyn.tasks.activity.ui/.settings/org.eclipse.mylyn.team.ui.prefs
+++ b/mylyn.tasks/org.eclipse.mylyn.tasks.activity.ui/.settings/org.eclipse.mylyn.team.ui.prefs
@@ -1,2 +1,0 @@
-commit.comment.template=${task.key}\: ${task.description}\n\nTask-Url\: ${task.url}
-eclipse.preferences.version=1

--- a/mylyn.tasks/org.eclipse.mylyn.tasks.bugs/.settings/org.eclipse.mylyn.team.ui.prefs
+++ b/mylyn.tasks/org.eclipse.mylyn.tasks.bugs/.settings/org.eclipse.mylyn.team.ui.prefs
@@ -1,2 +1,0 @@
-commit.comment.template=${task.key}\: ${task.description}\n\nTask-Url\: ${task.url}
-eclipse.preferences.version=1

--- a/mylyn.tasks/org.eclipse.mylyn.tasks.core.tests/.settings/org.eclipse.mylyn.team.ui.prefs
+++ b/mylyn.tasks/org.eclipse.mylyn.tasks.core.tests/.settings/org.eclipse.mylyn.team.ui.prefs
@@ -1,2 +1,0 @@
-commit.comment.template=${task.key}\: ${task.description}\n\nTask-Url\: ${task.url}
-eclipse.preferences.version=1

--- a/mylyn.tasks/org.eclipse.mylyn.tasks.core/.settings/org.eclipse.mylyn.team.ui.prefs
+++ b/mylyn.tasks/org.eclipse.mylyn.tasks.core/.settings/org.eclipse.mylyn.team.ui.prefs
@@ -1,2 +1,0 @@
-commit.comment.template=${task.key}\: ${task.description}\n\nTask-Url\: ${task.url}
-eclipse.preferences.version=1

--- a/mylyn.tasks/org.eclipse.mylyn.tasks.index.core/.settings/org.eclipse.mylyn.team.ui.prefs
+++ b/mylyn.tasks/org.eclipse.mylyn.tasks.index.core/.settings/org.eclipse.mylyn.team.ui.prefs
@@ -1,2 +1,0 @@
-commit.comment.template=${task.key}\: ${task.description}\n\nTask-Url\: ${task.url}
-eclipse.preferences.version=1

--- a/mylyn.tasks/org.eclipse.mylyn.tasks.index.tests/.settings/org.eclipse.mylyn.team.ui.prefs
+++ b/mylyn.tasks/org.eclipse.mylyn.tasks.index.tests/.settings/org.eclipse.mylyn.team.ui.prefs
@@ -1,2 +1,0 @@
-commit.comment.template=${task.key}\: ${task.description}\n\nTask-Url\: ${task.url}
-eclipse.preferences.version=1

--- a/mylyn.tasks/org.eclipse.mylyn.tasks.index.ui/.settings/org.eclipse.mylyn.team.ui.prefs
+++ b/mylyn.tasks/org.eclipse.mylyn.tasks.index.ui/.settings/org.eclipse.mylyn.team.ui.prefs
@@ -1,2 +1,0 @@
-commit.comment.template=${task.key}\: ${task.description}\n\nTask-Url\: ${task.url}
-eclipse.preferences.version=1

--- a/mylyn.tasks/org.eclipse.mylyn.tasks.search/.settings/org.eclipse.mylyn.team.ui.prefs
+++ b/mylyn.tasks/org.eclipse.mylyn.tasks.search/.settings/org.eclipse.mylyn.team.ui.prefs
@@ -1,2 +1,0 @@
-commit.comment.template=${task.key}\: ${task.description}\n\nTask-Url\: ${task.url}
-eclipse.preferences.version=1

--- a/mylyn.tasks/org.eclipse.mylyn.tasks.tests/.settings/org.eclipse.mylyn.team.ui.prefs
+++ b/mylyn.tasks/org.eclipse.mylyn.tasks.tests/.settings/org.eclipse.mylyn.team.ui.prefs
@@ -1,2 +1,0 @@
-commit.comment.template=${task.key}\: ${task.description}\n\nTask-Url\: ${task.url}
-eclipse.preferences.version=1

--- a/mylyn.tasks/org.eclipse.mylyn.tasks.ui.tests/.settings/org.eclipse.mylyn.team.ui.prefs
+++ b/mylyn.tasks/org.eclipse.mylyn.tasks.ui.tests/.settings/org.eclipse.mylyn.team.ui.prefs
@@ -1,2 +1,0 @@
-commit.comment.template=${task.key}\: ${task.description}\n\nTask-Url\: ${task.url}
-eclipse.preferences.version=1

--- a/mylyn.tasks/org.eclipse.mylyn.tasks.ui/.settings/org.eclipse.mylyn.team.ui.prefs
+++ b/mylyn.tasks/org.eclipse.mylyn.tasks.ui/.settings/org.eclipse.mylyn.team.ui.prefs
@@ -1,2 +1,0 @@
-commit.comment.template=${task.key}\: ${task.description}\n\nTask-Url\: ${task.url}
-eclipse.preferences.version=1

--- a/mylyn.tasks/org.eclipse.mylyn.tests.util/.settings/org.eclipse.mylyn.team.ui.prefs
+++ b/mylyn.tasks/org.eclipse.mylyn.tests.util/.settings/org.eclipse.mylyn.team.ui.prefs
@@ -1,2 +1,0 @@
-commit.comment.template=${task.key}\: ${task.description}\n\nTask-Url\: ${task.url}
-eclipse.preferences.version=1

--- a/mylyn.versions/org.eclipse.mylyn.cvs-feature/.settings/org.eclipse.mylyn.team.ui.prefs
+++ b/mylyn.versions/org.eclipse.mylyn.cvs-feature/.settings/org.eclipse.mylyn.team.ui.prefs
@@ -1,2 +1,0 @@
-commit.comment.template=${task.key}\: ${task.description}\n\nTask-Url\: ${task.url}
-eclipse.preferences.version=1

--- a/mylyn.versions/org.eclipse.mylyn.git-feature/.settings/org.eclipse.mylyn.team.ui.prefs
+++ b/mylyn.versions/org.eclipse.mylyn.git-feature/.settings/org.eclipse.mylyn.team.ui.prefs
@@ -1,2 +1,0 @@
-commit.comment.template=${task.key}\: ${task.description}\n\nTask-Url\: ${task.url}
-eclipse.preferences.version=1

--- a/mylyn.versions/org.eclipse.mylyn.git.core/.settings/org.eclipse.mylyn.team.ui.prefs
+++ b/mylyn.versions/org.eclipse.mylyn.git.core/.settings/org.eclipse.mylyn.team.ui.prefs
@@ -1,2 +1,0 @@
-commit.comment.template=${task.key}\: ${task.description}\n\nTask-Url\: ${task.url}
-eclipse.preferences.version=1

--- a/mylyn.versions/org.eclipse.mylyn.git.ui/.settings/org.eclipse.mylyn.team.ui.prefs
+++ b/mylyn.versions/org.eclipse.mylyn.git.ui/.settings/org.eclipse.mylyn.team.ui.prefs
@@ -1,2 +1,0 @@
-commit.comment.template=${task.key}\: ${task.description}\n\nTask-Url\: ${task.url}
-eclipse.preferences.version=1

--- a/mylyn.versions/org.eclipse.mylyn.subclipse-feature/.settings/org.eclipse.mylyn.team.ui.prefs
+++ b/mylyn.versions/org.eclipse.mylyn.subclipse-feature/.settings/org.eclipse.mylyn.team.ui.prefs
@@ -1,2 +1,0 @@
-commit.comment.template=${task.key}\: ${task.description}\n\nTask-Url\: ${task.url}
-eclipse.preferences.version=1

--- a/mylyn.versions/org.eclipse.mylyn.subclipse.core/.settings/org.eclipse.mylyn.team.ui.prefs
+++ b/mylyn.versions/org.eclipse.mylyn.subclipse.core/.settings/org.eclipse.mylyn.team.ui.prefs
@@ -1,2 +1,0 @@
-commit.comment.template=${task.key}\: ${task.description}\n\nTask-Url\: ${task.url}
-eclipse.preferences.version=1

--- a/mylyn.versions/org.eclipse.mylyn.subclipse.ui/.settings/org.eclipse.mylyn.team.ui.prefs
+++ b/mylyn.versions/org.eclipse.mylyn.subclipse.ui/.settings/org.eclipse.mylyn.team.ui.prefs
@@ -1,2 +1,0 @@
-commit.comment.template=${task.key}\: ${task.description}\n\nTask-Url\: ${task.url}
-eclipse.preferences.version=1

--- a/mylyn.versions/org.eclipse.mylyn.versions-feature/.settings/org.eclipse.mylyn.team.ui.prefs
+++ b/mylyn.versions/org.eclipse.mylyn.versions-feature/.settings/org.eclipse.mylyn.team.ui.prefs
@@ -1,2 +1,0 @@
-commit.comment.template=${task.key}\: ${task.description}\n\nTask-Url\: ${task.url}
-eclipse.preferences.version=1

--- a/mylyn.versions/org.eclipse.mylyn.versions.core/.settings/org.eclipse.mylyn.team.ui.prefs
+++ b/mylyn.versions/org.eclipse.mylyn.versions.core/.settings/org.eclipse.mylyn.team.ui.prefs
@@ -1,2 +1,0 @@
-commit.comment.template=${task.key}\: ${task.description}\n\nTask-Url\: ${task.url}
-eclipse.preferences.version=1

--- a/mylyn.versions/org.eclipse.mylyn.versions.tests/.settings/org.eclipse.mylyn.team.ui.prefs
+++ b/mylyn.versions/org.eclipse.mylyn.versions.tests/.settings/org.eclipse.mylyn.team.ui.prefs
@@ -1,2 +1,0 @@
-commit.comment.template=${task.key}\: ${task.description}\n\nTask-Url\: ${task.url}
-eclipse.preferences.version=1

--- a/mylyn.versions/org.eclipse.mylyn.versions.ui/.settings/org.eclipse.mylyn.team.ui.prefs
+++ b/mylyn.versions/org.eclipse.mylyn.versions.ui/.settings/org.eclipse.mylyn.team.ui.prefs
@@ -1,2 +1,0 @@
-commit.comment.template=${task.key}\: ${task.description}\n\nTask-Url\: ${task.url}
-eclipse.preferences.version=1

--- a/org.eclipse.mylyn-site/.settings/org.eclipse.mylyn.team.ui.prefs
+++ b/org.eclipse.mylyn-site/.settings/org.eclipse.mylyn.team.ui.prefs
@@ -1,2 +1,0 @@
-commit.comment.template=${task.key}\: ${task.description}\n\nTask-Url\: ${task.url}
-eclipse.preferences.version=1

--- a/org.eclipse.mylyn-target/.settings/org.eclipse.mylyn.team.ui.prefs
+++ b/org.eclipse.mylyn-target/.settings/org.eclipse.mylyn.team.ui.prefs
@@ -1,2 +1,0 @@
-commit.comment.template=${task.key}\: ${task.description}\n\nTask-Url\: ${task.url}
-eclipse.preferences.version=1

--- a/org.eclipse.mylyn.discovery-directory/.settings/org.eclipse.mylyn.team.ui.prefs
+++ b/org.eclipse.mylyn.discovery-directory/.settings/org.eclipse.mylyn.team.ui.prefs
@@ -1,2 +1,0 @@
-commit.comment.template=${task.key}\: ${task.description}\n\nTask-Url\: ${task.url}
-eclipse.preferences.version=1

--- a/org.eclipse.mylyn.releng/.settings/org.eclipse.mylyn.team.ui.prefs
+++ b/org.eclipse.mylyn.releng/.settings/org.eclipse.mylyn.team.ui.prefs
@@ -1,2 +1,0 @@
-commit.comment.template=${task.key}\: ${task.description}\n\nTask-Url\: ${task.url}
-eclipse.preferences.version=1

--- a/org.eclipse.mylyn.releng/oomph/Mylyn.setup
+++ b/org.eclipse.mylyn.releng/oomph/Mylyn.setup
@@ -31,6 +31,40 @@
   </annotation>
   <setupTask
       xsi:type="setup:CompoundTask"
+      name="User Preferences">
+    <annotation
+        source="http://www.eclipse.org/oomph/setup/UserPreferences"/>
+    <setupTask
+        xsi:type="setup:CompoundTask"
+        name="org.eclipse.mylyn.team.ui">
+      <setupTask
+          xsi:type="setup:PreferenceTask"
+          key="/instance/org.eclipse.mylyn.team.ui/org.eclipse.mylyn.team.commit.template"
+          value="$${task.description} #$${task.key}&#xA;&#xA;Task-Url: $${task.url}"/>
+    </setupTask>
+    <setupTask
+        xsi:type="setup:CompoundTask"
+        name="org.eclipse.pde.api.tools">
+      <setupTask
+          xsi:type="setup:PreferenceTask"
+          key="/instance/org.eclipse.pde.api.tools/missing_default_api_profile"
+          value="Error"/>
+      <setupTask
+          xsi:type="setup:PreferenceTask"
+          key="/instance/org.eclipse.pde.api.tools/MISSING_EE_DESCRIPTIONS"
+          value="Warning"/>
+    </setupTask>
+    <setupTask
+        xsi:type="setup:CompoundTask"
+        name="org.eclipse.ui.ide">
+      <setupTask
+          xsi:type="setup:PreferenceTask"
+          key="/instance/org.eclipse.ui.ide/WORKSPACE_NAME"
+          value="Mylyn"/>
+    </setupTask>
+  </setupTask>
+  <setupTask
+      xsi:type="setup:CompoundTask"
       name="Global Variables">
     <setupTask
         xsi:type="setup:VariableTask"
@@ -51,30 +85,6 @@
         defaultValue="eclipse-mylyn"
         label="GitHub Orga for Repositories">
       <description>Enter the Github Orga for the Repositories</description>
-    </setupTask>
-  </setupTask>
-  <setupTask
-      xsi:type="setup:CompoundTask"
-      name="Preferences">
-    <setupTask
-        xsi:type="setup:CompoundTask"
-        name="org.eclipse.ui.ide">
-      <setupTask
-          xsi:type="setup:PreferenceTask"
-          key="/instance/org.eclipse.ui.ide/WORKSPACE_NAME"
-          value="Mylyn"/>
-    </setupTask>
-    <setupTask
-        xsi:type="setup:CompoundTask"
-        name="org.eclipse.pde.api.tools">
-      <setupTask
-          xsi:type="setup:PreferenceTask"
-          key="/instance/org.eclipse.pde.api.tools/missing_default_api_profile"
-          value="Error"/>
-      <setupTask
-          xsi:type="setup:PreferenceTask"
-          key="/instance/org.eclipse.pde.api.tools/MISSING_EE_DESCRIPTIONS"
-          value="Warning"/>
     </setupTask>
   </setupTask>
   <setupTask

--- a/org.eclipse.mylyn.tests/.settings/org.eclipse.mylyn.team.ui.prefs
+++ b/org.eclipse.mylyn.tests/.settings/org.eclipse.mylyn.team.ui.prefs
@@ -1,2 +1,0 @@
-commit.comment.template=${task.key}\: ${task.description}\n\nTask-Url\: ${task.url}
-eclipse.preferences.version=1


### PR DESCRIPTION
Here the version with the global setting (coming from mylyn.setup) and the4 deleted local settings.

@merks: Is it correct that we we use a User Preferences without an Annotation that the user can only temporary change the Preference and the next start we again set it to the value stored in the mylyn.setup