### PR TITLE
[#287] Remove guava

### DIFF
--- a/mylyn.commons/org.eclipse.mylyn.commons.core/META-INF/MANIFEST.MF
+++ b/mylyn.commons/org.eclipse.mylyn.commons.core/META-INF/MANIFEST.MF
@@ -6,6 +6,7 @@ Bundle-Version: 4.1.0.qualifier
 Bundle-Vendor: %Bundle-Vendor
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Export-Package: org.eclipse.mylyn.commons.core,
+ org.eclipse.mylyn.commons.core.collections;x-friends:="org.eclipse.mylyn.reviews.core,org.eclipse.mylyn.tasks.ui",
  org.eclipse.mylyn.commons.core.io,
  org.eclipse.mylyn.commons.core.net,
  org.eclipse.mylyn.commons.core.operations,

--- a/mylyn.commons/org.eclipse.mylyn.commons.core/src/org/eclipse/mylyn/commons/core/collections/LinkedHashMappArrayListValuedHashMap.java
+++ b/mylyn.commons/org.eclipse.mylyn.commons.core/src/org/eclipse/mylyn/commons/core/collections/LinkedHashMappArrayListValuedHashMap.java
@@ -1,15 +1,17 @@
 /*******************************************************************************
- * Copyright (c) 2023 Tasktop Technologies and others.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v2.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * Copyright (c) 2023 George Lindholm and others.
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0
+ * 
+ * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
- *     Tasktop Technologies - initial API and implementation
+ *   See git history
  *******************************************************************************/
 
-package org.eclipse.mylyn.commons.core;
+package org.eclipse.mylyn.commons.core.collections;
 
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
@@ -25,7 +27,8 @@ import org.apache.commons.collections4.multimap.AbstractListValuedMap;
  * @author George Lindholm
  * @since 4.1
  */
-public class LinkedHashMappArrayListValuedHashMap<K, V> extends AbstractListValuedMap<K, V> {
+public final class LinkedHashMappArrayListValuedHashMap<K, V> extends AbstractListValuedMap<K, V> {
+
 	public LinkedHashMappArrayListValuedHashMap() {
 		super(new LinkedHashMap<>());
 	}

--- a/mylyn.reviews/org.eclipse.mylyn.reviews.core/src/org/eclipse/mylyn/reviews/internal/core/TaskBuildStatusMapper.java
+++ b/mylyn.reviews/org.eclipse.mylyn.reviews.core/src/org/eclipse/mylyn/reviews/internal/core/TaskBuildStatusMapper.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2016 Vaughan Hilts and others.
+ * Copyright (c) 2015, 2023 Vaughan Hilts and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -7,8 +7,8 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  *
- *     Vaughan Hilts - 	   Initial implementation
- *     Kyle Ross 	 - 	   Initial implementation
+ * Contributors:
+ *   See git history
  *******************************************************************************/
 
 package org.eclipse.mylyn.reviews.internal.core;
@@ -22,7 +22,7 @@ import java.util.function.Function;
 
 import org.apache.commons.collections4.MultiValuedMap;
 import org.eclipse.core.runtime.Assert;
-import org.eclipse.mylyn.commons.core.LinkedHashMappArrayListValuedHashMap;
+import org.eclipse.mylyn.commons.core.collections.LinkedHashMappArrayListValuedHashMap;
 import org.eclipse.mylyn.tasks.core.data.TaskAttribute;
 import org.eclipse.mylyn.tasks.core.data.TaskAttributeMapper;
 import org.eclipse.mylyn.tasks.core.data.TaskData;

--- a/mylyn.tasks/org.eclipse.mylyn.tasks.ui/src/org/eclipse/mylyn/internal/tasks/ui/SynchronizeRelevantTasksJob.java
+++ b/mylyn.tasks/org.eclipse.mylyn.tasks.ui/src/org/eclipse/mylyn/internal/tasks/ui/SynchronizeRelevantTasksJob.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016 Tasktop Technologies and others.
+ * Copyright (c) 2016, 2023 Tasktop Technologies and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -8,7 +8,7 @@
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
- *     Tasktop Technologies - initial API and implementation
+ *   See git history
  *******************************************************************************/
 
 package org.eclipse.mylyn.internal.tasks.ui;
@@ -25,7 +25,7 @@ import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.jobs.Job;
-import org.eclipse.mylyn.commons.core.LinkedHashMappArrayListValuedHashMap;
+import org.eclipse.mylyn.commons.core.collections.LinkedHashMappArrayListValuedHashMap;
 import org.eclipse.mylyn.internal.tasks.core.ITaskJobFactory;
 import org.eclipse.mylyn.internal.tasks.core.LocalTask;
 import org.eclipse.mylyn.internal.tasks.core.TaskActivityManager;


### PR DESCRIPTION
Move newly introduced `LinkedHashMappArrayListValuedHashMap` to a provisional API package.