### PR TITLE
[#315] Deploy Docs Snapshot was not executed and prepare separate Branch for mylyn.setup tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -70,7 +70,7 @@ pipeline {
 		}
 		stage('Deploy Docs Snapshot') {
 			when {
-				branch 'master'
+				branch 'main'
 			}
 			steps {
 				sshagent ( ['projects-storage.eclipse.org-bot-ssh']) {

--- a/org.eclipse.mylyn.releng/oomph/Mylyn.setup
+++ b/org.eclipse.mylyn.releng/oomph/Mylyn.setup
@@ -335,6 +335,9 @@
     <stream
         name="main"
         label="main"/>
+    <stream
+        name="315-setup-test"
+        label="MylynDocs-Setup-Test"/>
     <description>The new Setup for Mylyn hosted on GitHub</description>
   </project>
   <project name="github.admin"


### PR DESCRIPTION
I will use the Branch 315-setup-test to test tat a new Eclipse Installation with Eclipse-Installer has no problems.
When finish, I will remove the branch from mylyn.setup so that we have only the main stream.