### PR TITLE
Fix build

### DIFF
--- a/mylyn.context/org.eclipse.mylyn.pde.ui/META-INF/MANIFEST.MF
+++ b/mylyn.context/org.eclipse.mylyn.pde.ui/META-INF/MANIFEST.MF
@@ -31,7 +31,8 @@ Require-Bundle: org.eclipse.core.resources;bundle-version="0.0.0",
  org.eclipse.ui.editors;bundle-version="0.0.0",
  org.eclipse.ui.forms;bundle-version="0.0.0",
  org.eclipse.ui.ide;bundle-version="0.0.0",
- org.eclipse.ui.workbench.texteditor;bundle-version="0.0.0"
+ org.eclipse.ui.workbench.texteditor;bundle-version="0.0.0",
+ org.eclipse.ui.genericeditor;bundle-version="0.0.0"
 Bundle-Activator: org.eclipse.mylyn.internal.pde.ui.PdeUiBridgePlugin
 Bundle-ActivationPolicy: lazy
 Bundle-ClassPath: .


### PR DESCRIPTION
PDE ui now transitively requires genericeditor as visible by failure in another PR
https://ci.eclipse.org/mylyn/job/GitHub-mylyn-Orga/job/org.eclipse.mylyn/view/change-requests/job/PR-319/2/console