### PR TITLE
Reduce ancient Orbit dependencies usage

### DIFF
--- a/mylyn.reviews/org.eclipse.mylyn.gerrit.ui.tests/META-INF/MANIFEST.MF
+++ b/mylyn.reviews/org.eclipse.mylyn.gerrit.ui.tests/META-INF/MANIFEST.MF
@@ -6,7 +6,7 @@ Bundle-Version: 4.1.0.qualifier
 Bundle-Vendor: Eclipse Mylyn
 Fragment-Host: org.eclipse.mylyn.gerrit.ui
 Bundle-RequiredExecutionEnvironment: JavaSE-17
-Require-Bundle: org.hamcrest.library;bundle-version="1.3.0",
+Require-Bundle: org.hamcrest;bundle-version="2.0.0",
  org.junit;bundle-version="4.5.0",
  org.mockito.mockito-core;bundle-version="4.8.1"
 Export-Package: org.eclipse.mylyn.internal.gerrit.ui;x-internal:=true,

--- a/mylyn.reviews/org.eclipse.mylyn.reviews.core.tests/META-INF/MANIFEST.MF
+++ b/mylyn.reviews/org.eclipse.mylyn.reviews.core.tests/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-SymbolicName: org.eclipse.mylyn.reviews.core.tests;singleton:=true
 Bundle-Version: 4.1.0.qualifier
 Bundle-Vendor: Eclipse Mylyn
 Fragment-Host: org.eclipse.mylyn.reviews.core
-Require-Bundle: org.hamcrest.library;bundle-version="1.3.0",
+Require-Bundle: org.hamcrest;bundle-version="1.3.0",
  org.junit;bundle-version="4.13.2",
  org.mockito.mockito-core;bundle-version="4.8.1"
 Bundle-RequiredExecutionEnvironment: JavaSE-17

--- a/mylyn.reviews/org.eclipse.mylyn.reviews.tests/META-INF/MANIFEST.MF
+++ b/mylyn.reviews/org.eclipse.mylyn.reviews.tests/META-INF/MANIFEST.MF
@@ -23,6 +23,6 @@ Require-Bundle: org.eclipse.compare;bundle-version="0.0.0",
  org.eclipse.mylyn.reviews.ui;bundle-version="4.1.0",
  org.eclipse.mylyn.tasks.core;bundle-version="4.1.0",
  org.eclipse.team.core;bundle-version="0.0.0",
- org.hamcrest.library;bundle-version="1.3.0",
+ org.hamcrest;bundle-version="2.2.0",
  org.junit;bundle-version="4.13.2",
  org.mockito.mockito-core;bundle-version="4.8.1"

--- a/mylyn.tasks/connectors/bugzilla-rest/org.eclipse.mylyn.bugzilla.rest.core.tests/META-INF/MANIFEST.MF
+++ b/mylyn.tasks/connectors/bugzilla-rest/org.eclipse.mylyn.bugzilla.rest.core.tests/META-INF/MANIFEST.MF
@@ -6,7 +6,7 @@ Bundle-Version: 4.1.0.qualifier
 Bundle-Vendor: Eclipse Mylyn
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Bundle: org.hamcrest;bundle-version="0.0.0",
- org.hamcrest.library;bundle-version="0.0.0",
+ org.hamcrest;bundle-version="0.0.0",
  org.eclipse.core.runtime;bundle-version="0.0.0",
  org.eclipse.jdt.annotation;bundle-version="[2.0.0,3.0.0)";resolution:=optional,
  org.eclipse.mylyn.bugzilla.rest.core;bundle-version="4.1.0",

--- a/org.eclipse.mylyn-site/category.xml
+++ b/org.eclipse.mylyn-site/category.xml
@@ -171,7 +171,6 @@
    <bundle id="jakarta.xml.bind"/>
    <bundle id="javax.activation" version="1.2.2.v20221203-1659"/>
    <bundle id="javax.activation" version="2.0.0.v20221203-1659"/>
-   <bundle id="javax.xml.stream"/>
    <bundle id="org.apache.ant"/>
    <bundle id="org.apache.commons.codec"/>
    <bundle id="org.apache.commons.httpclient"/>
@@ -179,7 +178,7 @@
    <bundle id="org.apache.commons.collections4"/>
    <bundle id="org.apache.commons.lang"/>
    <bundle id="org.apache.commons.lang3"/>
-   <bundle id="org.apache.commons.logging" version="1.1.1.v201101211721"/>
+   <bundle id="org.apache.commons.logging"/>
    <bundle id="org.apache.httpcomponents.httpclient"/>
    <bundle id="org.apache.httpcomponents.httpcore"/>
    <bundle id="org.apache.lucene.analysis-common"/>

--- a/org.eclipse.mylyn-target/org.eclipse.mylyn.target.target
+++ b/org.eclipse.mylyn-target/org.eclipse.mylyn.target.target
@@ -41,14 +41,6 @@
 			<unit id="com.google.gerrit.prettify" version="0.0.0"/>
 			<unit id="com.google.gerrit.reviewdb" version="0.0.0"/>
 			<unit id="com.thoughtworks.qdox" version="0.0.0"/>
-			<unit id="javax.xml.stream" version="0.0.0"/>
-			<unit id="org.hamcrest" version="0.0.0"/>
-			<unit id="org.hamcrest.core" version="0.0.0"/>
-			<unit id="org.hamcrest.generator" version="0.0.0"/>
-			<unit id="org.hamcrest.integration" version="0.0.0"/>
-			<unit id="org.hamcrest.library" version="0.0.0"/>
-			<unit id="org.hamcrest.text" version="0.0.0"/>
-			<unit id="org.apache.commons.logging" version="1.1.1.v201101211721"/>&gt;
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
 			<repository location="https://download.eclipse.org/tools/orbit/downloads/drops/R20221123021534/repository/"/>
@@ -85,6 +77,8 @@
 			<unit id="com.google.gson" version="0.0.0"/>
 			<unit id="org.jsoup" version="0.0.0"/>
 			<unit id="org.mockito.mockito-core" version="0.0.0"/>
+			<unit id="org.hamcrest" version="0.0.0"/>
+			<unit id="org.apache.commons.logging" version="0.0.0"/>
 		</location>
 	</locations>
 </target>


### PR DESCRIPTION
* Hamcrest 2.x is in latest platform/orbit
* javax.xml.stream is part of jvm so no need for it
* commons-logging is in latest orbit