### PR TITLE
[#339] Replace dependency to org.eclipse.osgi.services

### DIFF
--- a/mylyn.builds/org.eclipse.mylyn.builds.ui/META-INF/MANIFEST.MF
+++ b/mylyn.builds/org.eclipse.mylyn.builds.ui/META-INF/MANIFEST.MF
@@ -38,7 +38,6 @@ Require-Bundle: org.eclipse.compare;bundle-version="0.0.0",
  org.eclipse.ui.console;bundle-version="0.0.0";resolution:=optional,
  org.eclipse.ui.forms;bundle-version="0.0.0",
  org.eclipse.ui.navigator;bundle-version="0.0.0",
- org.eclipse.osgi.services;bundle-version="[3.11.100,4.0.0)",
  org.eclipse.e4.core.contexts;bundle-version="[1.12.0,2.0.0)",
  org.eclipse.e4.ui.workbench;bundle-version="[1.15.0,2.0.0)"
 Bundle-ActivationPolicy: lazy
@@ -57,4 +56,5 @@ Export-Package: org.eclipse.mylyn.builds.ui;x-internal:=true,
  org.eclipse.mylyn.internal.builds.ui.notifications;x-internal:=true,
  org.eclipse.mylyn.internal.builds.ui.util;x-internal:=true,
  org.eclipse.mylyn.internal.builds.ui.view;x-internal:=true
+Import-Package: org.osgi.service.event;version="[1.4.0,2.0.0)"
 Service-Component: OSGI-INF/org.eclipse.mylyn.internal.builds.ui.BuildsStartup.xml

--- a/mylyn.context/org.eclipse.mylyn.team.ui/META-INF/MANIFEST.MF
+++ b/mylyn.context/org.eclipse.mylyn.team.ui/META-INF/MANIFEST.MF
@@ -23,7 +23,6 @@ Require-Bundle: org.eclipse.compare;bundle-version="0.0.0",
  org.eclipse.ui.forms;bundle-version="0.0.0",
  org.eclipse.ui.navigator;bundle-version="0.0.0",
  org.eclipse.ui.navigator.resources;bundle-version="0.0.0",
- org.eclipse.osgi.services;bundle-version="[3.11.100,4.0.0)",
  org.eclipse.e4.core.contexts;bundle-version="[1.12.0,2.0.0)",
  org.eclipse.e4.ui.workbench;bundle-version="[1.15.0,2.0.0)"
 Bundle-ActivationPolicy: lazy
@@ -34,6 +33,7 @@ Export-Package: org.eclipse.mylyn.internal.team.ui;x-internal:=true,
  org.eclipse.mylyn.internal.team.ui.properties;x-internal:=true,
  org.eclipse.mylyn.internal.team.ui.templates;x-internal:=true,
  org.eclipse.mylyn.team.ui
+Import-Package: org.osgi.service.event;version="[1.4.0,2.0.0)"
 Bundle-ClassPath: .
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-Localization: plugin

--- a/mylyn.tasks/org.eclipse.mylyn.tasks.ui/META-INF/MANIFEST.MF
+++ b/mylyn.tasks/org.eclipse.mylyn.tasks.ui/META-INF/MANIFEST.MF
@@ -37,7 +37,6 @@ Require-Bundle: org.eclipse.compare;bundle-version="0.0.0",
  org.eclipse.ui.navigator;bundle-version="0.0.0";resolution:=optional,
  org.eclipse.ui.views;bundle-version="0.0.0",
  org.eclipse.ui.workbench.texteditor;bundle-version="0.0.0",
- org.eclipse.osgi.services;bundle-version="[3.11.100,4.0.0)",
  org.eclipse.e4.core.contexts;bundle-version="[1.12.0,2.0.0)",
  org.eclipse.e4.ui.workbench;bundle-version="[1.15.0,2.0.0)"
 Bundle-ActivationPolicy: lazy
@@ -73,7 +72,8 @@ Import-Package: com.google.common.base;version="31.1.0",
  org.apache.commons.collections4.bidimap;version="4.4.0",
  org.apache.commons.collections4.multimap;version="4.4.0",
  org.apache.commons.httpclient;version="3.1.0",
- org.apache.commons.lang3.reflect;version="3.13.0",
  org.apache.commons.lang3;version="3.13.0",
- org.apache.commons.logging;version="[1.0.4,2.0.0)"
+ org.apache.commons.lang3.reflect;version="3.13.0",
+ org.apache.commons.logging;version="[1.0.4,2.0.0)",
+ org.osgi.service.event;version="[1.4.0,2.0.0)"
 Service-Component: OSGI-INF/org.eclipse.mylyn.internal.tasks.ui.TaskUiStartup.xml


### PR DESCRIPTION
Move to
```
Import-Package: org.osgi.service.event;version="1.4.1"
```

Fixed #339 