### PR TITLE
Explicit lucene version #389

### DIFF
--- a/mylyn.tasks/org.eclipse.mylyn.tasks.index.core/META-INF/MANIFEST.MF
+++ b/mylyn.tasks/org.eclipse.mylyn.tasks.index.core/META-INF/MANIFEST.MF
@@ -10,14 +10,14 @@ Require-Bundle: org.eclipse.core.runtime;bundle-version="0.0.0",
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-ActivationPolicy: lazy
 Export-Package: org.eclipse.mylyn.internal.tasks.index.core;x-internal:=true
-Import-Package: org.apache.lucene.analysis;version="9.5.0",
- org.apache.lucene.analysis.core;version="9.5.0",
- org.apache.lucene.analysis.miscellaneous;version="9.5.0",
- org.apache.lucene.analysis.standard;version="9.5.0",
- org.apache.lucene.document;version="9.5.0",
- org.apache.lucene.index;version="9.5.0",
- org.apache.lucene.queryparser.classic;version="9.5.0",
- org.apache.lucene.search;version="9.5.0",
- org.apache.lucene.store;version="9.5.0",
- org.apache.lucene.util;version="9.5.0"
+Import-Package: org.apache.lucene.analysis;version="0.0.0",
+ org.apache.lucene.analysis.core;version="0.0.0",
+ org.apache.lucene.analysis.miscellaneous;version="0.0.0",
+ org.apache.lucene.analysis.standard;version="0.0.0",
+ org.apache.lucene.document;version="0.0.0",
+ org.apache.lucene.index;version="0.0.0",
+ org.apache.lucene.queryparser.classic;version="0.0.0",
+ org.apache.lucene.search;version="0.0.0",
+ org.apache.lucene.store;version="0.0.0",
+ org.apache.lucene.util;version="0.0.0"
 


### PR DESCRIPTION
Strange missing class error after doing a Clean Up of Tasks

Tasks is using an explicit reference to 9.5.0, p2 -> 9.5.1.
Changing the version to 0.0 .0 clears the error

Task-Url: https://github.com/eclipse-mylyn/org.eclipse.mylyn/issues/389