### PR TITLE
[#423] Resolve "light" warnings for Mylyn Docs

### DIFF
--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.ant.tests/META-INF/MANIFEST.MF
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.ant.tests/META-INF/MANIFEST.MF
@@ -1,4 +1,5 @@
 Manifest-Version: 1.0
+Automatic-Module-Name: org.eclipse.mylyn.wikitext.ant.tests
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.eclipse.mylyn.wikitext.ant.tests
 Bundle-Version: 4.2.0.qualifier

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.ant.tests/src/test/java/org/eclipse/mylyn/wikitext/ant/internal/tests/AbstractTestAntTask.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.ant.tests/src/test/java/org/eclipse/mylyn/wikitext/ant/internal/tests/AbstractTestAntTask.java
@@ -28,6 +28,7 @@ import org.eclipse.mylyn.wikitext.textile.TextileLanguage;
 import org.junit.After;
 import org.junit.Before;
 
+@SuppressWarnings("nls")
 public abstract class AbstractTestAntTask {
 
 	protected File tempFolder;

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.ant.tests/src/test/java/org/eclipse/mylyn/wikitext/ant/internal/tests/HtmlToMarkupTaskTest.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.ant.tests/src/test/java/org/eclipse/mylyn/wikitext/ant/internal/tests/HtmlToMarkupTaskTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2024 Tasktop Technologies.
+ * Copyright (c) 2011, 2024 Tasktop Technologies and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -29,6 +29,7 @@ import org.junit.Test;
 /**
  * @author David Green
  */
+@SuppressWarnings("nls")
 public class HtmlToMarkupTaskTest extends AbstractTestAntTask {
 
 	private HtmlToMarkupTask task;
@@ -63,8 +64,7 @@ public class HtmlToMarkupTaskTest extends AbstractTestAntTask {
 
 	private File createSimpleHtmlMarkup() throws IOException {
 		File htmlFile = new File(tempFolder, "markup.html");
-		PrintWriter writer = new PrintWriter(new FileWriter(htmlFile));
-		try (writer) {
+		try (PrintWriter writer = new PrintWriter(new FileWriter(htmlFile))) {
 			writer.println(
 					"<html><body>\n<h1>First Heading</h1>\n\n<p>some content</p>\n<h1>Second Heading</h1>\n<p>some more content</p></body></html>");
 		}

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.ant.tests/src/test/java/org/eclipse/mylyn/wikitext/ant/internal/tests/MarkupToDitaTaskTest.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.ant.tests/src/test/java/org/eclipse/mylyn/wikitext/ant/internal/tests/MarkupToDitaTaskTest.java
@@ -27,6 +27,7 @@ import org.eclipse.mylyn.wikitext.ant.internal.MarkupToDitaTask;
 import org.junit.Before;
 import org.junit.Test;
 
+@SuppressWarnings("nls")
 public class MarkupToDitaTaskTest extends AbstractTestAntTask {
 
 	private MarkupToDitaTask ditaTask;
@@ -47,8 +48,7 @@ public class MarkupToDitaTaskTest extends AbstractTestAntTask {
 
 	private File createSimpleTextileMarkup() throws IOException {
 		File markupFile = new File(tempFolder, "markup.textile");
-		PrintWriter writer = new PrintWriter(new FileWriter(markupFile));
-		try (writer) {
+		try (PrintWriter writer = new PrintWriter(new FileWriter(markupFile))) {
 			writer.println("h1. First Heading");
 			writer.println();
 			writer.println("some content");
@@ -66,8 +66,7 @@ public class MarkupToDitaTaskTest extends AbstractTestAntTask {
 
 	private File createTextileMarkupWithXref(int headingLevel) throws IOException {
 		File markupFile = new File(tempFolder, "markup.textile");
-		PrintWriter writer = new PrintWriter(new FileWriter(markupFile));
-		try (writer) {
+		try (PrintWriter writer = new PrintWriter(new FileWriter(markupFile))) {
 			writer.println("h" + headingLevel + "(#Id1). First Heading");
 			writer.println();
 			writer.println("some content with a \"ref to 2\":#Id2");
@@ -81,8 +80,7 @@ public class MarkupToDitaTaskTest extends AbstractTestAntTask {
 
 	private File createSimpleTextileMarkupWithFQNHeadings() throws IOException {
 		File markupFile = new File(tempFolder, "markup.textile");
-		PrintWriter writer = new PrintWriter(new FileWriter(markupFile));
-		try (writer) {
+		try (PrintWriter writer = new PrintWriter(new FileWriter(markupFile))) {
 			writer.println("h1. " + MarkupToDitaTaskTest.class.getName());
 			writer.println();
 			writer.println("some content");

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.ant.tests/src/test/java/org/eclipse/mylyn/wikitext/ant/internal/tests/MarkupToDocbookTaskTest.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.ant.tests/src/test/java/org/eclipse/mylyn/wikitext/ant/internal/tests/MarkupToDocbookTaskTest.java
@@ -27,6 +27,7 @@ import org.eclipse.mylyn.wikitext.ant.internal.MarkupToDocbookTask;
 import org.junit.Before;
 import org.junit.Test;
 
+@SuppressWarnings("nls")
 public class MarkupToDocbookTaskTest extends AbstractTestAntTask {
 
 	private MarkupToDocbookTask task;
@@ -94,8 +95,7 @@ public class MarkupToDocbookTaskTest extends AbstractTestAntTask {
 
 	protected File createSimpleTextileMarkup() throws IOException {
 		File markupFile = new File(tempFolder, "markup.textile");
-		PrintWriter writer = new PrintWriter(new FileWriter(markupFile));
-		try (writer) {
+		try (PrintWriter writer = new PrintWriter(new FileWriter(markupFile))) {
 			writer.println("h1. First Heading");
 			writer.println();
 			writer.println("some content");

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.ant.tests/src/test/java/org/eclipse/mylyn/wikitext/ant/internal/tests/MarkupToEclipseHelpTaskTest.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.ant.tests/src/test/java/org/eclipse/mylyn/wikitext/ant/internal/tests/MarkupToEclipseHelpTaskTest.java
@@ -26,6 +26,7 @@ import org.eclipse.mylyn.wikitext.ant.internal.MarkupToEclipseHelpTask;
 import org.eclipse.mylyn.wikitext.ant.internal.MarkupToHtmlTask;
 import org.junit.Test;
 
+@SuppressWarnings("nls")
 public class MarkupToEclipseHelpTaskTest extends MarkupToHtmlTaskTest {
 
 	@Override
@@ -101,8 +102,7 @@ public class MarkupToEclipseHelpTaskTest extends MarkupToHtmlTaskTest {
 
 	protected File createSimpleTextileMarkupWithMultiLevelHeadings() throws IOException {
 		File markupFile = new File(tempFolder, "markup.textile");
-		PrintWriter writer = new PrintWriter(new FileWriter(markupFile));
-		try (writer) {
+		try (PrintWriter writer = new PrintWriter(new FileWriter(markupFile))) {
 			writer.println("h1. First Heading");
 			writer.println();
 			writer.println("some content");

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.ant.tests/src/test/java/org/eclipse/mylyn/wikitext/ant/internal/tests/MarkupToHtmlTaskTest.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.ant.tests/src/test/java/org/eclipse/mylyn/wikitext/ant/internal/tests/MarkupToHtmlTaskTest.java
@@ -34,6 +34,7 @@ import org.junit.Test;
  * @author David Green
  * @author Torkild U. Resheim
  */
+@SuppressWarnings("nls")
 public class MarkupToHtmlTaskTest extends AbstractTestAntTask {
 
 	protected MarkupToHtmlTask task;
@@ -268,8 +269,7 @@ public class MarkupToHtmlTaskTest extends AbstractTestAntTask {
 
 	protected File createSimpleTextileMarkupWithImage() throws IOException {
 		File markupFile = new File(tempFolder, "markup.textile");
-		PrintWriter writer = new PrintWriter(new FileWriter(markupFile));
-		try (writer) {
+		try (PrintWriter writer = new PrintWriter(new FileWriter(markupFile))) {
 			writer.println("some content with !image.png! an image");
 		}
 		return markupFile;

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.ant.tests/src/test/java/org/eclipse/mylyn/wikitext/ant/internal/tests/MarkupToXslfoTaskTest.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.ant.tests/src/test/java/org/eclipse/mylyn/wikitext/ant/internal/tests/MarkupToXslfoTaskTest.java
@@ -26,6 +26,7 @@ import org.eclipse.mylyn.wikitext.ant.internal.MarkupToXslfoTask;
 import org.junit.Before;
 import org.junit.Test;
 
+@SuppressWarnings("nls")
 public class MarkupToXslfoTaskTest extends AbstractTestAntTask {
 
 	private MarkupToXslfoTask task;
@@ -61,8 +62,7 @@ public class MarkupToXslfoTaskTest extends AbstractTestAntTask {
 
 	protected File createSimpleTextileMarkup() throws IOException {
 		File markupFile = new File(tempFolder, "markup.textile");
-		PrintWriter writer = new PrintWriter(new FileWriter(markupFile));
-		try (writer) {
+		try (PrintWriter writer = new PrintWriter(new FileWriter(markupFile))) {
 			writer.println("h1. First Heading");
 			writer.println();
 			writer.println("some content");

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.ant/META-INF/MANIFEST.MF
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.ant/META-INF/MANIFEST.MF
@@ -1,4 +1,5 @@
 Manifest-Version: 1.0
+Automatic-Module-Name: org.eclipse.mylyn.wikitext.ant
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.eclipse.mylyn.wikitext.ant
 Bundle-Version: 4.2.0.qualifier

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.ant/src/main/java/org/eclipse/mylyn/wikitext/ant/MarkupTask.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.ant/src/main/java/org/eclipse/mylyn/wikitext/ant/MarkupTask.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2007, 2013 David Green and others.
+ * Copyright (c) 2007, 2024 David Green and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -9,6 +9,7 @@
  *
  * Contributors:
  *     David Green - initial API and implementation
+ *     Alexander Fedorov (ArSysOp) - ongoing support
  *******************************************************************************/
 package org.eclipse.mylyn.wikitext.ant;
 
@@ -250,20 +251,13 @@ public abstract class MarkupTask extends Task {
 	 */
 	protected String readFully(File inputFile) {
 		StringBuilder w = new StringBuilder((int) inputFile.length());
-		try {
-			InputStream input = new BufferedInputStream(new FileInputStream(inputFile));
-			try (input) {
+		try (InputStream input = new BufferedInputStream(new FileInputStream(inputFile));
 				Reader r = sourceEncoding == null
 						? new InputStreamReader(input)
-						: new InputStreamReader(input, sourceEncoding);
-				try {
-					int i;
-					while ((i = r.read()) != -1) {
-						w.append((char) i);
-					}
-				} finally {
-					r.close();
-				}
+								: new InputStreamReader(input, sourceEncoding)) {
+			int i;
+			while ((i = r.read()) != -1) {
+				w.append((char) i);
 			}
 		} catch (IOException e) {
 			throw new BuildException(

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.ant/src/main/java/org/eclipse/mylyn/wikitext/ant/internal/HtmlToMarkupTask.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.ant/src/main/java/org/eclipse/mylyn/wikitext/ant/internal/HtmlToMarkupTask.java
@@ -128,17 +128,10 @@ public class HtmlToMarkupTask extends MarkupTask {
 			try (Writer writer = new OutputStreamWriter(new BufferedOutputStream(new FileOutputStream(outputFile)),
 					StandardCharsets.UTF_8)) {
 				DocumentBuilder builder = markupLanguage.createDocumentBuilder(writer);
-
-				Reader input;
-				try (InputStream in = new BufferedInputStream(new FileInputStream(source))) {
-					input = getSourceEncoding() == null
-							? new InputStreamReader(in)
-									: new InputStreamReader(in, getSourceEncoding());
-				} catch (Exception e) {
-					throw new BuildException(MessageFormat.format(Messages.getString("MarkupTask.cannotReadSource"), //$NON-NLS-1$
-							source, e.getMessage()), e);
-				}
-				try {
+				try (InputStream in = new BufferedInputStream(new FileInputStream(source));
+						Reader input = getSourceEncoding() == null
+								? new InputStreamReader(in)
+								: new InputStreamReader(in, getSourceEncoding())) {
 					new HtmlParser().parse(new InputSource(input), builder);
 				} catch (Exception e) {
 					throw new BuildException(MessageFormat.format(

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.ant/src/main/java/org/eclipse/mylyn/wikitext/ant/internal/MarkupToDitaTask.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.ant/src/main/java/org/eclipse/mylyn/wikitext/ant/internal/MarkupToDitaTask.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2007, 2013 David Green and others.
+ * Copyright (c) 2007, 2024 David Green and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -9,6 +9,7 @@
  *
  * Contributors:
  *     David Green - initial API and implementation
+ *     Alexander Fedorov (ArSysOp) - ongoing support
  *******************************************************************************/
 package org.eclipse.mylyn.wikitext.ant.internal;
 
@@ -169,15 +170,8 @@ public class MarkupToDitaTask extends MarkupTask {
 
 			OutlineItem outline = new OutlineParser(markupLanguage).parse(markupContent);
 
-			Writer writer;
-			try {
-				writer = new OutputStreamWriter(new BufferedOutputStream(new FileOutputStream(outputFile)),
-						StandardCharsets.UTF_8);
-			} catch (Exception e) {
-				throw new BuildException(MessageFormat.format(Messages.getString("MarkupToDitaTask.11"), outputFile, //$NON-NLS-1$
-						e.getMessage()), e);
-			}
-			try {
+			try (Writer writer = new OutputStreamWriter(new BufferedOutputStream(new FileOutputStream(outputFile)),
+					StandardCharsets.UTF_8)) {
 				if (topicStrategy == BreakStrategy.NONE) {
 					DitaTopicDocumentBuilder builder = new DitaTopicDocumentBuilder(new DefaultXmlStreamWriter(writer),
 							formatting);
@@ -194,10 +188,10 @@ public class MarkupToDitaTask extends MarkupTask {
 
 					parser.parse(markupContent);
 				} else {
-					DitaBookMapDocumentBuilder builder = new DitaBookMapDocumentBuilder(formatting
+
+					try (DitaBookMapDocumentBuilder builder = new DitaBookMapDocumentBuilder(formatting
 							? new FormattingXMLStreamWriter(new DefaultXmlStreamWriter(writer))
-							: new DefaultXmlStreamWriter(writer));
-					try {
+									: new DefaultXmlStreamWriter(writer))) {
 						builder.setFormattingDependencies(formatting);
 
 						MarkupParser parser = new MarkupParser();
@@ -229,24 +223,14 @@ public class MarkupToDitaTask extends MarkupTask {
 						}
 
 						parser.parse(markupContent);
-					} finally {
-						try {
-							builder.close();
-						} catch (IOException e) {
-							throw new BuildException(
-									MessageFormat.format(Messages.getString("MarkupToDitaTask.12"), outputFile, //$NON-NLS-1$
-											e.getMessage()),
-									e);
-						}
+					} catch (IOException e) {
+						throw new BuildException(MessageFormat.format(Messages.getString("MarkupToDitaTask.12"), outputFile, //$NON-NLS-1$
+								e.getMessage()), e);
 					}
 				}
-			} finally {
-				try {
-					writer.close();
-				} catch (Exception e) {
-					throw new BuildException(MessageFormat.format(Messages.getString("MarkupToDitaTask.12"), outputFile, //$NON-NLS-1$
-							e.getMessage()), e);
-				}
+			} catch (Exception e) {
+				throw new BuildException(MessageFormat.format(Messages.getString("MarkupToDitaTask.11"), outputFile, //$NON-NLS-1$
+						e.getMessage()), e);
 			}
 		}
 	}

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.ant/src/main/java/org/eclipse/mylyn/wikitext/ant/internal/MarkupToDocbookTask.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.ant/src/main/java/org/eclipse/mylyn/wikitext/ant/internal/MarkupToDocbookTask.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2007, 2013 David Green and others.
+ * Copyright (c) 2007, 2024 David Green and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -9,12 +9,14 @@
  *
  * Contributors:
  *     David Green - initial API and implementation
+ *     Alexander Fedorov (ArSysOp) - ongoing support
  *******************************************************************************/
 package org.eclipse.mylyn.wikitext.ant.internal;
 
 import java.io.BufferedOutputStream;
 import java.io.File;
 import java.io.FileOutputStream;
+import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
 import java.nio.charset.StandardCharsets;
@@ -134,17 +136,8 @@ public class MarkupToDocbookTask extends MarkupTask {
 			}
 			performValidation(source, markupContent);
 
-			Writer writer;
-			try {
-				writer = new OutputStreamWriter(new BufferedOutputStream(new FileOutputStream(docbookOutputFile)),
-						StandardCharsets.UTF_8);
-			} catch (Exception e) {
-				throw new BuildException(
-						MessageFormat.format(Messages.getString("MarkupToDocbookTask.11"), docbookOutputFile, //$NON-NLS-1$
-								e.getMessage()),
-						e);
-			}
-			try {
+			try (Writer writer = new OutputStreamWriter(
+					new BufferedOutputStream(new FileOutputStream(docbookOutputFile)), StandardCharsets.UTF_8)) {
 				DocBookDocumentBuilder builder = new DocBookDocumentBuilder(writer) {
 					@Override
 					protected XmlStreamWriter createXmlStreamWriter(Writer out) {
@@ -159,15 +152,11 @@ public class MarkupToDocbookTask extends MarkupTask {
 					builder.setDoctype(doctype);
 				}
 				parser.parse(markupContent);
-			} finally {
-				try {
-					writer.close();
-				} catch (Exception e) {
-					throw new BuildException(
-							MessageFormat.format(Messages.getString("MarkupToDocbookTask.12"), docbookOutputFile, //$NON-NLS-1$
-									e.getMessage()),
-							e);
-				}
+			} catch (IOException e) {
+				throw new BuildException(
+						MessageFormat.format(Messages.getString("MarkupToDocbookTask.11"), docbookOutputFile, //$NON-NLS-1$
+								e.getMessage()),
+						e);
 			}
 		}
 

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.ant/src/main/java/org/eclipse/mylyn/wikitext/ant/internal/MarkupToEclipseHelpTask.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.ant/src/main/java/org/eclipse/mylyn/wikitext/ant/internal/MarkupToEclipseHelpTask.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2007, 2013 David Green and others.
+ * Copyright (c) 2007, 2024 David Green and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -9,12 +9,14 @@
  *
  * Contributors:
  *     David Green - initial API and implementation
+ *     Alexander Fedorov (ArSysOp) - ongoing support
  *******************************************************************************/
 package org.eclipse.mylyn.wikitext.ant.internal;
 
 import java.io.BufferedOutputStream;
 import java.io.File;
 import java.io.FileOutputStream;
+import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
 import java.nio.charset.StandardCharsets;
@@ -49,16 +51,8 @@ public class MarkupToEclipseHelpTask extends MarkupToHtmlTask {
 		File tocOutputFile = computeTocFile(source, name);
 		if (!tocOutputFile.exists() || overwrite || tocOutputFile.lastModified() < source.lastModified()) {
 			File htmlOutputFile = computeHtmlFile(source, name);
-
-			Writer writer;
-			try {
-				writer = new OutputStreamWriter(new BufferedOutputStream(new FileOutputStream(tocOutputFile)),
-						StandardCharsets.UTF_8);
-			} catch (Exception e) {
-				throw new BuildException(String.format("Cannot write to file '%s': %s", tocOutputFile, e.getMessage()), //$NON-NLS-1$
-						e);
-			}
-			try {
+			try (Writer writer = new OutputStreamWriter(new BufferedOutputStream(new FileOutputStream(tocOutputFile)),
+					StandardCharsets.UTF_8)){
 
 				MarkupToEclipseToc toEclipseToc = new SplittingMarkupToEclipseToc();
 
@@ -90,13 +84,9 @@ public class MarkupToEclipseHelpTask extends MarkupToHtmlTask {
 				} catch (Exception e) {
 					throw new BuildException(String.format("Cannot write to file '%s': %s", tocXml, e.getMessage()), e); //$NON-NLS-1$
 				}
-			} finally {
-				try {
-					writer.close();
-				} catch (Exception e) {
-					throw new BuildException(String.format("Cannot write to file '%s': %s", tocOutputFile, //$NON-NLS-1$
-							e.getMessage()), e);
-				}
+			} catch (IOException e) {
+				throw new BuildException(String.format("Cannot write to file '%s': %s", tocOutputFile, e.getMessage()), //$NON-NLS-1$
+						e);
 			}
 		}
 	}

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.ant/src/main/java/org/eclipse/mylyn/wikitext/ant/internal/MarkupToXslfoTask.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.ant/src/main/java/org/eclipse/mylyn/wikitext/ant/internal/MarkupToXslfoTask.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2009, 2013 David Green and others.
+ * Copyright (c) 2009, 2024 David Green and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -9,12 +9,14 @@
  *
  * Contributors:
  *     David Green - initial API and implementation
+ *     Alexander Fedorov (ArSysOp) - ongoing support
  *******************************************************************************/
 package org.eclipse.mylyn.wikitext.ant.internal;
 
 import java.io.BufferedOutputStream;
 import java.io.File;
 import java.io.FileOutputStream;
+import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
 import java.nio.charset.StandardCharsets;
@@ -140,15 +142,8 @@ public class MarkupToXslfoTask extends MarkupTask {
 
 			performValidation(source, markupContent);
 
-			Writer out;
-			try {
-				out = new OutputStreamWriter(new BufferedOutputStream(new FileOutputStream(outputFile)),
-						StandardCharsets.UTF_8);
-			} catch (Exception e) {
-				throw new BuildException(
-						MessageFormat.format(Messages.getString("MarkupToXslfoTask.8"), outputFile, e.getMessage()), e); //$NON-NLS-1$
-			}
-			try {
+			try (Writer out = new OutputStreamWriter(new BufferedOutputStream(new FileOutputStream(outputFile)),
+					StandardCharsets.UTF_8)) {
 				XslfoDocumentBuilder builder = new XslfoDocumentBuilder(out);
 				XslfoDocumentBuilder.Configuration configuration = this.configuration.clone();
 				if (configuration.getTitle() == null) {
@@ -167,13 +162,9 @@ public class MarkupToXslfoTask extends MarkupTask {
 				}
 
 				parser.parse(markupContent);
-			} finally {
-				try {
-					out.close();
-				} catch (Exception e) {
-					throw new BuildException(MessageFormat.format(Messages.getString("MarkupToXslfoTask.9"), outputFile, //$NON-NLS-1$
-							e.getMessage()), e);
-				}
+			} catch (IOException e) {
+				throw new BuildException(
+						MessageFormat.format(Messages.getString("MarkupToXslfoTask.8"), outputFile, e.getMessage()), e); //$NON-NLS-1$
 			}
 		}
 		return markupContent;

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.ant/src/main/java/org/eclipse/mylyn/wikitext/ant/internal/messages.properties
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.ant/src/main/java/org/eclipse/mylyn/wikitext/ant/internal/messages.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2007, 2013 David Green and others.
+# Copyright (c) 2007, 2024 David Green and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -9,6 +9,7 @@
 #
 # Contributors:
 #     David Green - initial API and implementation
+#     Alexander Fedorov (ArSysOp) - ongoing support
 ###############################################################################
 MarkupTask.0=Must specify @markupLanguage
 MarkupTask.1=Validating {0}
@@ -16,7 +17,6 @@ MarkupTask.2={0} is not supported by markup language {1}
 MarkupTask.3=Validation: {0} errors and {1} warnings on file ''{2}''
 MarkupTask.tooManyConfigurations=Only one MarkupLanguageConfiguration may be specified
 MarkupToDocbookTask.11=Cannot write to file ''{0}'': {1}
-MarkupToDocbookTask.12=Cannot write to file ''{0}'': {1}
 MarkupToDocbookTask.1=Please add one or more source filesets or specify @file
 MarkupToDocbookTask.2=@file may not be specified if filesets are also specified
 MarkupToDocbookTask.3=File cannot be found: {0}
@@ -32,7 +32,6 @@ MarkupToHtmlTask.12=Cannot process file ''{0}'': {1}
 MarkupToHtmlTask.13=multipleOutputFiles have already been created in folder ''{0}''
 MarkupToHtmlTask.14=Processing file ''{0}''
 MarkupToHtmlTask.16=Cannot write to file ''{0}'': {1}
-MarkupToHtmlTask.17=Cannot write to file ''{0}'': {1}
 MarkupToHtmlTask.2=@file may not be specified if filesets are also specified
 MarkupToHtmlTask.3=File cannot be found: {0}
 MarkupToHtmlTask.4=Not a file: {0}
@@ -61,7 +60,6 @@ MarkupToXslfoTask.5=Cannot process file ''{0}'': {1}
 MarkupToXslfoTask.6=Cannot process file ''{0}'': {1}
 MarkupToXslfoTask.7=Processing file ''{0}''
 MarkupToXslfoTask.8=Cannot write to file ''{0}'': {1}
-MarkupToXslfoTask.9=Cannot write to file ''{0}'': {1}
 
 MarkupTask.cannotReadSource=Cannot read file ''{0}'': {1}
 

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.asciidoc.tests/META-INF/MANIFEST.MF
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.asciidoc.tests/META-INF/MANIFEST.MF
@@ -1,4 +1,5 @@
 Manifest-Version: 1.0
+Automatic-Module-Name: org.eclipse.mylyn.wikitext.asciidoc.tests
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.eclipse.mylyn.wikitext.asciidoc.tests
 Bundle-Version: 4.2.0.qualifier

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.asciidoc.tests/src/test/java/org/eclipse/mylyn/internal/wikitext/asciidoc/tests/AsciiDocDocumentBuilderTest.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.asciidoc.tests/src/test/java/org/eclipse/mylyn/internal/wikitext/asciidoc/tests/AsciiDocDocumentBuilderTest.java
@@ -28,6 +28,7 @@ import org.eclipse.mylyn.wikitext.parser.LinkAttributes;
 import org.junit.Before;
 import org.junit.Test;
 
+@SuppressWarnings("nls")
 public class AsciiDocDocumentBuilderTest {
 
 	private DocumentBuilder builder;

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.asciidoc.tests/src/test/java/org/eclipse/mylyn/internal/wikitext/asciidoc/tests/AsciiDocLanguageAnchorTest.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.asciidoc.tests/src/test/java/org/eclipse/mylyn/internal/wikitext/asciidoc/tests/AsciiDocLanguageAnchorTest.java
@@ -18,6 +18,7 @@ import static org.junit.Assert.assertEquals;
 
 import org.junit.Test;
 
+@SuppressWarnings("nls")
 public class AsciiDocLanguageAnchorTest extends AsciiDocLanguageTestBase {
 
 	@Test

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.asciidoc.tests/src/test/java/org/eclipse/mylyn/internal/wikitext/asciidoc/tests/AsciiDocLanguageAttributeTest.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.asciidoc.tests/src/test/java/org/eclipse/mylyn/internal/wikitext/asciidoc/tests/AsciiDocLanguageAttributeTest.java
@@ -23,6 +23,7 @@ import org.junit.Test;
  *
  * @author Max Rydahl Andersen
  */
+@SuppressWarnings("nls")
 public class AsciiDocLanguageAttributeTest extends AsciiDocLanguageTestBase {
 
 	static final String MARKUP_FOR_DEFAULT = "Some default values\n\n" + //

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.asciidoc.tests/src/test/java/org/eclipse/mylyn/internal/wikitext/asciidoc/tests/AsciiDocLanguageBlockElementsTest.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.asciidoc.tests/src/test/java/org/eclipse/mylyn/internal/wikitext/asciidoc/tests/AsciiDocLanguageBlockElementsTest.java
@@ -29,6 +29,7 @@ import org.junit.Test;
  *
  * @author Max Rydahl Andersen
  */
+@SuppressWarnings("nls")
 public class AsciiDocLanguageBlockElementsTest extends AsciiDocLanguageTestBase {
 
 	@Test
@@ -635,13 +636,13 @@ public class AsciiDocLanguageBlockElementsTest extends AsciiDocLanguageTestBase 
 				"= Title =\nSam One <sam.one@example.com>; Sam Two <https://example.com/samtwo[@samtwo]>\n");
 		String expectedHtml = //
 				"""
-						<h1 id="header">Title</h1>\
-						<div class="details">\
-						<span id="author" class="author">Sam One</span>\
-						<span id="email" class="email"><a href="mailto:sam.one@example.com">sam.one@example.com</a></span>\
-						<span id="author2" class="author">Sam Two</span>\
-						<span id="email2" class="email"><a href="https://example.com/samtwo">@samtwo</a></span>\
-						</div>""";
+				<h1 id="header">Title</h1>\
+				<div class="details">\
+				<span id="author" class="author">Sam One</span>\
+				<span id="email" class="email"><a href="mailto:sam.one@example.com">sam.one@example.com</a></span>\
+				<span id="author2" class="author">Sam Two</span>\
+				<span id="email2" class="email"><a href="https://example.com/samtwo">@samtwo</a></span>\
+				</div>""";
 		assertEquals(expectedHtml, html);
 	}
 

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.asciidoc.tests/src/test/java/org/eclipse/mylyn/internal/wikitext/asciidoc/tests/AsciiDocLanguageCodeBlockElementsTest.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.asciidoc.tests/src/test/java/org/eclipse/mylyn/internal/wikitext/asciidoc/tests/AsciiDocLanguageCodeBlockElementsTest.java
@@ -23,6 +23,7 @@ import org.junit.Test;
  *
  * @author Max Rydahl Andersen
  */
+@SuppressWarnings("nls")
 public class AsciiDocLanguageCodeBlockElementsTest extends AsciiDocLanguageTestBase {
 
 	@Test

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.asciidoc.tests/src/test/java/org/eclipse/mylyn/internal/wikitext/asciidoc/tests/AsciiDocLanguageCommentBlockElementsTest.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.asciidoc.tests/src/test/java/org/eclipse/mylyn/internal/wikitext/asciidoc/tests/AsciiDocLanguageCommentBlockElementsTest.java
@@ -23,6 +23,7 @@ import org.junit.Test;
  *
  * @author Max Rydahl Andersen
  */
+@SuppressWarnings("nls")
 public class AsciiDocLanguageCommentBlockElementsTest extends AsciiDocLanguageTestBase {
 
 	@Test

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.asciidoc.tests/src/test/java/org/eclipse/mylyn/internal/wikitext/asciidoc/tests/AsciiDocLanguageHorizontalRuleTest.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.asciidoc.tests/src/test/java/org/eclipse/mylyn/internal/wikitext/asciidoc/tests/AsciiDocLanguageHorizontalRuleTest.java
@@ -17,6 +17,7 @@ import static org.junit.Assert.assertEquals;
 
 import org.junit.Test;
 
+@SuppressWarnings("nls")
 public class AsciiDocLanguageHorizontalRuleTest extends AsciiDocLanguageTestBase {
 
 	@Test

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.asciidoc.tests/src/test/java/org/eclipse/mylyn/internal/wikitext/asciidoc/tests/AsciiDocLanguageImageTest.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.asciidoc.tests/src/test/java/org/eclipse/mylyn/internal/wikitext/asciidoc/tests/AsciiDocLanguageImageTest.java
@@ -23,6 +23,7 @@ import org.junit.Test;
  *
  * @author Max Rydahl Andersen
  */
+@SuppressWarnings("nls")
 public class AsciiDocLanguageImageTest extends AsciiDocLanguageTestBase {
 
 	@Test
@@ -47,12 +48,12 @@ public class AsciiDocLanguageImageTest extends AsciiDocLanguageTestBase {
 				"You can find image:http://upload.wikimedia.org/wikipedia/commons/3/35/Tux.svg[Linux,25,35] everywhere these days.");
 		assertEquals(
 				"""
-						<p>You can find\s\
-						<span class="image">\
-						<img height="35" width="25" alt="Linux" border="0" src="http://upload.wikimedia.org/wikipedia/commons/3/35/Tux.svg"/>\
-						</span>\
-						 everywhere these days.</p>
-						""",
+				<p>You can find\s\
+				<span class="image">\
+				<img height="35" width="25" alt="Linux" border="0" src="http://upload.wikimedia.org/wikipedia/commons/3/35/Tux.svg"/>\
+				</span>\
+				 everywhere these days.</p>
+				""",
 				html);
 	}
 
@@ -75,14 +76,14 @@ public class AsciiDocLanguageImageTest extends AsciiDocLanguageTestBase {
 		String html = parseToHtml("image::sunset.jpg[Sunset]");
 		assertEquals(
 				"""
-						<p>\
-						<div class="imageblock">\
-						<div class="content">\
-						<img alt="Sunset" border="0" src="sunset.jpg"/>\
-						</div>\
-						</div>\
-						</p>
-						""", html);
+				<p>\
+				<div class="imageblock">\
+				<div class="content">\
+				<img alt="Sunset" border="0" src="sunset.jpg"/>\
+				</div>\
+				</div>\
+				</p>
+				""", html);
 
 	}
 
@@ -107,17 +108,17 @@ public class AsciiDocLanguageImageTest extends AsciiDocLanguageTestBase {
 				+ "alt=\"Sunset\", width=\"300\", height=\"200\", link=\"http://www.flickr.com/photos/javh/5448336655\"]");
 		assertEquals(
 				"""
-						<p>\
-						<div class="imageblock">\
-						<div class="content">\
-						<a href="http://www.flickr.com/photos/javh/5448336655" class="image">\
-						<img height="200" width="300" alt="Sunset" border="0" src="sunset.jpg"/>\
-						</a>\
-						</div>\
-						<div class="title">Figure 1: A mountain sunset</div>\
-						</div>\
-						</p>
-						""", html);
+				<p>\
+				<div class="imageblock">\
+				<div class="content">\
+				<a href="http://www.flickr.com/photos/javh/5448336655" class="image">\
+				<img height="200" width="300" alt="Sunset" border="0" src="sunset.jpg"/>\
+				</a>\
+				</div>\
+				<div class="title">Figure 1: A mountain sunset</div>\
+				</div>\
+				</p>
+				""", html);
 	}
 
 	@Test

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.asciidoc.tests/src/test/java/org/eclipse/mylyn/internal/wikitext/asciidoc/tests/AsciiDocLanguageLinksTest.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.asciidoc.tests/src/test/java/org/eclipse/mylyn/internal/wikitext/asciidoc/tests/AsciiDocLanguageLinksTest.java
@@ -23,6 +23,7 @@ import org.junit.Test;
  *
  * @author Max Rydahl Andersen
  */
+@SuppressWarnings("nls")
 public class AsciiDocLanguageLinksTest extends AsciiDocLanguageTestBase {
 
 	@Test

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.asciidoc.tests/src/test/java/org/eclipse/mylyn/internal/wikitext/asciidoc/tests/AsciiDocLanguageListTest.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.asciidoc.tests/src/test/java/org/eclipse/mylyn/internal/wikitext/asciidoc/tests/AsciiDocLanguageListTest.java
@@ -28,6 +28,7 @@ import org.junit.Test;
  *
  * @author Patrik Suzzi
  */
+@SuppressWarnings("nls")
 public class AsciiDocLanguageListTest extends AsciiDocLanguageTestBase {
 
 	static final String BR = System.lineSeparator();
@@ -221,7 +222,7 @@ public class AsciiDocLanguageListTest extends AsciiDocLanguageTestBase {
 				+ "end of first list" + BR + BR //
 				+ "    - item a" + BR //
 				+ "    - item b" + BR //
-		);
+				);
 		assertEquals("""
 				<ul>\
 				<li>item 1</li>\
@@ -346,7 +347,7 @@ public class AsciiDocLanguageListTest extends AsciiDocLanguageTestBase {
 				+ "----" + BR //
 				+ "other code" + BR //
 				+ "----" + BR //
-		); //
+				); //
 		assertEquals("testListBreak", """
 				<ul>\
 				<li>lorem\
@@ -381,7 +382,7 @@ public class AsciiDocLanguageListTest extends AsciiDocLanguageTestBase {
 				code block 2
 				----
 				"""
-		); //
+				); //
 		assertEquals("testListBreak", """
 				<ul>\
 				<li>item 1\
@@ -413,7 +414,7 @@ public class AsciiDocLanguageListTest extends AsciiDocLanguageTestBase {
 				----
 
 				end of list"""
-		); //
+				); //
 		assertEquals("testListBreak", """
 				<ul>\
 				<li>item 1\
@@ -437,7 +438,7 @@ public class AsciiDocLanguageListTest extends AsciiDocLanguageTestBase {
 				----
 
 				end of list"""
-		); //
+				); //
 		assertEquals("testListBreak", """
 				<ul>\
 				<li>item 1\
@@ -462,7 +463,7 @@ public class AsciiDocLanguageListTest extends AsciiDocLanguageTestBase {
 				|===
 
 				end of list"""
-		); //
+				); //
 		assertEquals("testListBreak", """
 				<ul>\
 				<li>item 1\
@@ -672,7 +673,7 @@ public class AsciiDocLanguageListTest extends AsciiDocLanguageTestBase {
 				ab. level 5
 				I) level 1
 				"""
-		);
+				);
 		assertEquals("""
 				<ol style="list-style-type:upper-roman;">\
 				<li>level 1<ol style="list-style-type:upper-alpha;">\
@@ -784,7 +785,7 @@ public class AsciiDocLanguageListTest extends AsciiDocLanguageTestBase {
 
 				Sub First 1::: description
 				"""
-		);
+				);
 		assertEquals("""
 				<dl>\
 				<dt class="hdlist1">First</dt>\

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.asciidoc.tests/src/test/java/org/eclipse/mylyn/internal/wikitext/asciidoc/tests/AsciiDocLanguageMiscellaneousTest.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.asciidoc.tests/src/test/java/org/eclipse/mylyn/internal/wikitext/asciidoc/tests/AsciiDocLanguageMiscellaneousTest.java
@@ -23,6 +23,7 @@ import org.junit.Test;
  *
  * @author Max Rydahl Andersen
  */
+@SuppressWarnings("nls")
 public class AsciiDocLanguageMiscellaneousTest extends AsciiDocLanguageTestBase {
 
 	@Test

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.asciidoc.tests/src/test/java/org/eclipse/mylyn/internal/wikitext/asciidoc/tests/AsciiDocLanguagePreformattedBlockTest.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.asciidoc.tests/src/test/java/org/eclipse/mylyn/internal/wikitext/asciidoc/tests/AsciiDocLanguagePreformattedBlockTest.java
@@ -18,6 +18,7 @@ import static org.junit.Assert.assertEquals;
 
 import org.junit.Test;
 
+@SuppressWarnings("nls")
 public class AsciiDocLanguagePreformattedBlockTest extends AsciiDocLanguageTestBase {
 
 	@Test

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.asciidoc.tests/src/test/java/org/eclipse/mylyn/internal/wikitext/asciidoc/tests/AsciiDocLanguageSpanElementsTest.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.asciidoc.tests/src/test/java/org/eclipse/mylyn/internal/wikitext/asciidoc/tests/AsciiDocLanguageSpanElementsTest.java
@@ -23,6 +23,7 @@ import org.junit.Test;
  *
  * @author Max Rydahl Andersen
  */
+@SuppressWarnings("nls")
 public class AsciiDocLanguageSpanElementsTest extends AsciiDocLanguageTestBase {
 
 	@Test

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.asciidoc.tests/src/test/java/org/eclipse/mylyn/internal/wikitext/asciidoc/tests/AsciiDocLanguageSupportTest.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.asciidoc.tests/src/test/java/org/eclipse/mylyn/internal/wikitext/asciidoc/tests/AsciiDocLanguageSupportTest.java
@@ -28,6 +28,7 @@ import org.junit.Test;
 /**
  * Unit Tests for {@link LanguageSupport}
  */
+@SuppressWarnings("nls")
 public class AsciiDocLanguageSupportTest extends AsciiDocLanguageTestBase {
 
 	@Test

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.asciidoc.tests/src/test/java/org/eclipse/mylyn/internal/wikitext/asciidoc/tests/AsciiDocLanguageTableTest.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.asciidoc.tests/src/test/java/org/eclipse/mylyn/internal/wikitext/asciidoc/tests/AsciiDocLanguageTableTest.java
@@ -26,6 +26,7 @@ import org.junit.Test;
 /**
  * Tests for the AsciiDoc TableBlock elements.
  */
+@SuppressWarnings("nls")
 public class AsciiDocLanguageTableTest extends AsciiDocLanguageTestBase {
 
 	@Test
@@ -692,7 +693,7 @@ public class AsciiDocLanguageTableTest extends AsciiDocLanguageTestBase {
 				"lorem ""a\""",second,third
 				first,"lorem ""a\""",third
 				first,second,"lorem ""a\"""
-				|===
+		|===
 				Some Text""");
 		assertEquals("""
 				<table>\

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.asciidoc.tests/src/test/java/org/eclipse/mylyn/internal/wikitext/asciidoc/tests/AsciiDocLanguageTest.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.asciidoc.tests/src/test/java/org/eclipse/mylyn/internal/wikitext/asciidoc/tests/AsciiDocLanguageTest.java
@@ -22,6 +22,7 @@ import org.junit.Test;
  * @author Stefan Seelmann
  * @author Max Rydahl Andersen
  */
+@SuppressWarnings("nls")
 public class AsciiDocLanguageTest extends AsciiDocLanguageTestBase {
 
 	@Test

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.asciidoc.tests/src/test/java/org/eclipse/mylyn/internal/wikitext/asciidoc/tests/AsciiDocLanguageWithConfigurationIntegrationTest.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.asciidoc.tests/src/test/java/org/eclipse/mylyn/internal/wikitext/asciidoc/tests/AsciiDocLanguageWithConfigurationIntegrationTest.java
@@ -24,6 +24,7 @@ import org.eclipse.mylyn.wikitext.parser.MarkupParser;
 import org.eclipse.mylyn.wikitext.parser.markup.MarkupLanguageConfiguration;
 import org.junit.Test;
 
+@SuppressWarnings("nls")
 public class AsciiDocLanguageWithConfigurationIntegrationTest extends AsciiDocLanguageTestBase {
 
 	@Test

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.asciidoc.tests/src/test/java/org/eclipse/mylyn/internal/wikitext/asciidoc/tests/AsciiDocLanguageXrefTest.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.asciidoc.tests/src/test/java/org/eclipse/mylyn/internal/wikitext/asciidoc/tests/AsciiDocLanguageXrefTest.java
@@ -18,6 +18,7 @@ import static org.junit.Assert.assertEquals;
 
 import org.junit.Test;
 
+@SuppressWarnings("nls")
 public class AsciiDocLanguageXrefTest extends AsciiDocLanguageTestBase {
 
 	@Test

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.asciidoc.tests/src/test/java/org/eclipse/mylyn/internal/wikitext/asciidoc/tests/AsciiDocTableOfContentsTest.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.asciidoc.tests/src/test/java/org/eclipse/mylyn/internal/wikitext/asciidoc/tests/AsciiDocTableOfContentsTest.java
@@ -21,6 +21,7 @@ import org.junit.Test;
  *
  * @author Fabrizio Iannetti
  */
+@SuppressWarnings("nls")
 public class AsciiDocTableOfContentsTest extends AsciiDocLanguageTestBase {
 
 	@Test
@@ -39,7 +40,7 @@ public class AsciiDocTableOfContentsTest extends AsciiDocLanguageTestBase {
 				==== section 1.1.1 ====
 
 				"""
-		);
+				);
 		String expectedHtml = """
 				<h1 id="header">test</h1>\
 				<ol class="toc" style="list-style: none;">\
@@ -75,7 +76,7 @@ public class AsciiDocTableOfContentsTest extends AsciiDocLanguageTestBase {
 				==== section 1.1.1 ====
 
 				"""
-		);
+				);
 		String expectedHtml = """
 				<ol class="toc" style="list-style: none;">\
 				<li><a href="#_section_1">section 1</a>\
@@ -115,7 +116,7 @@ public class AsciiDocTableOfContentsTest extends AsciiDocLanguageTestBase {
 				====== section 1.1.1.1.1 ======
 
 				"""
-		);
+				);
 		String expectedHtml = """
 				<h1 id="header">test</h1>\
 				<ol class="toc" style="list-style: none;">\
@@ -165,7 +166,7 @@ public class AsciiDocTableOfContentsTest extends AsciiDocLanguageTestBase {
 				==== section 1.1.1 ====
 
 				"""
-		);
+				);
 		String expectedHtml = """
 				<h1 id="header">test</h1>\
 				<div class="title">Contents</div>\

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.asciidoc.tests/src/test/java/org/eclipse/mylyn/wikitext/asciidoc/internal/AsciiDocIdGenerationStrategyTest.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.asciidoc.tests/src/test/java/org/eclipse/mylyn/wikitext/asciidoc/internal/AsciiDocIdGenerationStrategyTest.java
@@ -18,6 +18,7 @@ import static org.junit.Assert.assertEquals;
 
 import org.junit.Test;
 
+@SuppressWarnings("nls")
 public class AsciiDocIdGenerationStrategyTest {
 
 	@Test

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.asciidoc/META-INF/MANIFEST.MF
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.asciidoc/META-INF/MANIFEST.MF
@@ -1,4 +1,5 @@
 Manifest-Version: 1.0
+Automatic-Module-Name: org.eclipse.mylyn.wikitext.asciidoc
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.eclipse.mylyn.wikitext.asciidoc
 Bundle-Version: 4.2.0.qualifier

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.asciidoc/src/main/java/org/eclipse/mylyn/wikitext/asciidoc/AsciiDocLanguage.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.asciidoc/src/main/java/org/eclipse/mylyn/wikitext/asciidoc/AsciiDocLanguage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2016 Stefan Seelmann and others.
+ * Copyright (c) 2012, 2024 Stefan Seelmann and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -12,6 +12,7 @@
  *     Max Rydahl Andersen - Bug 474084
  *     Patrik Suzzi <psuzzi@gmail.com> - Bug 481670, 474084
  *     Jeremie Bresson - Bug 488246
+ *     Alexander Fedorov (ArSysOp) - ongoing support
  *******************************************************************************/
 
 package org.eclipse.mylyn.wikitext.asciidoc;
@@ -141,7 +142,7 @@ public class AsciiDocLanguage extends AbstractMarkupLanguage {
 		phraseModifierSyntax.add(new InlineImageReplacementToken());
 
 		// pass-through
-		phraseModifierSyntax.add(new SimplePhraseModifier("+++", SpanType.SPAN, Mode.SPECIAL));
+		phraseModifierSyntax.add(new SimplePhraseModifier("+++", SpanType.SPAN, Mode.SPECIAL)); //$NON-NLS-1$
 
 		// emphasis span elements
 		phraseModifierSyntax.add(new SimplePhraseModifier("``", SpanType.CODE, Mode.NESTING)); //$NON-NLS-1$
@@ -150,16 +151,16 @@ public class AsciiDocLanguage extends AbstractMarkupLanguage {
 		phraseModifierSyntax.add(new SimplePhraseModifier("__", SpanType.EMPHASIS, Mode.NESTING)); //$NON-NLS-1$
 
 		// emphasis span elements on word boundaries
-		phraseModifierSyntax.beginGroup("(?:(?<=\\W)|^)(?:", 0);
+		phraseModifierSyntax.beginGroup("(?:(?<=\\W)|^)(?:", 0); //$NON-NLS-1$
 		phraseModifierSyntax.add(new SimplePhraseModifier("*", SpanType.STRONG, Mode.NESTING)); //$NON-NLS-1$
 		phraseModifierSyntax.add(new SimplePhraseModifier("_", SpanType.EMPHASIS, Mode.NESTING)); //$NON-NLS-1$
 		phraseModifierSyntax.add(new SimplePhraseModifier("`", SpanType.CODE, Mode.NESTING)); //$NON-NLS-1$
 		phraseModifierSyntax.add(new SimplePhraseModifier("+", SpanType.SPAN, Mode.NORMAL)); //$NON-NLS-1$
 		phraseModifierSyntax.add(new CssClassPhraseModifier());
-		phraseModifierSyntax.endGroup(")(?:(?=\\W)|$)", 0);
+		phraseModifierSyntax.endGroup(")(?:(?=\\W)|$)", 0); //$NON-NLS-1$
 
-		phraseModifierSyntax.add(new SimplePhraseModifier("^", SpanType.SUPERSCRIPT, Mode.NESTING));
-		phraseModifierSyntax.add(new SimplePhraseModifier("~", SpanType.SUBSCRIPT, Mode.NESTING));
+		phraseModifierSyntax.add(new SimplePhraseModifier("^", SpanType.SUPERSCRIPT, Mode.NESTING)); //$NON-NLS-1$
+		phraseModifierSyntax.add(new SimplePhraseModifier("~", SpanType.SUBSCRIPT, Mode.NESTING)); //$NON-NLS-1$
 	}
 
 	@Override

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.asciidoc/src/main/java/org/eclipse/mylyn/wikitext/asciidoc/AsciiDocMarkupLanguageConfiguration.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.asciidoc/src/main/java/org/eclipse/mylyn/wikitext/asciidoc/AsciiDocMarkupLanguageConfiguration.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2022 Jeremie Bresson and others.
+ * Copyright (c) 2017, 2024 Jeremie Bresson and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -9,6 +9,7 @@
  *
  * Contributors:
  *     Jeremie Bresson - initial API and implementation
+ *     Alexander Fedorov (ArSysOp) - ongoing support
  *******************************************************************************/
 
 package org.eclipse.mylyn.wikitext.asciidoc;
@@ -43,7 +44,7 @@ public class AsciiDocMarkupLanguageConfiguration extends MarkupLanguageConfigura
 	 *            initial attributes (key, values)
 	 */
 	public void setInitialAttributes(Map<String, String> initialAttributes) {
-		Objects.requireNonNull(initialAttributes, "initialAttributes can not be null");
+		Objects.requireNonNull(initialAttributes, "initialAttributes can not be null"); //$NON-NLS-1$
 		this.initialAttributes = Map.copyOf(initialAttributes);
 	}
 }

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.asciidoc/src/main/java/org/eclipse/mylyn/wikitext/asciidoc/internal/AsciiDocDocumentBuilder.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.asciidoc/src/main/java/org/eclipse/mylyn/wikitext/asciidoc/internal/AsciiDocDocumentBuilder.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2021 Jeremie Bresson and others.
+ * Copyright (c) 2016, 2024 Jeremie Bresson and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -9,6 +9,7 @@
  *
  * Contributors:
  *     Jeremie Bresson - copied from MarkdownDocumentBuilder and adapted to AsciiDoc
+ *     Alexander Fedorov (ArSysOp) - ongoing support
  *******************************************************************************/
 
 package org.eclipse.mylyn.wikitext.asciidoc.internal;
@@ -284,16 +285,16 @@ public class AsciiDocDocumentBuilder extends AbstractMarkupDocumentBuilder {
 			case CODE:
 				return new CodeSpan();
 			case SUPERSCRIPT:
-				return new ContentBlock("^", "^", 0, 0);
+				return new ContentBlock("^", "^", 0, 0); //$NON-NLS-1$//$NON-NLS-2$
 			case SUBSCRIPT:
-				return new ContentBlock("~", "~", 0, 0);
+				return new ContentBlock("~", "~", 0, 0); //$NON-NLS-1$ //$NON-NLS-2$
 			case MARK:
-				return new ContentBlock("#", "#", 0, 0);
+				return new ContentBlock("#", "#", 0, 0); //$NON-NLS-1$//$NON-NLS-2$
 			case SPAN:
 				if (attributes.getCssClass() != null) {
-					return new ContentBlock("[" + attributes.getCssClass() + "]#", "#", 0, 0);
+					return new ContentBlock("[" + attributes.getCssClass() + "]#", "#", 0, 0); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
 				}
-				return new ContentBlock("", "", 0, 0);
+				return new ContentBlock("", "", 0, 0); //$NON-NLS-1$//$NON-NLS-2$
 			default:
 				Logger.getLogger(getClass().getName()).warning("Unexpected block type: " + type); //$NON-NLS-1$
 				return new ContentBlock("", "", 0, 0); //$NON-NLS-1$ //$NON-NLS-2$

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.asciidoc/src/main/java/org/eclipse/mylyn/wikitext/asciidoc/internal/block/AttributeDefinitionBlock.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.asciidoc/src/main/java/org/eclipse/mylyn/wikitext/asciidoc/internal/block/AttributeDefinitionBlock.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Jeremie Bresson and others.
+ * Copyright (c) 2017, 2024 Jeremie Bresson and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -9,6 +9,7 @@
  *
  * Contributors:
  *     Jeremie Bresson - initial API and implementation
+ *     Alexander Fedorov (ArSysOp) - ongoing support
  *******************************************************************************/
 
 package org.eclipse.mylyn.wikitext.asciidoc.internal.block;
@@ -54,7 +55,7 @@ public class AttributeDefinitionBlock extends Block {
 			((AsciiDocContentState) getState()).removeAttribute(key);
 		} else {
 			String newKey = key.trim();
-			String newValue = value == null ? "" : value.trim();
+			String newValue = value == null ? "" : value.trim(); //$NON-NLS-1$
 			((AsciiDocContentState) getState()).putAttribute(newKey, newValue);
 		}
 		setClosed(true);

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.asciidoc/src/main/java/org/eclipse/mylyn/wikitext/asciidoc/internal/block/DefinitionListBlock.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.asciidoc/src/main/java/org/eclipse/mylyn/wikitext/asciidoc/internal/block/DefinitionListBlock.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2007, 2008 Fabrizio Iannetti and others.
+ * Copyright (c) 2007, 2024 Fabrizio Iannetti and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -9,6 +9,7 @@
  *
  * Contributors:
  *     Fabrizio Iannetti - initial API and implementation
+ *     Alexander Fedorov (ArSysOp) - ongoing support
  *******************************************************************************/
 
 package org.eclipse.mylyn.wikitext.asciidoc.internal.block;
@@ -87,7 +88,7 @@ public class DefinitionListBlock extends Block {
 
 	private void openLevel(int level) {
 		if (!isCurrentLevel(0) && !blockItemIsOpen) {
-			openItemBlock("", 0);
+			openItemBlock("", 0); //$NON-NLS-1$
 		}
 		builder.beginBlock(BlockType.DEFINITION_LIST, new ListAttributes());
 		levels.push(level);

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.asciidoc/src/main/java/org/eclipse/mylyn/wikitext/asciidoc/internal/block/HeadingBlock.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.asciidoc/src/main/java/org/eclipse/mylyn/wikitext/asciidoc/internal/block/HeadingBlock.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012 Stefan Seelmann and others.
+ * Copyright (c) 2012, 2024 Stefan Seelmann and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -9,6 +9,7 @@
  *
  * Contributors:
  *     Stefan Seelmann - initial API and implementation
+ *     Alexander Fedorov (ArSysOp) - ongoing support
  *******************************************************************************/
 
 package org.eclipse.mylyn.wikitext.asciidoc.internal.block;
@@ -74,8 +75,8 @@ public class HeadingBlock extends Block {
 				setClosed(true);
 			} else {
 				lineCount++;
-				String tocAttribute = getAsciiDocState().getAttribute("toc");
-				if (tocAttribute != null && !"macro".equals(tocAttribute)) {
+				String tocAttribute = getAsciiDocState().getAttribute("toc"); //$NON-NLS-1$
+				if (tocAttribute != null && !"macro".equals(tocAttribute)) { //$NON-NLS-1$
 					emitTableOfContent();
 				}
 			}
@@ -123,7 +124,7 @@ public class HeadingBlock extends Block {
 
 		HeadingAttributes attributes = new HeadingAttributes();
 		if (level == 1) {
-			attributes.setId("header");
+			attributes.setId("header"); //$NON-NLS-1$
 		} else {
 			attributes.setId(state.getIdGenerator().newId(null, text));
 		}
@@ -138,20 +139,20 @@ public class HeadingBlock extends Block {
 	}
 
 	private boolean processAuthors(String line) {
-		Matcher authorMatcher = Pattern.compile("(?:^|;)\\s*((?:\\w+\\s+)+)\\s*<([^>]+)>\\s*").matcher(line);
+		Matcher authorMatcher = Pattern.compile("(?:^|;)\\s*((?:\\w+\\s+)+)\\s*<([^>]+)>\\s*").matcher(line); //$NON-NLS-1$
 		int authorCount = 0;
 		while (authorMatcher.find()) {
 			if (authorCount == 0) {
-				Attributes attributes = new Attributes(null, "details", null, null);
+				Attributes attributes = new Attributes(null, "details", null, null); //$NON-NLS-1$
 				builder.beginBlock(BlockType.DIV, attributes);
 			}
 			authorCount++;
-			String idCount = authorCount > 1 ? Integer.toString(authorCount) : "";
-			Attributes attributes = new Attributes("author" + idCount, "author", null, null);
+			String idCount = authorCount > 1 ? Integer.toString(authorCount) : ""; //$NON-NLS-1$
+			Attributes attributes = new Attributes("author" + idCount, "author", null, null); //$NON-NLS-1$//$NON-NLS-2$
 			builder.beginSpan(SpanType.SPAN, attributes);
 			getMarkupLanguage().emitMarkupLine(getParser(), state, authorMatcher.group(1).trim(), 0);
 			builder.endSpan();
-			attributes = new Attributes("email" + idCount, "email", null, null);
+			attributes = new Attributes("email" + idCount, "email", null, null); //$NON-NLS-1$ //$NON-NLS-2$
 			builder.beginSpan(SpanType.SPAN, attributes);
 			getMarkupLanguage().emitMarkupLine(getParser(), state, authorMatcher.group(2).trim(), 0);
 			builder.endSpan();

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.asciidoc/src/main/java/org/eclipse/mylyn/wikitext/asciidoc/internal/block/ListBlock.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.asciidoc/src/main/java/org/eclipse/mylyn/wikitext/asciidoc/internal/block/ListBlock.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2016 Patrik Suzzi and others.
+ * Copyright (c) 2015, 2024 Patrik Suzzi and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -9,6 +9,7 @@
  *
  * Contributors:
  *     Patrik Suzzi - Bug 481670 - [asciidoc] support for lists
+ *     Alexander Fedorov (ArSysOp) - ongoing support
  *******************************************************************************/
 
 package org.eclipse.mylyn.wikitext.asciidoc.internal.block;
@@ -37,19 +38,19 @@ import com.google.common.collect.ImmutableList;
  */
 public class ListBlock extends Block {
 
-	private static final String PARAM_NAME_START = "start";
+	private static final String PARAM_NAME_START = "start"; //$NON-NLS-1$
 
-	private static final String PARAM_NAME_STYLE = "style";
+	private static final String PARAM_NAME_STYLE = "style"; //$NON-NLS-1$
 
 	private static final String ANY_CHAR = "\\s+(.*+)"; //$NON-NLS-1$
 
-	private static final List<String> TYPE_ORDER = ImmutableList.of("arabic", "loweralpha", "lowerroman", "upperalpha",
-			"upperroman");
+	private static final List<String> TYPE_ORDER = ImmutableList.of("arabic", "loweralpha", "lowerroman", "upperalpha", //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
+			"upperroman"); //$NON-NLS-1$
 
-	private static final List<String> TYPE_LISTSPEC = ImmutableList.of("1.", "a.", "i)", "A.", "I)");
+	private static final List<String> TYPE_LISTSPEC = ImmutableList.of("1.", "a.", "i)", "A.", "I)"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$ //$NON-NLS-5$
 
-	private static final List<String> TYPE_CSS_STYLE = ImmutableList.of("decimal", "lower-alpha", "lower-roman",
-			"upper-alpha", "upper-roman");
+	private static final List<String> TYPE_CSS_STYLE = ImmutableList.of("decimal", "lower-alpha", "lower-roman", //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+			"upper-alpha", "upper-roman"); //$NON-NLS-1$//$NON-NLS-2$
 
 	/** List item start */
 	private static final Pattern startPattern = Pattern
@@ -105,7 +106,7 @@ public class ListBlock extends Block {
 				List<String> positionalParameters = new ArrayList<>();
 				positionalParameters.add(PARAM_NAME_STYLE);
 				Map<String, String> lastProperties = getAsciiDocState().getLastProperties(positionalParameters);
-				getAsciiDocState().setLastPropertiesText("");
+				getAsciiDocState().setLastPropertiesText(""); //$NON-NLS-1$
 
 				String startProperty = lastProperties.get(PARAM_NAME_START);
 				if (startProperty != null) {
@@ -187,20 +188,20 @@ public class ListBlock extends Block {
 			}
 			listTypeIndex = level % TYPE_ORDER.size();
 		}
-		attributes.appendCssStyle("list-style-type:" + TYPE_CSS_STYLE.get(listTypeIndex) + ";");
+		attributes.appendCssStyle("list-style-type:" + TYPE_CSS_STYLE.get(listTypeIndex) + ";"); //$NON-NLS-1$ //$NON-NLS-2$
 	}
 
 	private String normalizeListSpec(String group) {
-		if (group.matches("[a-z]+\\.")) {
-			group = "a.";
-		} else if (group.matches("[A-Z]+\\.")) {
-			group = "A.";
-		} else if (group.matches("[IVXLCDM]+\\)")) {
-			group = "I)";
-		} else if (group.matches("[ivxlcdm]+\\)")) {
-			group = "i)";
-		} else if (group.matches("[0-9]+\\.")) {
-			group = "1.";
+		if (group.matches("[a-z]+\\.")) { //$NON-NLS-1$
+			group = "a."; //$NON-NLS-1$
+		} else if (group.matches("[A-Z]+\\.")) { //$NON-NLS-1$
+			group = "A."; //$NON-NLS-1$
+		} else if (group.matches("[IVXLCDM]+\\)")) { //$NON-NLS-1$
+			group = "I)"; //$NON-NLS-1$
+		} else if (group.matches("[ivxlcdm]+\\)")) { //$NON-NLS-1$
+			group = "i)"; //$NON-NLS-1$
+		} else if (group.matches("[0-9]+\\.")) { //$NON-NLS-1$
+			group = "1."; //$NON-NLS-1$
 		}
 
 		return group;

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.asciidoc/src/main/java/org/eclipse/mylyn/wikitext/asciidoc/internal/block/PreformattedBlock.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.asciidoc/src/main/java/org/eclipse/mylyn/wikitext/asciidoc/internal/block/PreformattedBlock.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2016 Max Rydahl and others.
+ * Copyright (c) 2015, 2024 Max Rydahl and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -11,6 +11,7 @@
  *     Stefan Seelmann - initial API and implementation
  *     Max Rydahl Andersen - copied from markdown to get base for asciidoc, Bug 474084
  *     Patrik Suzzi <psuzzi@gmail.com> - Bug 474084
+ *     Alexander Fedorov (ArSysOp) - ongoing support
  *******************************************************************************/
 
 package org.eclipse.mylyn.wikitext.asciidoc.internal.block;
@@ -79,7 +80,7 @@ public class PreformattedBlock extends AsciiDocBlock {
 			String content = matcher.group(3);
 
 			if (hasContent) {
-				builder.characters("\n");
+				builder.characters("\n"); //$NON-NLS-1$
 			}
 
 			// emit, handle intention, encode ampersands (&) and angle brackets (< and >)

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.asciidoc/src/main/java/org/eclipse/mylyn/wikitext/asciidoc/internal/block/TableBlock.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.asciidoc/src/main/java/org/eclipse/mylyn/wikitext/asciidoc/internal/block/TableBlock.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016 Jeremie Bresson and others.
+ * Copyright (c) 2016, 2024 Jeremie Bresson and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -9,6 +9,7 @@
  *
  * Contributors:
  *     Jeremie Bresson - initial API and implementation
+ *     Alexander Fedorov (ArSysOp) - ongoing support
  *******************************************************************************/
 
 package org.eclipse.mylyn.wikitext.asciidoc.internal.block;
@@ -142,13 +143,13 @@ public class TableBlock extends AsciiDocBlock {
 							cellSpan = 1;
 						}
 						String alignGroup = rowCellMatcher.group(2);
-						openCellBlock(alignGroup == null ? "" : alignGroup);
+						openCellBlock(alignGroup == null ? "" : alignGroup); //$NON-NLS-1$
 					}
 				} else {
 					if (!found && !isColFormatKnown()) {
 						colsAttribute = LanguageSupport.createDefaultColumnsAttributeList(cellsCount + 1);
 					}
-					openCellBlock("");
+					openCellBlock(""); //$NON-NLS-1$
 					handleCellContent(cellContent, contentOffset, false);
 					closeCellBlockIfNeeded();
 				}
@@ -195,14 +196,14 @@ public class TableBlock extends AsciiDocBlock {
 		}
 		attributes.setColspan(cellSpan > 1 ? Integer.toString(cellSpan) : null);
 		switch (alignCode) {
-			case "<":
-				attributes.setAlign("left");
+			case "<": //$NON-NLS-1$
+				attributes.setAlign("left"); //$NON-NLS-1$
 				break;
-			case "^":
-				attributes.setAlign("center");
+			case "^": //$NON-NLS-1$
+				attributes.setAlign("center"); //$NON-NLS-1$
 				break;
-			case ">":
-				attributes.setAlign("right");
+			case ">": //$NON-NLS-1$
+				attributes.setAlign("right"); //$NON-NLS-1$
 				break;
 			default:
 				break;
@@ -217,10 +218,10 @@ public class TableBlock extends AsciiDocBlock {
 		if (!cellBlockIsOpen) {
 			return;
 		}
-		String blockContent = append ? " " : "";
+		String blockContent = append ? " " : ""; //$NON-NLS-1$ //$NON-NLS-2$
 		if (format == TableFormat.COMMA_SEPARATED_VALUES) {
-			if (cellContent.startsWith("\"") && cellContent.endsWith("\"")) {
-				blockContent += cellContent.substring(1, cellContent.length() - 1).replace("\"\"", "\"");
+			if (cellContent.startsWith("\"") && cellContent.endsWith("\"")) { //$NON-NLS-1$ //$NON-NLS-2$
+				blockContent += cellContent.substring(1, cellContent.length() - 1).replace("\"\"", "\""); //$NON-NLS-1$ //$NON-NLS-2$
 			} else {
 				blockContent += cellContent;
 			}

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.asciidoc/src/main/java/org/eclipse/mylyn/wikitext/asciidoc/internal/block/TableOfContentsBlock.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.asciidoc/src/main/java/org/eclipse/mylyn/wikitext/asciidoc/internal/block/TableOfContentsBlock.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2007, 2008 David Green and others.
+ * Copyright (c) 2007, 2024 David Green and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -7,6 +7,7 @@
  *
  * Contributors:
  *     David Green - initial API and implementation
+ *     Alexander Fedorov (ArSysOp) - ongoing support
  *******************************************************************************/
 
 package org.eclipse.mylyn.wikitext.asciidoc.internal.block;
@@ -41,8 +42,8 @@ public class TableOfContentsBlock extends AbstractTableOfContentsBlock {
 			setClosed(true);
 			return 0;
 		}
-		String tocAttribute = getAsciiDocState().getAttribute("toc");
-		if ("macro".equals(tocAttribute)) {
+		String tocAttribute = getAsciiDocState().getAttribute("toc"); //$NON-NLS-1$
+		if ("macro".equals(tocAttribute)) { //$NON-NLS-1$
 			emitFullToc();
 		}
 
@@ -52,7 +53,7 @@ public class TableOfContentsBlock extends AbstractTableOfContentsBlock {
 	public void emitFullToc() {
 		if (!getMarkupLanguage().isFilterGenerativeContents()) {
 			setMaxLevel(1 + getTocLevelsAttribute());
-			String tocTitle = getAsciiDocState().getAttribute("toc-title");
+			String tocTitle = getAsciiDocState().getAttribute("toc-title"); //$NON-NLS-1$
 			OutlineParser outlineParser = new OutlineParser(new AsciiDocLanguage());
 			OutlineItem rootItem = outlineParser.parse(state.getMarkupContent());
 			List<OutlineItem> zeroLevelItems = rootItem.getChildren();
@@ -66,7 +67,7 @@ public class TableOfContentsBlock extends AbstractTableOfContentsBlock {
 	private void emitTocTitle(String tocTitle) {
 		if (tocTitle != null) {
 			Attributes attributes = new Attributes();
-			attributes.setCssClass("title");
+			attributes.setCssClass("title"); //$NON-NLS-1$
 			builder.beginBlock(BlockType.DIV, attributes);
 			builder.characters(tocTitle);
 			builder.endBlock();
@@ -77,7 +78,7 @@ public class TableOfContentsBlock extends AbstractTableOfContentsBlock {
 		int tocLevel = tocLevelDefault;
 		try {
 			tocLevel = Integer
-					.parseInt(getAsciiDocState().getAttributeOrValue("toclevels", Integer.toString(tocLevelDefault)));
+					.parseInt(getAsciiDocState().getAttributeOrValue("toclevels", Integer.toString(tocLevelDefault))); //$NON-NLS-1$
 		} catch (NumberFormatException e) {
 			// leave default in case of parsing error
 		}

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.asciidoc/src/main/java/org/eclipse/mylyn/wikitext/asciidoc/internal/phrase/CssClassPhraseModifier.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.asciidoc/src/main/java/org/eclipse/mylyn/wikitext/asciidoc/internal/phrase/CssClassPhraseModifier.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2007, 2008 David Green and others.
+ * Copyright (c) 2007, 2024 David Green and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -9,6 +9,7 @@
  *
  * Contributors:
  *     David Green - initial API and implementation
+ *     Alexander Fedorov (ArSysOp) - ongoing support
  *******************************************************************************/
 
 package org.eclipse.mylyn.wikitext.asciidoc.internal.phrase;
@@ -22,7 +23,7 @@ public class CssClassPhraseModifier extends PatternBasedElement {
 
 	@Override
 	protected String getPattern(int groupOffset) {
-		return "(?:\\[\\.*(.+?)\\])?#(.+?)#";
+		return "(?:\\[\\.*(.+?)\\])?#(.+?)#"; //$NON-NLS-1$
 	}
 
 	@Override

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.asciidoc/src/main/java/org/eclipse/mylyn/wikitext/asciidoc/internal/token/ExplicitLinkReplacementToken.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.asciidoc/src/main/java/org/eclipse/mylyn/wikitext/asciidoc/internal/token/ExplicitLinkReplacementToken.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015 Max Rydahl Andersen and others.
+ * Copyright (c) 2015, 2024 Max Rydahl Andersen and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -9,6 +9,7 @@
  *
  * Contributors:
  *     Max Rydahl Andersen- initial API and implementation
+ *     Alexander Fedorov (ArSysOp) - ongoing support
  *******************************************************************************/
 
 package org.eclipse.mylyn.wikitext.asciidoc.internal.token;
@@ -57,9 +58,9 @@ public class ExplicitLinkReplacementToken extends PatternBasedElement {
 			LinkAttributes attributes = new LinkAttributes();
 			if (text == null) {
 				text = href;
-			} else if (text.endsWith("^")) {
+			} else if (text.endsWith("^")) { //$NON-NLS-1$
 				text = text.substring(0, text.length() - 1);
-				attributes.setTarget("_blank");
+				attributes.setTarget("_blank"); //$NON-NLS-1$
 			}
 
 			builder.link(attributes, href, text);

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.asciidoc/src/main/java/org/eclipse/mylyn/wikitext/asciidoc/internal/token/ImplicitFormattedLinkReplacementToken.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.asciidoc/src/main/java/org/eclipse/mylyn/wikitext/asciidoc/internal/token/ImplicitFormattedLinkReplacementToken.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015 Max Rydahl Andersen and others.
+ * Copyright (c) 2015, 2024 Max Rydahl Andersen and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -9,6 +9,7 @@
  *
  * Contributors:
  *     Max Rydahl Andersen- initial API and implementation
+ *     Alexander Fedorov (ArSysOp) - ongoing support
  *******************************************************************************/
 
 package org.eclipse.mylyn.wikitext.asciidoc.internal.token;
@@ -48,9 +49,9 @@ public class ImplicitFormattedLinkReplacementToken extends PatternBasedElement {
 			String href = group(2);
 			String text = group(3);
 			LinkAttributes attributes = new LinkAttributes();
-			if (text.endsWith("^")) {
+			if (text.endsWith("^")) { //$NON-NLS-1$
 				text = text.substring(0, text.length() - 1);
-				attributes.setTarget("_blank");
+				attributes.setTarget("_blank"); //$NON-NLS-1$
 			}
 			builder.link(attributes, href, text);
 		}

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.asciidoc/src/main/java/org/eclipse/mylyn/wikitext/asciidoc/internal/token/InlineEscapedAttributeReplacementToken.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.asciidoc/src/main/java/org/eclipse/mylyn/wikitext/asciidoc/internal/token/InlineEscapedAttributeReplacementToken.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Jeremie Bresson and others.
+ * Copyright (c) 2017, 2024 Jeremie Bresson and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -9,6 +9,7 @@
  *
  * Contributors:
  *     Jeremie Bresson - initial API and implementation
+ *     Alexander Fedorov (ArSysOp) - ongoing support
  *******************************************************************************/
 
 package org.eclipse.mylyn.wikitext.asciidoc.internal.token;
@@ -20,7 +21,7 @@ public class InlineEscapedAttributeReplacementToken extends PatternBasedElement 
 
 	@Override
 	protected String getPattern(int groupOffset) {
-		return "\\\\(\\{\\w+\\})";
+		return "\\\\(\\{\\w+\\})"; //$NON-NLS-1$
 	}
 
 	@Override

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.asciidoc/src/main/java/org/eclipse/mylyn/wikitext/asciidoc/internal/util/LanguageSupport.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.asciidoc/src/main/java/org/eclipse/mylyn/wikitext/asciidoc/internal/util/LanguageSupport.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2016 Max Rydhal Andersen and others.
+ * Copyright (c) 2015, 2024 Max Rydhal Andersen and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -11,6 +11,7 @@
  *     David Green - initial API and implementation
  *     Max Rydahl Andersen - Bug 474084
  *     Patrik Suzzi <psuzzi@gmail.com> - Bug 474084
+ *     Alexander Fedorov (ArSysOp) - ongoing support
  *******************************************************************************/
 
 package org.eclipse.mylyn.wikitext.asciidoc.internal.util;
@@ -75,11 +76,11 @@ public class LanguageSupport {
 				value = matcher.group(2);
 				properties.put(key, value);
 			} else // could not parse key/value pairs
-			if (positionalParameters.isEmpty()) {
-				//no more positional items left - ignoring
-			} else {
-				properties.put(positionalParameters.remove(0), pair.trim());
-			}
+				if (positionalParameters.isEmpty()) {
+					//no more positional items left - ignoring
+				} else {
+					properties.put(positionalParameters.remove(0), pair.trim());
+				}
 		}
 
 		return properties;
@@ -142,7 +143,7 @@ public class LanguageSupport {
 	}
 
 	public static int computeHeadingLevel(int initialLevel, AsciiDocContentState state) {
-		String attributeValue = state.getAttributeOrValue(AsciiDocContentState.ATTRIBUTE_LEVELOFFSET, "0");
+		String attributeValue = state.getAttributeOrValue(AsciiDocContentState.ATTRIBUTE_LEVELOFFSET, "0"); //$NON-NLS-1$
 		int levelOffset;
 		try {
 			levelOffset = Integer.parseInt(attributeValue);

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark.tests/META-INF/MANIFEST.MF
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark.tests/META-INF/MANIFEST.MF
@@ -1,4 +1,5 @@
 Manifest-Version: 1.0
+Automatic-Module-Name: org.eclipse.mylyn.wikitext.commonmark.tests
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.eclipse.mylyn.wikitext.commonmark.tests
 Bundle-Version: 4.2.0.qualifier

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark.tests/src/test/java/org/eclipse/mylyn/wikitext/commonmark/internal/CommonMarkIdGenerationStrategyTest.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark.tests/src/test/java/org/eclipse/mylyn/wikitext/commonmark/internal/CommonMarkIdGenerationStrategyTest.java
@@ -18,6 +18,7 @@ import static org.junit.Assert.assertEquals;
 
 import org.junit.Test;
 
+@SuppressWarnings("nls")
 public class CommonMarkIdGenerationStrategyTest {
 
 	private final CommonMarkIdGenerationStrategy strategy = new CommonMarkIdGenerationStrategy();

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark.tests/src/test/java/org/eclipse/mylyn/wikitext/commonmark/internal/LinePredicatesTest.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark.tests/src/test/java/org/eclipse/mylyn/wikitext/commonmark/internal/LinePredicatesTest.java
@@ -23,6 +23,7 @@ import java.util.regex.Pattern;
 
 import org.junit.Test;
 
+@SuppressWarnings("nls")
 public class LinePredicatesTest {
 
 	@Test

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark.tests/src/test/java/org/eclipse/mylyn/wikitext/commonmark/internal/LineSequenceTest.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark.tests/src/test/java/org/eclipse/mylyn/wikitext/commonmark/internal/LineSequenceTest.java
@@ -27,6 +27,7 @@ import java.util.List;
 
 import org.junit.Test;
 
+@SuppressWarnings("nls")
 public class LineSequenceTest {
 
 	@Test(expected = NullPointerException.class)

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark.tests/src/test/java/org/eclipse/mylyn/wikitext/commonmark/internal/LineTest.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark.tests/src/test/java/org/eclipse/mylyn/wikitext/commonmark/internal/LineTest.java
@@ -24,6 +24,7 @@ import org.junit.Test;
 
 import com.google.common.base.Strings;
 
+@SuppressWarnings("nls")
 public class LineTest {
 
 	@Test(expected = NullPointerException.class)

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark.tests/src/test/java/org/eclipse/mylyn/wikitext/commonmark/internal/LinesIterableTest.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark.tests/src/test/java/org/eclipse/mylyn/wikitext/commonmark/internal/LinesIterableTest.java
@@ -29,6 +29,7 @@ import java.util.function.Predicate;
 
 import org.junit.Test;
 
+@SuppressWarnings("nls")
 public class LinesIterableTest {
 
 	@Test(expected = NullPointerException.class)

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark.tests/src/test/java/org/eclipse/mylyn/wikitext/commonmark/internal/PredicateLineSequenceTest.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark.tests/src/test/java/org/eclipse/mylyn/wikitext/commonmark/internal/PredicateLineSequenceTest.java
@@ -22,6 +22,7 @@ import java.util.function.Predicate;
 
 import org.junit.Test;
 
+@SuppressWarnings("nls")
 public class PredicateLineSequenceTest {
 
 	@Test(expected = NullPointerException.class)

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark.tests/src/test/java/org/eclipse/mylyn/wikitext/commonmark/internal/ProcessingContextTest.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark.tests/src/test/java/org/eclipse/mylyn/wikitext/commonmark/internal/ProcessingContextTest.java
@@ -28,6 +28,7 @@ import org.eclipse.mylyn.wikitext.commonmark.internal.inlines.InlineParser;
 import org.eclipse.mylyn.wikitext.commonmark.internal.inlines.SourceSpan;
 import org.junit.Test;
 
+@SuppressWarnings("nls")
 public class ProcessingContextTest {
 
 	@Test

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark.tests/src/test/java/org/eclipse/mylyn/wikitext/commonmark/internal/SimpleLocatorTest.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark.tests/src/test/java/org/eclipse/mylyn/wikitext/commonmark/internal/SimpleLocatorTest.java
@@ -19,6 +19,7 @@ import static org.junit.Assert.assertEquals;
 import org.eclipse.mylyn.wikitext.parser.Locator;
 import org.junit.Test;
 
+@SuppressWarnings("nls")
 public class SimpleLocatorTest {
 
 	@Test

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark.tests/src/test/java/org/eclipse/mylyn/wikitext/commonmark/internal/SourceBlocksTest.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark.tests/src/test/java/org/eclipse/mylyn/wikitext/commonmark/internal/SourceBlocksTest.java
@@ -31,6 +31,7 @@ import org.eclipse.mylyn.wikitext.parser.builder.event.DocumentBuilderEvent;
 import org.eclipse.mylyn.wikitext.parser.builder.event.EndBlockEvent;
 import org.junit.Test;
 
+@SuppressWarnings("nls")
 public class SourceBlocksTest {
 
 	private final SourceBlock block1 = mockBlock(BlockType.QUOTE, "b1");
@@ -73,10 +74,10 @@ public class SourceBlocksTest {
 				new EndBlockEvent());
 		assertEquals(
 				builder.getDocumentBuilderEvents()
-						.getEvents()
-						.stream()
-						.map(DocumentBuilderEvent::toString)
-						.collect(Collectors.joining("\n")),
+				.getEvents()
+				.stream()
+				.map(DocumentBuilderEvent::toString)
+				.collect(Collectors.joining("\n")),
 				expectedEvents, builder.getDocumentBuilderEvents().getEvents());
 	}
 

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark.tests/src/test/java/org/eclipse/mylyn/wikitext/commonmark/internal/TextSegmentTest.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark.tests/src/test/java/org/eclipse/mylyn/wikitext/commonmark/internal/TextSegmentTest.java
@@ -24,6 +24,7 @@ import org.junit.Test;
 
 import com.google.common.base.Strings;
 
+@SuppressWarnings("nls")
 public class TextSegmentTest {
 
 	@Test(expected = NullPointerException.class)

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark.tests/src/test/java/org/eclipse/mylyn/wikitext/commonmark/internal/ToStringHelperTest.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark.tests/src/test/java/org/eclipse/mylyn/wikitext/commonmark/internal/ToStringHelperTest.java
@@ -20,6 +20,7 @@ import org.junit.Test;
 
 import com.google.common.base.Strings;
 
+@SuppressWarnings("nls")
 public class ToStringHelperTest {
 	@Test
 	public void toStringValue() {

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark.tests/src/test/java/org/eclipse/mylyn/wikitext/commonmark/internal/TransformLineSequenceTest.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark.tests/src/test/java/org/eclipse/mylyn/wikitext/commonmark/internal/TransformLineSequenceTest.java
@@ -22,6 +22,7 @@ import java.util.function.Function;
 
 import org.junit.Test;
 
+@SuppressWarnings("nls")
 public class TransformLineSequenceTest {
 
 	static final class UpperCaseTransform implements Function<Line, Line> {

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark.tests/src/test/java/org/eclipse/mylyn/wikitext/commonmark/internal/blocks/AtxHeaderBlockTest.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark.tests/src/test/java/org/eclipse/mylyn/wikitext/commonmark/internal/blocks/AtxHeaderBlockTest.java
@@ -21,6 +21,7 @@ import static org.junit.Assert.assertTrue;
 import org.eclipse.mylyn.wikitext.commonmark.internal.LineSequence;
 import org.junit.Test;
 
+@SuppressWarnings("nls")
 public class AtxHeaderBlockTest {
 
 	AtxHeaderBlock block = new AtxHeaderBlock();

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark.tests/src/test/java/org/eclipse/mylyn/wikitext/commonmark/internal/blocks/BlockQuoteBlockTest.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark.tests/src/test/java/org/eclipse/mylyn/wikitext/commonmark/internal/blocks/BlockQuoteBlockTest.java
@@ -22,6 +22,7 @@ import java.util.List;
 import org.eclipse.mylyn.wikitext.commonmark.internal.LineSequence;
 import org.junit.Test;
 
+@SuppressWarnings("nls")
 public class BlockQuoteBlockTest {
 
 	@Test

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark.tests/src/test/java/org/eclipse/mylyn/wikitext/commonmark/internal/blocks/EmptyBlockTest.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark.tests/src/test/java/org/eclipse/mylyn/wikitext/commonmark/internal/blocks/EmptyBlockTest.java
@@ -20,6 +20,7 @@ import org.eclipse.mylyn.wikitext.commonmark.internal.LineSequence;
 import org.eclipse.mylyn.wikitext.commonmark.internal.ProcessingContext;
 import org.junit.Test;
 
+@SuppressWarnings("nls")
 public class EmptyBlockTest {
 
 	@Test

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark.tests/src/test/java/org/eclipse/mylyn/wikitext/commonmark/internal/blocks/FencedCodeBlockTest.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark.tests/src/test/java/org/eclipse/mylyn/wikitext/commonmark/internal/blocks/FencedCodeBlockTest.java
@@ -21,6 +21,7 @@ import static org.junit.Assert.assertTrue;
 import org.eclipse.mylyn.wikitext.commonmark.internal.LineSequence;
 import org.junit.Test;
 
+@SuppressWarnings("nls")
 public class FencedCodeBlockTest {
 
 	private final FencedCodeBlock block = new FencedCodeBlock();

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark.tests/src/test/java/org/eclipse/mylyn/wikitext/commonmark/internal/blocks/HorizontalRuleBlockTest.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark.tests/src/test/java/org/eclipse/mylyn/wikitext/commonmark/internal/blocks/HorizontalRuleBlockTest.java
@@ -23,6 +23,7 @@ import org.junit.Test;
 
 import com.google.common.base.Strings;
 
+@SuppressWarnings("nls")
 public class HorizontalRuleBlockTest {
 
 	private final HorizontalRuleBlock block = new HorizontalRuleBlock();

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark.tests/src/test/java/org/eclipse/mylyn/wikitext/commonmark/internal/blocks/HtmlBlockTest.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark.tests/src/test/java/org/eclipse/mylyn/wikitext/commonmark/internal/blocks/HtmlBlockTest.java
@@ -22,6 +22,7 @@ import org.eclipse.mylyn.wikitext.commonmark.internal.Line;
 import org.eclipse.mylyn.wikitext.commonmark.internal.LineSequence;
 import org.junit.Test;
 
+@SuppressWarnings("nls")
 public class HtmlBlockTest {
 
 	private final HtmlBlock block = new HtmlBlock();

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark.tests/src/test/java/org/eclipse/mylyn/wikitext/commonmark/internal/blocks/HtmlCommentBlockTest.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark.tests/src/test/java/org/eclipse/mylyn/wikitext/commonmark/internal/blocks/HtmlCommentBlockTest.java
@@ -19,6 +19,7 @@ import static org.junit.Assert.assertEquals;
 import org.eclipse.mylyn.wikitext.commonmark.internal.LineSequence;
 import org.junit.Test;
 
+@SuppressWarnings("nls")
 public class HtmlCommentBlockTest {
 
 	private final HtmlCommentBlock block = new HtmlCommentBlock();

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark.tests/src/test/java/org/eclipse/mylyn/wikitext/commonmark/internal/blocks/HtmlType1BlockTest.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark.tests/src/test/java/org/eclipse/mylyn/wikitext/commonmark/internal/blocks/HtmlType1BlockTest.java
@@ -19,6 +19,7 @@ import static org.junit.Assert.assertEquals;
 import org.eclipse.mylyn.wikitext.commonmark.internal.LineSequence;
 import org.junit.Test;
 
+@SuppressWarnings("nls")
 public class HtmlType1BlockTest {
 
 	private final HtmlType1Block block = new HtmlType1Block();

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark.tests/src/test/java/org/eclipse/mylyn/wikitext/commonmark/internal/blocks/IndentedCodeBlockTest.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark.tests/src/test/java/org/eclipse/mylyn/wikitext/commonmark/internal/blocks/IndentedCodeBlockTest.java
@@ -21,6 +21,7 @@ import static org.junit.Assert.assertTrue;
 import org.eclipse.mylyn.wikitext.commonmark.internal.LineSequence;
 import org.junit.Test;
 
+@SuppressWarnings("nls")
 public class IndentedCodeBlockTest {
 
 	private final IndentedCodeBlock block = new IndentedCodeBlock();

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark.tests/src/test/java/org/eclipse/mylyn/wikitext/commonmark/internal/blocks/ListBlockTest.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark.tests/src/test/java/org/eclipse/mylyn/wikitext/commonmark/internal/blocks/ListBlockTest.java
@@ -24,6 +24,7 @@ import java.util.stream.Collectors;
 import org.eclipse.mylyn.wikitext.commonmark.internal.LineSequence;
 import org.junit.Test;
 
+@SuppressWarnings("nls")
 public class ListBlockTest {
 
 	@Test

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark.tests/src/test/java/org/eclipse/mylyn/wikitext/commonmark/internal/blocks/ParagraphBlockTest.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark.tests/src/test/java/org/eclipse/mylyn/wikitext/commonmark/internal/blocks/ParagraphBlockTest.java
@@ -23,6 +23,7 @@ import java.util.List;
 import org.eclipse.mylyn.wikitext.commonmark.internal.LineSequence;
 import org.junit.Test;
 
+@SuppressWarnings("nls")
 public class ParagraphBlockTest {
 
 	private final ParagraphBlock block = new ParagraphBlock();

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark.tests/src/test/java/org/eclipse/mylyn/wikitext/commonmark/internal/blocks/SetextHeaderBlockTest.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark.tests/src/test/java/org/eclipse/mylyn/wikitext/commonmark/internal/blocks/SetextHeaderBlockTest.java
@@ -21,6 +21,7 @@ import static org.junit.Assert.assertTrue;
 import org.eclipse.mylyn.wikitext.commonmark.internal.LineSequence;
 import org.junit.Test;
 
+@SuppressWarnings("nls")
 public class SetextHeaderBlockTest {
 
 	private final SetextHeaderBlock block = new SetextHeaderBlock();

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark.tests/src/test/java/org/eclipse/mylyn/wikitext/commonmark/internal/inlines/AutoLinkSpanTest.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark.tests/src/test/java/org/eclipse/mylyn/wikitext/commonmark/internal/inlines/AutoLinkSpanTest.java
@@ -19,6 +19,7 @@ import static org.junit.Assert.assertEquals;
 
 import org.junit.Test;
 
+@SuppressWarnings("nls")
 public class AutoLinkSpanTest extends AbstractSourceSpanTest {
 
 	public AutoLinkSpanTest() {

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark.tests/src/test/java/org/eclipse/mylyn/wikitext/commonmark/internal/inlines/AutoLinkWithoutDemarcationSpanTest.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark.tests/src/test/java/org/eclipse/mylyn/wikitext/commonmark/internal/inlines/AutoLinkWithoutDemarcationSpanTest.java
@@ -19,6 +19,7 @@ import static org.junit.Assert.assertEquals;
 
 import org.junit.Test;
 
+@SuppressWarnings("nls")
 public class AutoLinkWithoutDemarcationSpanTest extends AbstractSourceSpanTest {
 
 	public AutoLinkWithoutDemarcationSpanTest() {

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark.tests/src/test/java/org/eclipse/mylyn/wikitext/commonmark/internal/inlines/BackslashEscapeSpanTest.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark.tests/src/test/java/org/eclipse/mylyn/wikitext/commonmark/internal/inlines/BackslashEscapeSpanTest.java
@@ -18,6 +18,7 @@ import static org.junit.Assert.assertEquals;
 
 import org.junit.Test;
 
+@SuppressWarnings("nls")
 public class BackslashEscapeSpanTest extends AbstractSourceSpanTest {
 
 	public BackslashEscapeSpanTest() {

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark.tests/src/test/java/org/eclipse/mylyn/wikitext/commonmark/internal/inlines/CodeSpanTest.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark.tests/src/test/java/org/eclipse/mylyn/wikitext/commonmark/internal/inlines/CodeSpanTest.java
@@ -19,6 +19,7 @@ import static org.junit.Assert.assertEquals;
 
 import org.junit.Test;
 
+@SuppressWarnings("nls")
 public class CodeSpanTest extends AbstractSourceSpanTest {
 
 	public CodeSpanTest() {

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark.tests/src/test/java/org/eclipse/mylyn/wikitext/commonmark/internal/inlines/CursorTest.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark.tests/src/test/java/org/eclipse/mylyn/wikitext/commonmark/internal/inlines/CursorTest.java
@@ -28,6 +28,7 @@ import org.eclipse.mylyn.wikitext.commonmark.internal.LineSequence;
 import org.eclipse.mylyn.wikitext.commonmark.internal.TextSegment;
 import org.junit.Test;
 
+@SuppressWarnings("nls")
 public class CursorTest {
 
 	@Test(expected = NullPointerException.class)

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark.tests/src/test/java/org/eclipse/mylyn/wikitext/commonmark/internal/inlines/HtmlEntitySpanTest.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark.tests/src/test/java/org/eclipse/mylyn/wikitext/commonmark/internal/inlines/HtmlEntitySpanTest.java
@@ -19,6 +19,7 @@ import static org.junit.Assert.assertEquals;
 
 import org.junit.Test;
 
+@SuppressWarnings("nls")
 public class HtmlEntitySpanTest extends AbstractSourceSpanTest {
 
 	public HtmlEntitySpanTest() {

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark.tests/src/test/java/org/eclipse/mylyn/wikitext/commonmark/internal/inlines/HtmlTagSpanTest.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark.tests/src/test/java/org/eclipse/mylyn/wikitext/commonmark/internal/inlines/HtmlTagSpanTest.java
@@ -18,6 +18,7 @@ import static org.eclipse.mylyn.wikitext.commonmark.internal.inlines.Cursors.cre
 
 import org.junit.Test;
 
+@SuppressWarnings("nls")
 public class HtmlTagSpanTest extends AbstractSourceSpanTest {
 
 	public HtmlTagSpanTest() {

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark.tests/src/test/java/org/eclipse/mylyn/wikitext/commonmark/internal/inlines/InlineParserTest.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark.tests/src/test/java/org/eclipse/mylyn/wikitext/commonmark/internal/inlines/InlineParserTest.java
@@ -27,6 +27,7 @@ import org.eclipse.mylyn.wikitext.commonmark.internal.ProcessingContext;
 import org.eclipse.mylyn.wikitext.commonmark.internal.TextSegment;
 import org.junit.Test;
 
+@SuppressWarnings("nls")
 public class InlineParserTest {
 
 	private final Line line = new Line(0, 1, "test");

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark.tests/src/test/java/org/eclipse/mylyn/wikitext/commonmark/internal/inlines/InlineTest.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark.tests/src/test/java/org/eclipse/mylyn/wikitext/commonmark/internal/inlines/InlineTest.java
@@ -25,6 +25,7 @@ import org.eclipse.mylyn.wikitext.parser.DocumentBuilder;
 import org.eclipse.mylyn.wikitext.parser.Locator;
 import org.junit.Test;
 
+@SuppressWarnings("nls")
 public class InlineTest {
 
 	@Test

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark.tests/src/test/java/org/eclipse/mylyn/wikitext/commonmark/internal/inlines/LineBreakSpanTest.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark.tests/src/test/java/org/eclipse/mylyn/wikitext/commonmark/internal/inlines/LineBreakSpanTest.java
@@ -18,6 +18,7 @@ import static org.eclipse.mylyn.wikitext.commonmark.internal.inlines.Cursors.cre
 
 import org.junit.Test;
 
+@SuppressWarnings("nls")
 public class LineBreakSpanTest extends AbstractSourceSpanTest {
 
 	public LineBreakSpanTest() {

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark.tests/src/test/java/org/eclipse/mylyn/wikitext/commonmark/internal/inlines/PotentialBracketEndDelimiterTest.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark.tests/src/test/java/org/eclipse/mylyn/wikitext/commonmark/internal/inlines/PotentialBracketEndDelimiterTest.java
@@ -27,6 +27,7 @@ import org.junit.Test;
 import com.google.common.escape.Escaper;
 import com.google.common.net.UrlEscapers;
 
+@SuppressWarnings("nls")
 public class PotentialBracketEndDelimiterTest {
 
 	private final Line line = new Line(0, 1, "test");

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark.tests/src/test/java/org/eclipse/mylyn/wikitext/commonmark/internal/inlines/PotentialBracketSpanTest.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark.tests/src/test/java/org/eclipse/mylyn/wikitext/commonmark/internal/inlines/PotentialBracketSpanTest.java
@@ -16,6 +16,7 @@ package org.eclipse.mylyn.wikitext.commonmark.internal.inlines;
 
 import org.junit.Test;
 
+@SuppressWarnings("nls")
 public class PotentialBracketSpanTest extends AbstractSourceSpanTest {
 
 	public PotentialBracketSpanTest() {

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark.tests/src/test/java/org/eclipse/mylyn/wikitext/commonmark/internal/inlines/PotentialEmphasisSpanTest.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark.tests/src/test/java/org/eclipse/mylyn/wikitext/commonmark/internal/inlines/PotentialEmphasisSpanTest.java
@@ -23,6 +23,7 @@ import org.eclipse.mylyn.wikitext.commonmark.internal.Line;
 import org.eclipse.mylyn.wikitext.commonmark.internal.TextSegment;
 import org.junit.Test;
 
+@SuppressWarnings("nls")
 public class PotentialEmphasisSpanTest extends AbstractSourceSpanTest {
 
 	public PotentialEmphasisSpanTest() {

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark.tests/src/test/java/org/eclipse/mylyn/wikitext/commonmark/internal/inlines/StringCharactersSpanTest.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark.tests/src/test/java/org/eclipse/mylyn/wikitext/commonmark/internal/inlines/StringCharactersSpanTest.java
@@ -18,6 +18,7 @@ import static org.eclipse.mylyn.wikitext.commonmark.internal.inlines.Cursors.cre
 
 import org.junit.Test;
 
+@SuppressWarnings("nls")
 public class StringCharactersSpanTest extends AbstractSourceSpanTest {
 
 	public StringCharactersSpanTest() {

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark.tests/src/test/java/org/eclipse/mylyn/wikitext/commonmark/internal/spec/tests/CommonMarkSpecTest.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark.tests/src/test/java/org/eclipse/mylyn/wikitext/commonmark/internal/spec/tests/CommonMarkSpecTest.java
@@ -47,6 +47,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.io.CharStreams;
 import com.google.common.io.Resources;
 
+@SuppressWarnings("nls")
 @RunWith(Parameterized.class)
 public class CommonMarkSpecTest {
 
@@ -71,7 +72,7 @@ public class CommonMarkSpecTest {
 			4425, // Lists
 			4664, // Lists
 			4681 // Lists
-	);
+			);
 
 	public static class Expectation {
 

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark.tests/src/test/java/org/eclipse/mylyn/wikitext/commonmark/internal/spec/tests/SimplifiedHtmlDocumentBuilder.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark.tests/src/test/java/org/eclipse/mylyn/wikitext/commonmark/internal/spec/tests/SimplifiedHtmlDocumentBuilder.java
@@ -22,6 +22,7 @@ import org.eclipse.mylyn.wikitext.parser.Attributes;
 import org.eclipse.mylyn.wikitext.parser.ImageAttributes;
 import org.eclipse.mylyn.wikitext.parser.builder.HtmlDocumentBuilder;
 
+@SuppressWarnings("nls")
 public class SimplifiedHtmlDocumentBuilder extends HtmlDocumentBuilder {
 
 	public SimplifiedHtmlDocumentBuilder(Writer out) {

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark.tests/src/test/java/org/eclipse/mylyn/wikitext/commonmark/tests/CommonMarkLanguageDocumentOffsetsTest.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark.tests/src/test/java/org/eclipse/mylyn/wikitext/commonmark/tests/CommonMarkLanguageDocumentOffsetsTest.java
@@ -29,6 +29,7 @@ import org.eclipse.mylyn.wikitext.parser.builder.HtmlDocumentBuilder;
 import org.eclipse.mylyn.wikitext.util.LocatorImpl;
 import org.junit.Test;
 
+@SuppressWarnings("nls")
 public class CommonMarkLanguageDocumentOffsetsTest {
 
 	@Test

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark.tests/src/test/java/org/eclipse/mylyn/wikitext/commonmark/tests/CommonMarkLanguageTest.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark.tests/src/test/java/org/eclipse/mylyn/wikitext/commonmark/tests/CommonMarkLanguageTest.java
@@ -41,6 +41,7 @@ import org.eclipse.mylyn.wikitext.parser.markup.MarkupLanguage;
 import org.eclipse.mylyn.wikitext.util.ServiceLocator;
 import org.junit.Test;
 
+@SuppressWarnings("nls")
 public class CommonMarkLanguageTest {
 
 	private final CommonMarkLanguage language = new CommonMarkLanguage();

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark/META-INF/MANIFEST.MF
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark/META-INF/MANIFEST.MF
@@ -1,4 +1,5 @@
 Manifest-Version: 1.0
+Automatic-Module-Name: org.eclipse.mylyn.wikitext.commonmark
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.eclipse.mylyn.wikitext.commonmark
 Bundle-Version: 4.2.0.qualifier

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark/src/main/java/org/eclipse/mylyn/wikitext/commonmark/CommonMarkLanguage.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark/src/main/java/org/eclipse/mylyn/wikitext/commonmark/CommonMarkLanguage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015 David Green.
+ * Copyright (c) 2015, 2024 David Green and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -9,6 +9,7 @@
  *
  * Contributors:
  *     David Green - initial API and implementation
+ *     Alexander Fedorov (ArSysOp) - ongoing support
  *******************************************************************************/
 package org.eclipse.mylyn.wikitext.commonmark;
 
@@ -34,7 +35,7 @@ public class CommonMarkLanguage extends MarkupLanguage {
 	private boolean strictlyConforming = false;
 
 	public CommonMarkLanguage() {
-		setName("CommonMark");
+		setName("CommonMark"); //$NON-NLS-1$
 	}
 
 	@Override

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark/src/main/java/org/eclipse/mylyn/wikitext/commonmark/internal/CommonMarkIdGenerationStrategy.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark/src/main/java/org/eclipse/mylyn/wikitext/commonmark/internal/CommonMarkIdGenerationStrategy.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015 David Green.
+ * Copyright (c) 2015, 2024 David Green and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -9,6 +9,7 @@
  *
  * Contributors:
  *     David Green - initial API and implementation
+ *     Alexander Fedorov (ArSysOp) - ongoing support
  *******************************************************************************/
 
 package org.eclipse.mylyn.wikitext.commonmark.internal;
@@ -25,7 +26,7 @@ public class CommonMarkIdGenerationStrategy extends IdGenerationStrategy {
 
 	@Override
 	public String generateId(String headingText) {
-		String id = headingText.toLowerCase(Locale.ENGLISH).replaceAll("[^a-z0-9_]", "-");
+		String id = headingText.toLowerCase(Locale.ENGLISH).replaceAll("[^a-z0-9_]", "-"); //$NON-NLS-1$//$NON-NLS-2$
 		id = hyphenMatcher.trimAndCollapseFrom(id, '-');
 		return id;
 	}

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark/src/main/java/org/eclipse/mylyn/wikitext/commonmark/internal/Line.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark/src/main/java/org/eclipse/mylyn/wikitext/commonmark/internal/Line.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015 David Green.
+ * Copyright (c) 2015, 2024 David Green and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -9,6 +9,7 @@
  *
  * Contributors:
  *     David Green - initial API and implementation
+ *     Alexander Fedorov (ArSysOp) - ongoing support
  *******************************************************************************/
 
 package org.eclipse.mylyn.wikitext.commonmark.internal;
@@ -83,9 +84,9 @@ public class Line {
 
 	@Override
 	public String toString() {
-		return toStringHelper(Line.class).add("lineNumber", lineNumber)
-				.add("offset", offset)
-				.add("text", ToStringHelper.toStringValue(text))
+		return toStringHelper(Line.class).add("lineNumber", lineNumber) //$NON-NLS-1$
+				.add("offset", offset) //$NON-NLS-1$
+				.add("text", ToStringHelper.toStringValue(text)) //$NON-NLS-1$
 				.toString();
 	}
 }

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark/src/main/java/org/eclipse/mylyn/wikitext/commonmark/internal/LinePredicates.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark/src/main/java/org/eclipse/mylyn/wikitext/commonmark/internal/LinePredicates.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2021 David Green.
+ * Copyright (c) 2015, 2024 David Green and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -9,6 +9,7 @@
  *
  * Contributors:
  *     David Green - initial API and implementation
+ *     Alexander Fedorov (ArSysOp) - ongoing support
  *******************************************************************************/
 
 package org.eclipse.mylyn.wikitext.commonmark.internal;
@@ -23,7 +24,7 @@ public class LinePredicates {
 
 			@Override
 			public String toString() {
-				return "empty(line)";
+				return "empty(line)"; //$NON-NLS-1$
 			}
 
 			@Override
@@ -38,7 +39,7 @@ public class LinePredicates {
 
 			@Override
 			public String toString() {
-				return "matches(" + pattern.pattern() + ")";
+				return "matches(" + pattern.pattern() + ")"; //$NON-NLS-1$//$NON-NLS-2$
 			}
 
 			@Override

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark/src/main/java/org/eclipse/mylyn/wikitext/commonmark/internal/LineSequence.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark/src/main/java/org/eclipse/mylyn/wikitext/commonmark/internal/LineSequence.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2021 David Green.
+ * Copyright (c) 2015, 2024 David Green and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -9,6 +9,7 @@
  *
  * Contributors:
  *     David Green - initial API and implementation
+ *     Alexander Fedorov (ArSysOp) - ongoing support
  *******************************************************************************/
 
 package org.eclipse.mylyn.wikitext.commonmark.internal;
@@ -66,8 +67,8 @@ public abstract class LineSequence implements Iterable<Line> {
 
 	@Override
 	public String toString() {
-		return toStringHelper(LineSequence.class).add("currentLine", getCurrentLine())
-				.add("nextLine", getNextLine())
+		return toStringHelper(LineSequence.class).add("currentLine", getCurrentLine()) //$NON-NLS-1$
+				.add("nextLine", getNextLine()) //$NON-NLS-1$
 				.toString();
 	}
 }

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark/src/main/java/org/eclipse/mylyn/wikitext/commonmark/internal/ProcessingContext.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark/src/main/java/org/eclipse/mylyn/wikitext/commonmark/internal/ProcessingContext.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2022 David Green and others.
+ * Copyright (c) 2015, 2024 David Green and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -9,6 +9,7 @@
  *
  * Contributors:
  *     David Green - initial API and implementation
+ *     Alexander Fedorov (ArSysOp) - ongoing support
  *******************************************************************************/
 
 package org.eclipse.mylyn.wikitext.commonmark.internal;
@@ -74,7 +75,7 @@ public class ProcessingContext {
 	}
 
 	public String generateHeadingId(int headingLevel, String headingText) {
-		return idGenerator.newId("h" + headingLevel, headingText);
+		return idGenerator.newId("h" + headingLevel, headingText); //$NON-NLS-1$
 	}
 
 	public InlineParser getInlineParser() {

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark/src/main/java/org/eclipse/mylyn/wikitext/commonmark/internal/SimpleLocator.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark/src/main/java/org/eclipse/mylyn/wikitext/commonmark/internal/SimpleLocator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015 David Green.
+ * Copyright (c) 2015, 2024 David Green and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -9,6 +9,7 @@
  *
  * Contributors:
  *     David Green - initial API and implementation
+ *     Alexander Fedorov (ArSysOp) - ongoing support
  *******************************************************************************/
 
 package org.eclipse.mylyn.wikitext.commonmark.internal;
@@ -75,11 +76,11 @@ public class SimpleLocator implements Locator {
 
 	@Override
 	public String toString() {
-		return toStringHelper(Locator.class).add("lineNumber", lineNumber)
-				.add("lineDocumentOffset", lineDocumentOffset)
-				.add("lineLength", lineLength)
-				.add("lineCharacterOffset", lineCharacterOffset)
-				.add("lineSegmentEndOffset", lineSegmentEndOffset)
+		return toStringHelper(Locator.class).add("lineNumber", lineNumber) //$NON-NLS-1$
+				.add("lineDocumentOffset", lineDocumentOffset) //$NON-NLS-1$
+				.add("lineLength", lineLength) //$NON-NLS-1$
+				.add("lineCharacterOffset", lineCharacterOffset) //$NON-NLS-1$
+				.add("lineSegmentEndOffset", lineSegmentEndOffset) //$NON-NLS-1$
 				.toString();
 	}
 }

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark/src/main/java/org/eclipse/mylyn/wikitext/commonmark/internal/TextSegment.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark/src/main/java/org/eclipse/mylyn/wikitext/commonmark/internal/TextSegment.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015 David Green.
+ * Copyright (c) 2015, 2024 David Green and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -9,6 +9,7 @@
  *
  * Contributors:
  *     David Green - initial API and implementation
+ *     Alexander Fedorov (ArSysOp) - ongoing support
  *******************************************************************************/
 
 package org.eclipse.mylyn.wikitext.commonmark.internal;
@@ -33,10 +34,10 @@ public class TextSegment {
 	}
 
 	private static String computeText(List<Line> lines) {
-		String text = "";
+		String text = ""; //$NON-NLS-1$
 		for (Line line : lines) {
 			if (text.length() > 0) {
-				text += "\n";
+				text += "\n"; //$NON-NLS-1$
 			}
 			text += line.getText();
 		}
@@ -81,7 +82,7 @@ public class TextSegment {
 
 	@Override
 	public String toString() {
-		return toStringHelper(TextSegment.class).add("text", ToStringHelper.toStringValue(text)).toString();
+		return toStringHelper(TextSegment.class).add("text", ToStringHelper.toStringValue(text)).toString(); //$NON-NLS-1$
 	}
 
 	public Line getLineAtOffset(int textOffset) {

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark/src/main/java/org/eclipse/mylyn/wikitext/commonmark/internal/ToStringHelper.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark/src/main/java/org/eclipse/mylyn/wikitext/commonmark/internal/ToStringHelper.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015 David Green.
+ * Copyright (c) 2015, 2024 David Green and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -9,13 +9,14 @@
  *
  * Contributors:
  *     David Green - initial API and implementation
+ *     Alexander Fedorov (ArSysOp) - ongoing support
  *******************************************************************************/
 
 package org.eclipse.mylyn.wikitext.commonmark.internal;
 
 public class ToStringHelper {
 
-	private static final String ELIPSES = "...";
+	private static final String ELIPSES = "..."; //$NON-NLS-1$
 
 	private static final int STRING_MAX_LENGTH = 20;
 
@@ -27,7 +28,7 @@ public class ToStringHelper {
 		if (stringValue.length() > 20) {
 			stringValue = stringValue.substring(0, STRING_MAX_LENGTH) + ELIPSES;
 		}
-		return stringValue.replace("\t", "\\t").replace("\n", "\\n").replace("\r", "\\r");
+		return stringValue.replace("\t", "\\t").replace("\n", "\\n").replace("\r", "\\r"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$ //$NON-NLS-5$ //$NON-NLS-6$
 	}
 
 	private ToStringHelper() {

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark/src/main/java/org/eclipse/mylyn/wikitext/commonmark/internal/blocks/AbstractHtmlBlock.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark/src/main/java/org/eclipse/mylyn/wikitext/commonmark/internal/blocks/AbstractHtmlBlock.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015 David Green.
+ * Copyright (c) 2015, 2024 David Green and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -33,7 +33,7 @@ abstract class AbstractHtmlBlock extends SourceBlock {
 		while (line != null) {
 			String lineText = line.getText();
 			builder.charactersUnescaped(lineText);
-			builder.charactersUnescaped("\n");
+			builder.charactersUnescaped("\n"); //$NON-NLS-1$
 
 			lineSequence.advance();
 

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark/src/main/java/org/eclipse/mylyn/wikitext/commonmark/internal/blocks/AtxHeaderBlock.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark/src/main/java/org/eclipse/mylyn/wikitext/commonmark/internal/blocks/AtxHeaderBlock.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015 David Green.
+ * Copyright (c) 2015, 2024 David Green and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -9,6 +9,7 @@
  *
  * Contributors:
  *     David Green - initial API and implementation
+ *     Alexander Fedorov (ArSysOp) - ongoing support
  *******************************************************************************/
 
 package org.eclipse.mylyn.wikitext.commonmark.internal.blocks;
@@ -30,7 +31,7 @@ import org.eclipse.mylyn.wikitext.parser.HeadingAttributes;
 
 public class AtxHeaderBlock extends SourceBlock {
 
-	private static final Pattern PATTERN = Pattern.compile(" {0,3}(#{1,6})(?:[ \t]+?(.+?))??(?:[ \t]+#+)?[ \t]*");
+	private static final Pattern PATTERN = Pattern.compile(" {0,3}(#{1,6})(?:[ \t]+?(.+?))??(?:[ \t]+#+)?[ \t]*"); //$NON-NLS-1$
 
 	@Override
 	public void process(ProcessingContext context, DocumentBuilder builder, LineSequence lineSequence) {

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark/src/main/java/org/eclipse/mylyn/wikitext/commonmark/internal/blocks/BlockQuoteBlock.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark/src/main/java/org/eclipse/mylyn/wikitext/commonmark/internal/blocks/BlockQuoteBlock.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2021 David Green.
+ * Copyright (c) 2015, 2024 David Green.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -9,6 +9,7 @@
  *
  * Contributors:
  *     David Green - initial API and implementation
+ *     Alexander Fedorov (ArSysOp) - ongoing support
  *******************************************************************************/
 
 package org.eclipse.mylyn.wikitext.commonmark.internal.blocks;
@@ -33,7 +34,7 @@ import org.eclipse.mylyn.wikitext.parser.DocumentBuilder.BlockType;
 
 public class BlockQuoteBlock extends BlockWithNestedBlocks {
 
-	private static final Pattern START_PATTERN = Pattern.compile("\\s{0,3}>\\s?(.*)");
+	private static final Pattern START_PATTERN = Pattern.compile("\\s{0,3}>\\s?(.*)"); //$NON-NLS-1$
 
 	@Override
 	public void process(ProcessingContext context, DocumentBuilder builder, LineSequence lineSequence) {

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark/src/main/java/org/eclipse/mylyn/wikitext/commonmark/internal/blocks/FencedCodeBlock.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark/src/main/java/org/eclipse/mylyn/wikitext/commonmark/internal/blocks/FencedCodeBlock.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2021 David Green.
+ * Copyright (c) 2015, 2024 David Green.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -9,6 +9,7 @@
  *
  * Contributors:
  *     David Green - initial API and implementation
+ *     Alexander Fedorov (ArSysOp) - ongoing support
  *******************************************************************************/
 
 package org.eclipse.mylyn.wikitext.commonmark.internal.blocks;
@@ -32,7 +33,7 @@ import org.eclipse.mylyn.wikitext.parser.DocumentBuilder.BlockType;
 
 public class FencedCodeBlock extends SourceBlock {
 
-	private final Pattern openingFencePattern = Pattern.compile("(\\s{0,4})(`{3,}|~{3,})\\s*(?:([^\\s~`]+)[^~`]*)?");
+	private final Pattern openingFencePattern = Pattern.compile("(\\s{0,4})(`{3,}|~{3,})\\s*(?:([^\\s~`]+)[^~`]*)?"); //$NON-NLS-1$
 
 	@Override
 	public void process(ProcessingContext context, DocumentBuilder builder, LineSequence lineSequence) {
@@ -67,12 +68,12 @@ public class FencedCodeBlock extends SourceBlock {
 		String text = line.getText();
 		text = removeIndent(indent, text);
 		builder.characters(text);
-		builder.characters("\n");
+		builder.characters("\n"); //$NON-NLS-1$
 	}
 
 	private String removeIndent(String indent, String text) {
 		if (indent != null && indent.length() > 0) {
-			Pattern indentPattern = Pattern.compile("\\s{1," + indent.length() + "}(.*)");
+			Pattern indentPattern = Pattern.compile("\\s{1," + indent.length() + "}(.*)"); //$NON-NLS-1$ //$NON-NLS-2$
 			Matcher matcher = indentPattern.matcher(text);
 			if (matcher.matches()) {
 				return matcher.group(1);
@@ -84,7 +85,7 @@ public class FencedCodeBlock extends SourceBlock {
 	private Pattern closingFencePattern(Matcher matcher) {
 		String fence = matcher.group(2);
 		char fenceDelimiter = fence.charAt(0);
-		return Pattern.compile("\\s{0,3}" + fenceDelimiter + "{" + fence.length() + ",}\\s*");
+		return Pattern.compile("\\s{0,3}" + fenceDelimiter + "{" + fence.length() + ",}\\s*"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
 	}
 
 	private void addInfoTextCssClass(ProcessingContext processingContext, Attributes codeAttributes, Matcher matcher) {
@@ -93,7 +94,7 @@ public class FencedCodeBlock extends SourceBlock {
 			InlineParser inlineParser = processingContext.getInlineParser();
 			String language = inlineParser.toStringContent(processingContext,
 					new TextSegment(Collections.singletonList(new Line(0, 0, infoText))));
-			codeAttributes.setCssClass("language-" + language);
+			codeAttributes.setCssClass("language-" + language); //$NON-NLS-1$
 		}
 	}
 

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark/src/main/java/org/eclipse/mylyn/wikitext/commonmark/internal/blocks/HorizontalRuleBlock.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark/src/main/java/org/eclipse/mylyn/wikitext/commonmark/internal/blocks/HorizontalRuleBlock.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015 David Green.
+ * Copyright (c) 2015, 2024 David Green and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -9,6 +9,7 @@
  *
  * Contributors:
  *     David Green - initial API and implementation
+ *     Alexander Fedorov (ArSysOp) - ongoing support
  *******************************************************************************/
 
 package org.eclipse.mylyn.wikitext.commonmark.internal.blocks;
@@ -23,7 +24,7 @@ import org.eclipse.mylyn.wikitext.parser.DocumentBuilder;
 
 public class HorizontalRuleBlock extends SourceBlock {
 
-	private static final Pattern PATTERN = Pattern.compile(" {0,3}((\\*[ \t]*){3,}|(-[ \t]*){3,}|(_[ \t]*){3,})");
+	private static final Pattern PATTERN = Pattern.compile(" {0,3}((\\*[ \t]*){3,}|(-[ \t]*){3,}|(_[ \t]*){3,})"); //$NON-NLS-1$
 
 	@Override
 	public void process(ProcessingContext context, DocumentBuilder builder, LineSequence lineSequence) {

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark/src/main/java/org/eclipse/mylyn/wikitext/commonmark/internal/blocks/HtmlBlock.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark/src/main/java/org/eclipse/mylyn/wikitext/commonmark/internal/blocks/HtmlBlock.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015 David Green.
+ * Copyright (c) 2015, 2024 David Green and other.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -9,6 +9,7 @@
  *
  * Contributors:
  *     David Green - initial API and implementation
+ *     Alexander Fedorov (ArSysOp) - ongoing support
  *******************************************************************************/
 
 package org.eclipse.mylyn.wikitext.commonmark.internal.blocks;
@@ -23,9 +24,9 @@ import org.eclipse.mylyn.wikitext.parser.DocumentBuilder;
 
 public class HtmlBlock extends SourceBlock {
 
-	private static final String BLOCK_TAG_NAMES = "address|article|aside|base|basefont|blockquote|body|button|canvas|caption|center|col|colgroup|dd|details|dialog|dir|div|dl|dt|embed|fieldset|figcaption|figure|footer|form|frame|frameset|h1|h2|h3|h4|h5|h6|head|header|hgroup|hr|html|iframe|legend|li|link|main|map|menu|menuitem|meta|nav|noframes|object|ol|optgroup|option|output|p|param|progress|section|source|summary|table|tbody|td|textarea|tfoot|th|thead|title|tr|track|ul|video";
+	private static final String BLOCK_TAG_NAMES = "address|article|aside|base|basefont|blockquote|body|button|canvas|caption|center|col|colgroup|dd|details|dialog|dir|div|dl|dt|embed|fieldset|figcaption|figure|footer|form|frame|frameset|h1|h2|h3|h4|h5|h6|head|header|hgroup|hr|html|iframe|legend|li|link|main|map|menu|menuitem|meta|nav|noframes|object|ol|optgroup|option|output|p|param|progress|section|source|summary|table|tbody|td|textarea|tfoot|th|thead|title|tr|track|ul|video"; //$NON-NLS-1$
 
-	private final Pattern startPattern = Pattern.compile("\\s{0,3}((</?(?:" + BLOCK_TAG_NAMES + ")(\\s|/>|>)?)).*",
+	private final Pattern startPattern = Pattern.compile("\\s{0,3}((</?(?:" + BLOCK_TAG_NAMES + ")(\\s|/>|>)?)).*", //$NON-NLS-1$ //$NON-NLS-2$
 			Pattern.CASE_INSENSITIVE | Pattern.MULTILINE);
 
 	@Override
@@ -33,7 +34,7 @@ public class HtmlBlock extends SourceBlock {
 		for (Line line = lineSequence.getCurrentLine(); line != null && !line.isEmpty(); lineSequence
 				.advance(), line = lineSequence.getCurrentLine()) {
 			builder.charactersUnescaped(line.getText());
-			builder.charactersUnescaped("\n");
+			builder.charactersUnescaped("\n"); //$NON-NLS-1$
 		}
 	}
 

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark/src/main/java/org/eclipse/mylyn/wikitext/commonmark/internal/blocks/HtmlCdataBlock.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark/src/main/java/org/eclipse/mylyn/wikitext/commonmark/internal/blocks/HtmlCdataBlock.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015 David Green.
+ * Copyright (c) 2015, 2024 David Green and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -9,6 +9,7 @@
  *
  * Contributors:
  *     David Green - initial API and implementation
+ *     Alexander Fedorov (ArSysOp) - ongoing support
  *******************************************************************************/
 
 package org.eclipse.mylyn.wikitext.commonmark.internal.blocks;
@@ -17,9 +18,9 @@ import java.util.regex.Pattern;
 
 public class HtmlCdataBlock extends AbstractHtmlBlock {
 
-	private final Pattern startPattern = Pattern.compile("\\s{0,3}(<!\\[CDATA\\[).*");
+	private final Pattern startPattern = Pattern.compile("\\s{0,3}(<!\\[CDATA\\[).*"); //$NON-NLS-1$
 
-	private final Pattern closePattern = Pattern.compile("]]>");
+	private final Pattern closePattern = Pattern.compile("]]>"); //$NON-NLS-1$
 
 	@Override
 	protected Pattern closePattern() {

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark/src/main/java/org/eclipse/mylyn/wikitext/commonmark/internal/blocks/HtmlCommentBlock.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark/src/main/java/org/eclipse/mylyn/wikitext/commonmark/internal/blocks/HtmlCommentBlock.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015 David Green.
+ * Copyright (c) 2015, 2024 David Green and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -9,6 +9,7 @@
  *
  * Contributors:
  *     David Green - initial API and implementation
+ *     Alexander Fedorov (ArSysOp) - ongoing support
  *******************************************************************************/
 
 package org.eclipse.mylyn.wikitext.commonmark.internal.blocks;
@@ -21,11 +22,11 @@ import org.eclipse.mylyn.wikitext.commonmark.internal.LineSequence;
 
 public class HtmlCommentBlock extends AbstractHtmlBlock {
 
-	private final Pattern startPattern = Pattern.compile("\\s{0,3}(<!--)(?!>|->).*");
+	private final Pattern startPattern = Pattern.compile("\\s{0,3}(<!--)(?!>|->).*"); //$NON-NLS-1$
 
-	private final Pattern doubleHyphen = Pattern.compile("--(?!>)");
+	private final Pattern doubleHyphen = Pattern.compile("--(?!>)"); //$NON-NLS-1$
 
-	private final Pattern closePattern = Pattern.compile("(?<!-)-->");
+	private final Pattern closePattern = Pattern.compile("(?<!-)-->"); //$NON-NLS-1$
 
 	@Override
 	public boolean canStart(LineSequence lineSequence) {

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark/src/main/java/org/eclipse/mylyn/wikitext/commonmark/internal/blocks/HtmlDoctypeBlock.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark/src/main/java/org/eclipse/mylyn/wikitext/commonmark/internal/blocks/HtmlDoctypeBlock.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015 David Green.
+ * Copyright (c) 2015, 2024 David Green and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -9,6 +9,7 @@
  *
  * Contributors:
  *     David Green - initial API and implementation
+ *     Alexander Fedorov (ArSysOp) - ongoing support
  *******************************************************************************/
 
 package org.eclipse.mylyn.wikitext.commonmark.internal.blocks;
@@ -17,9 +18,9 @@ import java.util.regex.Pattern;
 
 public class HtmlDoctypeBlock extends AbstractHtmlBlock {
 
-	private final Pattern startPattern = Pattern.compile("\\s{0,3}(<![A-Z]).*");
+	private final Pattern startPattern = Pattern.compile("\\s{0,3}(<![A-Z]).*"); //$NON-NLS-1$
 
-	private final Pattern closePattern = Pattern.compile(">");
+	private final Pattern closePattern = Pattern.compile(">"); //$NON-NLS-1$
 
 	@Override
 	protected Pattern closePattern() {

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark/src/main/java/org/eclipse/mylyn/wikitext/commonmark/internal/blocks/HtmlProcessingInstructionBlock.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark/src/main/java/org/eclipse/mylyn/wikitext/commonmark/internal/blocks/HtmlProcessingInstructionBlock.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015 David Green.
+ * Copyright (c) 2015, 2024 David Green and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -9,6 +9,7 @@
  *
  * Contributors:
  *     David Green - initial API and implementation
+ *     Alexander Fedorov (ArSysOp) - ongoing support
  *******************************************************************************/
 
 package org.eclipse.mylyn.wikitext.commonmark.internal.blocks;
@@ -17,9 +18,9 @@ import java.util.regex.Pattern;
 
 public class HtmlProcessingInstructionBlock extends AbstractHtmlBlock {
 
-	private final Pattern startPattern = Pattern.compile("\\s{0,3}(<\\?).*");
+	private final Pattern startPattern = Pattern.compile("\\s{0,3}(<\\?).*"); //$NON-NLS-1$
 
-	private final Pattern closePattern = Pattern.compile("\\?>");
+	private final Pattern closePattern = Pattern.compile("\\?>"); //$NON-NLS-1$
 
 	@Override
 	protected Pattern closePattern() {

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark/src/main/java/org/eclipse/mylyn/wikitext/commonmark/internal/blocks/HtmlType1Block.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark/src/main/java/org/eclipse/mylyn/wikitext/commonmark/internal/blocks/HtmlType1Block.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015 David Green.
+ * Copyright (c) 2015, 2024 David Green and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -9,6 +9,7 @@
  *
  * Contributors:
  *     David Green - initial API and implementation
+ *     Alexander Fedorov (ArSysOp) - ongoing support
  *******************************************************************************/
 
 package org.eclipse.mylyn.wikitext.commonmark.internal.blocks;
@@ -17,10 +18,10 @@ import java.util.regex.Pattern;
 
 public class HtmlType1Block extends AbstractHtmlBlock {
 
-	private final Pattern startPattern = Pattern.compile("\\s{0,3}(<(?:pre|script|style))(\\s|>|$).*",
+	private final Pattern startPattern = Pattern.compile("\\s{0,3}(<(?:pre|script|style))(\\s|>|$).*", //$NON-NLS-1$
 			Pattern.CASE_INSENSITIVE);
 
-	private final Pattern closePattern = Pattern.compile("\\s{0,3}</(?:pre|script|style)\\s*>",
+	private final Pattern closePattern = Pattern.compile("\\s{0,3}</(?:pre|script|style)\\s*>", //$NON-NLS-1$
 			Pattern.CASE_INSENSITIVE | Pattern.MULTILINE);
 
 	@Override

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark/src/main/java/org/eclipse/mylyn/wikitext/commonmark/internal/blocks/HtmlType7Block.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark/src/main/java/org/eclipse/mylyn/wikitext/commonmark/internal/blocks/HtmlType7Block.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015 David Green.
+ * Copyright (c) 2015, 2024 David Green and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -9,6 +9,7 @@
  *
  * Contributors:
  *     David Green - initial API and implementation
+ *     Alexander Fedorov (ArSysOp) - ongoing support
  *******************************************************************************/
 
 package org.eclipse.mylyn.wikitext.commonmark.internal.blocks;
@@ -23,28 +24,28 @@ import org.eclipse.mylyn.wikitext.parser.DocumentBuilder;
 
 public class HtmlType7Block extends SourceBlock {
 
-	private static final String ATTRIBUTE_VALUE_QUOTED = "\"[^\"]*\"";
+	private static final String ATTRIBUTE_VALUE_QUOTED = "\"[^\"]*\""; //$NON-NLS-1$
 
-	private static final String ATTRIBUTE_VALUE_SINGLEQUOTED = "'[^']*'";
+	private static final String ATTRIBUTE_VALUE_SINGLEQUOTED = "'[^']*'"; //$NON-NLS-1$
 
-	private static final String ATTRIBUTE_VALUE_UNQUOTED = "[^ \"'=<>`]+";
+	private static final String ATTRIBUTE_VALUE_UNQUOTED = "[^ \"'=<>`]+"; //$NON-NLS-1$
 
-	private static final String ATTRIBUTE_VALUE = "(?:" + ATTRIBUTE_VALUE_QUOTED + "|" + ATTRIBUTE_VALUE_SINGLEQUOTED
-			+ "|" + ATTRIBUTE_VALUE_UNQUOTED + ")";
+	private static final String ATTRIBUTE_VALUE = "(?:" + ATTRIBUTE_VALUE_QUOTED + "|" + ATTRIBUTE_VALUE_SINGLEQUOTED //$NON-NLS-1$ //$NON-NLS-2$
+			+ "|" + ATTRIBUTE_VALUE_UNQUOTED + ")"; //$NON-NLS-1$ //$NON-NLS-2$
 
-	private static final String ATTRIBUTE_NAME = "[a-z_:][a-z0-9_.:-]*";
+	private static final String ATTRIBUTE_NAME = "[a-z_:][a-z0-9_.:-]*"; //$NON-NLS-1$
 
-	private static final String ATTRIBUTE = "(?:" + ATTRIBUTE_NAME + "(?:\\s*=\\s*" + ATTRIBUTE_VALUE + ")?)";
+	private static final String ATTRIBUTE = "(?:" + ATTRIBUTE_NAME + "(?:\\s*=\\s*" + ATTRIBUTE_VALUE + ")?)"; //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
 
-	private static final String REPEATING_ATTRIBUTE = "(?:\\s+" + ATTRIBUTE + ")*";
+	private static final String REPEATING_ATTRIBUTE = "(?:\\s+" + ATTRIBUTE + ")*"; //$NON-NLS-1$ //$NON-NLS-2$
 
-	private static final String HTML_TAG_NAME = "([a-z][a-z0-9-]*)";
+	private static final String HTML_TAG_NAME = "([a-z][a-z0-9-]*)"; //$NON-NLS-1$
 
 	private final Pattern startPattern = Pattern.compile(
-			"\\s{0,3}<" + HTML_TAG_NAME + REPEATING_ATTRIBUTE + "\\s*/?>\\s*",
+			"\\s{0,3}<" + HTML_TAG_NAME + REPEATING_ATTRIBUTE + "\\s*/?>\\s*", //$NON-NLS-1$ //$NON-NLS-2$
 			Pattern.CASE_INSENSITIVE | Pattern.MULTILINE);
 
-	private final Pattern closePattern = Pattern.compile("\\s{0,3}</" + HTML_TAG_NAME + "\\s*>\\s*",
+	private final Pattern closePattern = Pattern.compile("\\s{0,3}</" + HTML_TAG_NAME + "\\s*>\\s*", //$NON-NLS-1$ //$NON-NLS-2$
 			Pattern.CASE_INSENSITIVE | Pattern.MULTILINE);
 
 	@Override
@@ -52,7 +53,7 @@ public class HtmlType7Block extends SourceBlock {
 		Line line = lineSequence.getCurrentLine();
 		while (line != null && !line.isEmpty()) {
 			builder.charactersUnescaped(line.getText());
-			builder.charactersUnescaped("\n");
+			builder.charactersUnescaped("\n"); //$NON-NLS-1$
 
 			lineSequence.advance();
 			line = lineSequence.getCurrentLine();

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark/src/main/java/org/eclipse/mylyn/wikitext/commonmark/internal/blocks/IndentedCodeBlock.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark/src/main/java/org/eclipse/mylyn/wikitext/commonmark/internal/blocks/IndentedCodeBlock.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2021 David Green.
+ * Copyright (c) 2015, 2024 David Green and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -9,6 +9,7 @@
  *
  * Contributors:
  *     David Green - initial API and implementation
+ *     Alexander Fedorov (ArSysOp) - ongoing support
  *******************************************************************************/
 
 package org.eclipse.mylyn.wikitext.commonmark.internal.blocks;
@@ -30,7 +31,7 @@ import org.eclipse.mylyn.wikitext.parser.DocumentBuilder.BlockType;
 
 public class IndentedCodeBlock extends SourceBlock {
 
-	private static final Pattern PATTERN = Pattern.compile("(?: {0,3}\t| {4})(.*)");
+	private static final Pattern PATTERN = Pattern.compile("(?: {0,3}\t| {4})(.*)"); //$NON-NLS-1$
 
 	@Override
 	public void process(ProcessingContext context, DocumentBuilder builder, LineSequence lineSequence) {
@@ -46,14 +47,14 @@ public class IndentedCodeBlock extends SourceBlock {
 			if (!matcher.matches()) {
 				checkState(line.isEmpty());
 				if (iterator.hasNext()) {
-					builder.characters("\n");
+					builder.characters("\n"); //$NON-NLS-1$
 				}
 			} else {
 				String content = matcher.group(1);
 				if (!content.isEmpty() || blockHasContent && iterator.hasNext()) {
 					blockHasContent = true;
 					builder.characters(content);
-					builder.characters("\n");
+					builder.characters("\n"); //$NON-NLS-1$
 				}
 			}
 		}

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark/src/main/java/org/eclipse/mylyn/wikitext/commonmark/internal/blocks/ListBlock.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark/src/main/java/org/eclipse/mylyn/wikitext/commonmark/internal/blocks/ListBlock.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2021 David Green.
+ * Copyright (c) 2015, 2024 David Green and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -9,6 +9,7 @@
  *
  * Contributors:
  *     David Green - initial API and implementation
+ *     Alexander Fedorov (ArSysOp) - ongoing support
  *******************************************************************************/
 
 package org.eclipse.mylyn.wikitext.commonmark.internal.blocks;
@@ -39,7 +40,7 @@ import com.google.common.base.CharMatcher;
 public class ListBlock extends BlockWithNestedBlocks {
 
 	private final Pattern bulletPattern = Pattern
-			.compile("\\s{0,3}(([*+-])|(([0-9]{0,5})[.)]))(?:(?:\\s(\\s*)(.*))|\\s*$)");
+			.compile("\\s{0,3}(([*+-])|(([0-9]{0,5})[.)]))(?:(?:\\s(\\s*)(.*))|\\s*$)"); //$NON-NLS-1$
 
 	private final HorizontalRuleBlock horizontalRuleBlock = new HorizontalRuleBlock();
 
@@ -62,7 +63,7 @@ public class ListBlock extends BlockWithNestedBlocks {
 	public void createContext(final ProcessingContextBuilder contextBuilder, LineSequence lineSequence) {
 		process(ProcessingContext.builder().build(), new NoOpDocumentBuilder(), lineSequence,
 				(dummyContext, builder, listMode, lineSequence1) -> CommonMark.sourceBlocks()
-						.createContext(contextBuilder, listItemLineSequence(lineSequence1)));
+				.createContext(contextBuilder, listItemLineSequence(lineSequence1)));
 	}
 
 	private void process(ProcessingContext context, DocumentBuilder builder, LineSequence lineSequence,
@@ -259,7 +260,7 @@ public class ListBlock extends BlockWithNestedBlocks {
 		Matcher matcher = bulletPattern.matcher(line.getText());
 		checkState(matcher.matches());
 		String marker = matcher.group(4);
-		if ("1".equals(marker)) {
+		if ("1".equals(marker)) { //$NON-NLS-1$
 			marker = null;
 		}
 		return marker;

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark/src/main/java/org/eclipse/mylyn/wikitext/commonmark/internal/blocks/SetextHeaderBlock.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark/src/main/java/org/eclipse/mylyn/wikitext/commonmark/internal/blocks/SetextHeaderBlock.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015 David Green.
+ * Copyright (c) 2015, 2024 David Green and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -9,6 +9,7 @@
  *
  * Contributors:
  *     David Green - initial API and implementation
+ *     Alexander Fedorov (ArSysOp) - ongoing support
  *******************************************************************************/
 
 package org.eclipse.mylyn.wikitext.commonmark.internal.blocks;
@@ -30,9 +31,9 @@ import org.eclipse.mylyn.wikitext.parser.HeadingAttributes;
 
 public class SetextHeaderBlock extends SourceBlock {
 
-	private final Pattern indentPattern = Pattern.compile("\\s{0,3}\\S.*");
+	private final Pattern indentPattern = Pattern.compile("\\s{0,3}\\S.*"); //$NON-NLS-1$
 
-	private final Pattern setextUnderlinePattern = Pattern.compile("\\s{0,3}((-|=)+)\\s*");
+	private final Pattern setextUnderlinePattern = Pattern.compile("\\s{0,3}((-|=)+)\\s*"); //$NON-NLS-1$
 
 	@Override
 	public void process(ProcessingContext context, DocumentBuilder builder, LineSequence lineSequence) {

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark/src/main/java/org/eclipse/mylyn/wikitext/commonmark/internal/inlines/AutoLinkSpan.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark/src/main/java/org/eclipse/mylyn/wikitext/commonmark/internal/inlines/AutoLinkSpan.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015 David Green.
+ * Copyright (c) 2015, 2024 David Green and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -9,6 +9,7 @@
  *
  * Contributors:
  *     David Green - initial API and implementation
+ *     Alexander Fedorov (ArSysOp) - ongoing support
  *******************************************************************************/
 
 package org.eclipse.mylyn.wikitext.commonmark.internal.inlines;
@@ -23,6 +24,7 @@ import com.google.common.net.UrlEscapers;
 
 public class AutoLinkSpan extends SourceSpan {
 
+	@SuppressWarnings("nls")
 	private static final Set<String> SCHEMES = Set.of("coap", "doi", "javascript", "aaa", "aaas", "about", "acap",
 			"cap", "cid", "crid", "data", "dav", "dict", "dns", "file", "ftp", "geo", "go", "gopher", "h323", "http",
 			"https", "iax", "icap", "im", "imap", "info", "ipp", "iris", "iris.beep", "iris.xpc", "iris.xpcs",
@@ -40,10 +42,10 @@ public class AutoLinkSpan extends SourceSpan {
 			"things", "udp", "unreal", "ut2004", "ventrilo", "view-source", "webcal", "wtai", "wyciwyg", "xfire", "xri",
 			"ymsgr");
 
-	private static final String EMAIL_DOMAIN_PART = "[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?";
+	private static final String EMAIL_DOMAIN_PART = "[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?"; //$NON-NLS-1$
 
-	private static final String EMAIL_REGEX = "[a-z0-9.!#$%&'*+/=?^_`{|}~-]+@" + EMAIL_DOMAIN_PART + "(?:\\."
-			+ EMAIL_DOMAIN_PART + ")*";
+	private static final String EMAIL_REGEX = "[a-z0-9.!#$%&'*+/=?^_`{|}~-]+@" + EMAIL_DOMAIN_PART + "(?:\\." //$NON-NLS-1$ //$NON-NLS-2$
+			+ EMAIL_DOMAIN_PART + ")*"; //$NON-NLS-1$
 
 	private final Pattern linkPattern = createLinkPattern();
 
@@ -57,7 +59,7 @@ public class AutoLinkSpan extends SourceSpan {
 				String link = href;
 				String email = matcher.group(2);
 				if (email != null) {
-					link = "mailto:" + email;
+					link = "mailto:" + email; //$NON-NLS-1$
 				}
 				int endOffset = cursor.getOffset(matcher.end(3));
 				int linkLength = endOffset - cursor.getOffset();
@@ -70,20 +72,20 @@ public class AutoLinkSpan extends SourceSpan {
 	}
 
 	private String escapeUri(String link) {
-		return UrlEscapers.urlFragmentEscaper().escape(link).replace("%23", "#").replace("%25", "%");
+		return UrlEscapers.urlFragmentEscaper().escape(link).replace("%23", "#").replace("%25", "%"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 	}
 
 	private Pattern createLinkPattern() {
-		String regex = "";
+		String regex = ""; //$NON-NLS-1$
 		for (String scheme : SCHEMES) {
 			if (regex.isEmpty()) {
-				regex += "<((?:(?:";
+				regex += "<((?:(?:"; //$NON-NLS-1$
 			} else {
-				regex += "|";
+				regex += "|"; //$NON-NLS-1$
 			}
-			regex += scheme.replace(".", "\\.");
+			regex += scheme.replace(".", "\\."); //$NON-NLS-1$ //$NON-NLS-2$
 		}
-		regex += "):[^\\s>]+)|(" + EMAIL_REGEX + "))(>).*";
+		regex += "):[^\\s>]+)|(" + EMAIL_REGEX + "))(>).*"; //$NON-NLS-1$ //$NON-NLS-2$
 		return Pattern.compile(regex, Pattern.DOTALL | Pattern.CASE_INSENSITIVE);
 	}
 }

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark/src/main/java/org/eclipse/mylyn/wikitext/commonmark/internal/inlines/AutoLinkWithoutDemarcationSpan.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark/src/main/java/org/eclipse/mylyn/wikitext/commonmark/internal/inlines/AutoLinkWithoutDemarcationSpan.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015 David Green.
+ * Copyright (c) 2015, 2024 David Green and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -9,6 +9,7 @@
  *
  * Contributors:
  *     David Green - initial API and implementation
+ *     Alexander Fedorov (ArSysOp) - ongoing support
  *******************************************************************************/
 
 package org.eclipse.mylyn.wikitext.commonmark.internal.inlines;
@@ -23,7 +24,7 @@ import com.google.common.net.UrlEscapers;
 public class AutoLinkWithoutDemarcationSpan extends SourceSpan {
 
 	private final Pattern linkPattern = Pattern
-			.compile("(https?://[a-zA-Z0-9%._~!$&?#'()*+,;:@/=-]*[a-zA-Z0-9_~!$&?#'(*+@/=-]).*", Pattern.DOTALL);
+			.compile("(https?://[a-zA-Z0-9%._~!$&?#'()*+,;:@/=-]*[a-zA-Z0-9_~!$&?#'(*+@/=-]).*", Pattern.DOTALL); //$NON-NLS-1$
 
 	@Override
 	public Optional<? extends Inline> createInline(Cursor cursor) {
@@ -45,6 +46,6 @@ public class AutoLinkWithoutDemarcationSpan extends SourceSpan {
 	}
 
 	private String escapeUri(String link) {
-		return UrlEscapers.urlFragmentEscaper().escape(link).replace("%23", "#").replace("%25", "%");
+		return UrlEscapers.urlFragmentEscaper().escape(link).replace("%23", "#").replace("%25", "%"); //$NON-NLS-1$//$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 	}
 }

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark/src/main/java/org/eclipse/mylyn/wikitext/commonmark/internal/inlines/BackslashEscapeSpan.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark/src/main/java/org/eclipse/mylyn/wikitext/commonmark/internal/inlines/BackslashEscapeSpan.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015 David Green.
+ * Copyright (c) 2015, 2024 David Green and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -9,6 +9,7 @@
  *
  * Contributors:
  *     David Green - initial API and implementation
+ *     Alexander Fedorov (ArSysOp) - ongoing support
  *******************************************************************************/
 
 package org.eclipse.mylyn.wikitext.commonmark.internal.inlines;
@@ -19,7 +20,7 @@ import com.google.common.base.CharMatcher;
 
 public class BackslashEscapeSpan extends SourceSpan {
 
-	private static CharMatcher ESCAPABLE = CharMatcher.anyOf("!\"\\#$%&'()*+,-./:;<=>?@[]^_`{|}~");
+	private static CharMatcher ESCAPABLE = CharMatcher.anyOf("!\"\\#$%&'()*+,-./:;<=>?@[]^_`{|}~"); //$NON-NLS-1$
 
 	@Override
 	public Optional<? extends Inline> createInline(Cursor cursor) {

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark/src/main/java/org/eclipse/mylyn/wikitext/commonmark/internal/inlines/CodeSpan.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark/src/main/java/org/eclipse/mylyn/wikitext/commonmark/internal/inlines/CodeSpan.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015 David Green.
+ * Copyright (c) 2015, 2024 David Green and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -9,6 +9,7 @@
  *
  * Contributors:
  *     David Green - initial API and implementation
+ *     Alexander Fedorov (ArSysOp) - ongoing support
  *******************************************************************************/
 
 package org.eclipse.mylyn.wikitext.commonmark.internal.inlines;
@@ -21,7 +22,7 @@ import com.google.common.base.Strings;
 
 public class CodeSpan extends SourceSpan {
 
-	Pattern pattern = Pattern.compile("(`+).*", Pattern.DOTALL | Pattern.MULTILINE);
+	Pattern pattern = Pattern.compile("(`+).*", Pattern.DOTALL | Pattern.MULTILINE); //$NON-NLS-1$
 
 	@Override
 	public Optional<? extends Inline> createInline(Cursor cursor) {
@@ -31,7 +32,7 @@ public class CodeSpan extends SourceSpan {
 			if (matcher.matches()) {
 				String openingBackticks = matcher.group(1);
 				int backtickCount = openingBackticks.length();
-				Pattern closingPattern = Pattern.compile("(?<!`)(" + Strings.repeat("`", backtickCount) + ")([^`]|$)",
+				Pattern closingPattern = Pattern.compile("(?<!`)(" + Strings.repeat("`", backtickCount) + ")([^`]|$)", //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
 						Pattern.DOTALL | Pattern.MULTILINE);
 				cursor.advance(backtickCount);
 				String textAtOffset = cursor.getTextAtOffset();

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark/src/main/java/org/eclipse/mylyn/wikitext/commonmark/internal/inlines/HtmlEntitySpan.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark/src/main/java/org/eclipse/mylyn/wikitext/commonmark/internal/inlines/HtmlEntitySpan.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015 David Green.
+ * Copyright (c) 2015, 2024 David Green and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -9,6 +9,7 @@
  *
  * Contributors:
  *     David Green - initial API and implementation
+ *     Alexander Fedorov (ArSysOp) - ongoing support
  *******************************************************************************/
 
 package org.eclipse.mylyn.wikitext.commonmark.internal.inlines;
@@ -21,7 +22,7 @@ import org.eclipse.mylyn.wikitext.commonmark.internal.Line;
 
 public class HtmlEntitySpan extends SourceSpan {
 
-	private final Pattern pattern = Pattern.compile("&(#x[a-f0-9]{1,8}|#[0-9]{1,8}|[a-z][a-z0-9]{1,31});.*",
+	private final Pattern pattern = Pattern.compile("&(#x[a-f0-9]{1,8}|#[0-9]{1,8}|[a-z][a-z0-9]{1,31});.*", //$NON-NLS-1$
 			Pattern.CASE_INSENSITIVE | Pattern.DOTALL);
 
 	@Override
@@ -37,7 +38,7 @@ public class HtmlEntitySpan extends SourceSpan {
 				Line lineAtOffset = cursor.getLineAtOffset();
 
 				if (isInvalidUnicodeCodepoint(ent)) {
-					return Optional.of(new Characters(lineAtOffset, offset, length, "\ufffd"));
+					return Optional.of(new Characters(lineAtOffset, offset, length, "\ufffd")); //$NON-NLS-1$
 				}
 				return Optional.of(new HtmlEntity(lineAtOffset, offset, length, ent));
 			}

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark/src/main/java/org/eclipse/mylyn/wikitext/commonmark/internal/inlines/HtmlTagSpan.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark/src/main/java/org/eclipse/mylyn/wikitext/commonmark/internal/inlines/HtmlTagSpan.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015 David Green.
+ * Copyright (c) 2015, 2024 David Green and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -9,6 +9,7 @@
  *
  * Contributors:
  *     David Green - initial API and implementation
+ *     Alexander Fedorov (ArSysOp) - ongoing support
  *******************************************************************************/
 
 package org.eclipse.mylyn.wikitext.commonmark.internal.inlines;
@@ -19,33 +20,33 @@ import java.util.regex.Pattern;
 
 public class HtmlTagSpan extends SourceSpan {
 
-	private static final String ATTRIBUTE_VALUE_QUOTED = "\"[^\"]*\"";
+	private static final String ATTRIBUTE_VALUE_QUOTED = "\"[^\"]*\""; //$NON-NLS-1$
 
-	private static final String ATTRIBUTE_VALUE_SINGLEQUOTED = "'[^']*'";
+	private static final String ATTRIBUTE_VALUE_SINGLEQUOTED = "'[^']*'"; //$NON-NLS-1$
 
-	private static final String ATTRIBUTE_VALUE_UNQUOTED = "[^\"'<>=]+";
+	private static final String ATTRIBUTE_VALUE_UNQUOTED = "[^\"'<>=]+"; //$NON-NLS-1$
 
-	private static final String ATTRIBUTE_VALUE = "(?:" + ATTRIBUTE_VALUE_QUOTED + "|" + ATTRIBUTE_VALUE_SINGLEQUOTED
-			+ "|" + ATTRIBUTE_VALUE_UNQUOTED + ")";
+	private static final String ATTRIBUTE_VALUE = "(?:" + ATTRIBUTE_VALUE_QUOTED + "|" + ATTRIBUTE_VALUE_SINGLEQUOTED //$NON-NLS-1$ //$NON-NLS-2$
+			+ "|" + ATTRIBUTE_VALUE_UNQUOTED + ")"; //$NON-NLS-1$ //$NON-NLS-2$
 
-	private static final String ATTRIBUTE_NAME = "[a-zA-Z_][a-zA-Z0-9_:.-]*";
+	private static final String ATTRIBUTE_NAME = "[a-zA-Z_][a-zA-Z0-9_:.-]*"; //$NON-NLS-1$
 
-	private static final String ATTRIBUTE = "(?:\\s+" + ATTRIBUTE_NAME + "(?:\\s*=\\s*" + ATTRIBUTE_VALUE + ")?)";
+	private static final String ATTRIBUTE = "(?:\\s+" + ATTRIBUTE_NAME + "(?:\\s*=\\s*" + ATTRIBUTE_VALUE + ")?)"; //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
 
-	private static final String TAG = "<[a-zA-Z_][a-zA-Z_:0-9]*" + ATTRIBUTE + "*\\s*/?>";
+	private static final String TAG = "<[a-zA-Z_][a-zA-Z_:0-9]*" + ATTRIBUTE + "*\\s*/?>"; //$NON-NLS-1$ //$NON-NLS-2$
 
-	private static final String CLOSE_TAG = "</[a-zA-Z_][a-zA-Z_:0-9-]*\\s*>";
+	private static final String CLOSE_TAG = "</[a-zA-Z_][a-zA-Z_:0-9-]*\\s*>"; //$NON-NLS-1$
 
-	private static final String COMMENT = "<!---->|<!--(?:-?[^>-])(?:-?[^-])*-->";
+	private static final String COMMENT = "<!---->|<!--(?:-?[^>-])(?:-?[^-])*-->"; //$NON-NLS-1$
 
-	private static final String PROCESSING_INSTRUCTION = "<\\?.*?\\?>";
+	private static final String PROCESSING_INSTRUCTION = "<\\?.*?\\?>"; //$NON-NLS-1$
 
-	private static final String XML_DECLARATION = "<![A-Z]+(\\s+[^>]*)*>";
+	private static final String XML_DECLARATION = "<![A-Z]+(\\s+[^>]*)*>"; //$NON-NLS-1$
 
-	private static final String CDATA = "<!\\[CDATA\\[.*?\\]\\]>";
+	private static final String CDATA = "<!\\[CDATA\\[.*?\\]\\]>"; //$NON-NLS-1$
 
-	private static final String REGEX_TAG = "(" + TAG + "|" + CLOSE_TAG + "|" + COMMENT + "|" + PROCESSING_INSTRUCTION
-			+ "|" + XML_DECLARATION + "|" + CDATA + ").*";
+	private static final String REGEX_TAG = "(" + TAG + "|" + CLOSE_TAG + "|" + COMMENT + "|" + PROCESSING_INSTRUCTION //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
+			+ "|" + XML_DECLARATION + "|" + CDATA + ").*"; //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
 
 	private final Pattern tagPattern = Pattern.compile(REGEX_TAG, Pattern.DOTALL);
 

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark/src/main/java/org/eclipse/mylyn/wikitext/commonmark/internal/inlines/Image.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark/src/main/java/org/eclipse/mylyn/wikitext/commonmark/internal/inlines/Image.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015 David Green.
+ * Copyright (c) 2015, 2024 David Green and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -9,6 +9,7 @@
  *
  * Contributors:
  *     David Green - initial API and implementation
+ *     Alexander Fedorov (ArSysOp) - ongoing support
  *******************************************************************************/
 
 package org.eclipse.mylyn.wikitext.commonmark.internal.inlines;
@@ -71,11 +72,11 @@ public class Image extends InlineWithNestedContents {
 
 	@Override
 	public String toString() {
-		return toStringHelper(Image.class).add("offset", getOffset())
-				.add("length", getLength())
-				.add("src", ToStringHelper.toStringValue(src))
-				.add("title", title)
-				.add("contents", getContents())
+		return toStringHelper(Image.class).add("offset", getOffset()) //$NON-NLS-1$
+				.add("length", getLength()) //$NON-NLS-1$
+				.add("src", ToStringHelper.toStringValue(src)) //$NON-NLS-1$
+				.add("title", title) //$NON-NLS-1$
+				.add("contents", getContents()) //$NON-NLS-1$
 				.toString();
 	}
 }

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark/src/main/java/org/eclipse/mylyn/wikitext/commonmark/internal/inlines/Inline.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark/src/main/java/org/eclipse/mylyn/wikitext/commonmark/internal/inlines/Inline.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015 David Green.
+ * Copyright (c) 2015, 2024 David Green and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -9,6 +9,7 @@
  *
  * Contributors:
  *     David Green - initial API and implementation
+ *     Alexander Fedorov (ArSysOp) - ongoing support
  *******************************************************************************/
 
 package org.eclipse.mylyn.wikitext.commonmark.internal.inlines;
@@ -85,7 +86,7 @@ public abstract class Inline {
 		if (this == obj) {
 			return true;
 		}
-		if ((obj == null) || (getClass() != obj.getClass())) {
+		if (obj == null || getClass() != obj.getClass()) {
 			return false;
 		}
 		Inline other = (Inline) obj;
@@ -94,6 +95,6 @@ public abstract class Inline {
 
 	@Override
 	public String toString() {
-		return toStringHelper(getClass()).add("offset", getOffset()).add("length", getLength()).toString();
+		return toStringHelper(getClass()).add("offset", getOffset()).add("length", getLength()).toString(); //$NON-NLS-1$//$NON-NLS-2$
 	}
 }

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark/src/main/java/org/eclipse/mylyn/wikitext/commonmark/internal/inlines/InlineParser.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark/src/main/java/org/eclipse/mylyn/wikitext/commonmark/internal/inlines/InlineParser.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2022 David Green.
+ * Copyright (c) 2015, 2024 David Green and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -9,6 +9,7 @@
  *
  * Contributors:
  *     David Green - initial API and implementation
+ *     Alexander Fedorov (ArSysOp) - ongoing support
  *******************************************************************************/
 
 package org.eclipse.mylyn.wikitext.commonmark.internal.inlines;
@@ -99,7 +100,7 @@ public class InlineParser {
 
 			@Override
 			public void entityReference(String entity) {
-				stringBuilder.append(firstNonNull(EntityReferences.instance().equivalentString(entity), ""));
+				stringBuilder.append(firstNonNull(EntityReferences.instance().equivalentString(entity), "")); //$NON-NLS-1$
 			}
 		};
 		for (Inline inline : contents) {

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark/src/main/java/org/eclipse/mylyn/wikitext/commonmark/internal/inlines/InlineWithNestedContents.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark/src/main/java/org/eclipse/mylyn/wikitext/commonmark/internal/inlines/InlineWithNestedContents.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2022 David Green and others.
+ * Copyright (c) 2015, 2024 David Green and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -9,6 +9,7 @@
  *
  * Contributors:
  *     David Green - initial API and implementation
+ *     Alexander Fedorov (ArSysOp) - ongoing support
  *******************************************************************************/
 
 package org.eclipse.mylyn.wikitext.commonmark.internal.inlines;
@@ -52,9 +53,9 @@ public abstract class InlineWithNestedContents extends Inline {
 
 	@Override
 	public String toString() {
-		return toStringHelper(getClass()).add("offset", getOffset())
-				.add("length", getLength())
-				.add("contents", getContents())
+		return toStringHelper(getClass()).add("offset", getOffset()) //$NON-NLS-1$
+				.add("length", getLength()) //$NON-NLS-1$
+				.add("contents", getContents()) //$NON-NLS-1$
 				.toString();
 	}
 }

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark/src/main/java/org/eclipse/mylyn/wikitext/commonmark/internal/inlines/InlineWithText.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark/src/main/java/org/eclipse/mylyn/wikitext/commonmark/internal/inlines/InlineWithText.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015 David Green.
+ * Copyright (c) 2015, 2024 David Green and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -9,6 +9,7 @@
  *
  * Contributors:
  *     David Green - initial API and implementation
+ *     Alexander Fedorov (ArSysOp) - ongoing support
  *******************************************************************************/
 
 package org.eclipse.mylyn.wikitext.commonmark.internal.inlines;
@@ -51,9 +52,9 @@ abstract class InlineWithText extends Inline {
 
 	@Override
 	public String toString() {
-		return toStringHelper(getClass()).add("offset", getOffset())
-				.add("length", getLength())
-				.add("text", getText())
+		return toStringHelper(getClass()).add("offset", getOffset()) //$NON-NLS-1$
+				.add("length", getLength()) //$NON-NLS-1$
+				.add("text", getText()) //$NON-NLS-1$
 				.toString();
 	}
 }

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark/src/main/java/org/eclipse/mylyn/wikitext/commonmark/internal/inlines/LineBreakSpan.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark/src/main/java/org/eclipse/mylyn/wikitext/commonmark/internal/inlines/LineBreakSpan.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015 David Green.
+ * Copyright (c) 2015, 2024 David Green and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -9,6 +9,7 @@
  *
  * Contributors:
  *     David Green - initial API and implementation
+ *     Alexander Fedorov (ArSysOp) - ongoing support
  *******************************************************************************/
 
 package org.eclipse.mylyn.wikitext.commonmark.internal.inlines;
@@ -19,7 +20,7 @@ import java.util.regex.Pattern;
 
 public class LineBreakSpan extends SourceSpan {
 
-	private final Pattern pattern = Pattern.compile("( *(\\\\)?\n).*", Pattern.DOTALL);
+	private final Pattern pattern = Pattern.compile("( *(\\\\)?\n).*", Pattern.DOTALL); //$NON-NLS-1$
 
 	@Override
 	public Optional<? extends Inline> createInline(Cursor cursor) {

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark/src/main/java/org/eclipse/mylyn/wikitext/commonmark/internal/inlines/Link.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark/src/main/java/org/eclipse/mylyn/wikitext/commonmark/internal/inlines/Link.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015 David Green.
+ * Copyright (c) 2015, 2024 David Green and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -9,6 +9,7 @@
  *
  * Contributors:
  *     David Green - initial API and implementation
+ *     Alexander Fedorov (ArSysOp) - ongoing support
  *******************************************************************************/
 
 package org.eclipse.mylyn.wikitext.commonmark.internal.inlines;
@@ -72,11 +73,11 @@ public class Link extends InlineWithNestedContents {
 
 	@Override
 	public String toString() {
-		return toStringHelper(Link.class).add("offset", getOffset())
-				.add("length", getLength())
-				.add("href", ToStringHelper.toStringValue(href))
-				.add("title", title)
-				.add("contents", getContents())
+		return toStringHelper(Link.class).add("offset", getOffset()) //$NON-NLS-1$
+				.add("length", getLength()) //$NON-NLS-1$
+				.add("href", ToStringHelper.toStringValue(href)) //$NON-NLS-1$
+				.add("title", title) //$NON-NLS-1$
+				.add("contents", getContents()) //$NON-NLS-1$
 				.toString();
 	}
 }

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark/src/main/java/org/eclipse/mylyn/wikitext/commonmark/internal/inlines/PotentialBracketEndDelimiter.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark/src/main/java/org/eclipse/mylyn/wikitext/commonmark/internal/inlines/PotentialBracketEndDelimiter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2021 David Green.
+ * Copyright (c) 2015, 2024 David Green and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -9,6 +9,7 @@
  *
  * Contributors:
  *     David Green - initial API and implementation
+ *     Alexander Fedorov (ArSysOp) - ongoing support
  *******************************************************************************/
 
 package org.eclipse.mylyn.wikitext.commonmark.internal.inlines;
@@ -37,41 +38,41 @@ import com.google.common.net.UrlEscapers;
 public class PotentialBracketEndDelimiter extends InlineWithText {
 
 	private static final Pattern HTML_ENTITY_PATTERN = Pattern
-			.compile("(&([a-zA-Z][a-zA-Z0-9]{1,32}|#x[a-fA-F0-9]{1,8}|#[0-9]{1,8});)");
+			.compile("(&([a-zA-Z][a-zA-Z0-9]{1,32}|#x[a-fA-F0-9]{1,8}|#[0-9]{1,8});)"); //$NON-NLS-1$
 
-	static final String ESCAPABLE_CHARACTER_GROUP = "[!\"\\\\#$%&'()*+,./:;<=>?@\\[\\]^_`{|}~-]";
+	static final String ESCAPABLE_CHARACTER_GROUP = "[!\"\\\\#$%&'()*+,./:;<=>?@\\[\\]^_`{|}~-]"; //$NON-NLS-1$
 
-	static final String ESCAPED_CHARS = "(?:\\\\" + ESCAPABLE_CHARACTER_GROUP + ")";
+	static final String ESCAPED_CHARS = "(?:\\\\" + ESCAPABLE_CHARACTER_GROUP + ")"; //$NON-NLS-1$ //$NON-NLS-2$
 
-	static final String CAPTURING_ESCAPED_CHARS = "\\\\(" + ESCAPABLE_CHARACTER_GROUP + ")";
+	static final String CAPTURING_ESCAPED_CHARS = "\\\\(" + ESCAPABLE_CHARACTER_GROUP + ")"; //$NON-NLS-1$ //$NON-NLS-2$
 
-	static final String PARENS_TITLE_PART = "(?:\\(((?:" + ESCAPED_CHARS + "|[^\\)])*)\\))";
+	static final String PARENS_TITLE_PART = "(?:\\(((?:" + ESCAPED_CHARS + "|[^\\)])*)\\))"; //$NON-NLS-1$ //$NON-NLS-2$
 
-	static final String SINGLE_QUOTED_TITLE_PART = "(?:'((?:" + ESCAPED_CHARS + "|[^'])*)')";
+	static final String SINGLE_QUOTED_TITLE_PART = "(?:'((?:" + ESCAPED_CHARS + "|[^'])*)')"; //$NON-NLS-1$ //$NON-NLS-2$
 
-	static final String QUOTED_TITLE_PART = "(?:\"((?:" + ESCAPED_CHARS + "|[^\"])*)\")";
+	static final String QUOTED_TITLE_PART = "(?:\"((?:" + ESCAPED_CHARS + "|[^\"])*)\")"; //$NON-NLS-1$ //$NON-NLS-2$
 
-	static final String BRACKET_URI_PART = "<((?:[^<>\\\\\r\n]|" + ESCAPED_CHARS + ")*?)>";
+	static final String BRACKET_URI_PART = "<((?:[^<>\\\\\r\n]|" + ESCAPED_CHARS + ")*?)>"; //$NON-NLS-1$ //$NON-NLS-2$
 
-	private static final String IN_PARENS = "\\((?:[^\\\\()]|" + ESCAPED_CHARS + ")*\\)";
+	private static final String IN_PARENS = "\\((?:[^\\\\()]|" + ESCAPED_CHARS + ")*\\)"; //$NON-NLS-1$ //$NON-NLS-2$
 
-	static final String NOBRACKET_URI_PART = "((?:[^\\\\\\s()]|" + ESCAPED_CHARS + "|" + IN_PARENS + "|\\\\)+)";
+	static final String NOBRACKET_URI_PART = "((?:[^\\\\\\s()]|" + ESCAPED_CHARS + "|" + IN_PARENS + "|\\\\)+)"; //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
 
-	static final String URI_PART = "(?:" + BRACKET_URI_PART + "|" + NOBRACKET_URI_PART + ")";
+	static final String URI_PART = "(?:" + BRACKET_URI_PART + "|" + NOBRACKET_URI_PART + ")"; //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
 
-	static final String TITLE_PART = "(?:" + QUOTED_TITLE_PART + "|" + SINGLE_QUOTED_TITLE_PART + "|"
-			+ PARENS_TITLE_PART + ")";
+	static final String TITLE_PART = "(?:" + QUOTED_TITLE_PART + "|" + SINGLE_QUOTED_TITLE_PART + "|" //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+			+ PARENS_TITLE_PART + ")"; //$NON-NLS-1$
 
-	final Pattern endPattern = Pattern.compile("\\(\\s*" + URI_PART + "?(?:\\s+" + TITLE_PART + ")?\\s*\\)(.*)",
+	final Pattern endPattern = Pattern.compile("\\(\\s*" + URI_PART + "?(?:\\s+" + TITLE_PART + ")?\\s*\\)(.*)", //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
 			Pattern.DOTALL);
 
-	final Pattern referenceLabelPattern = Pattern.compile("(\\s*\\[((?:[^\\]]|\\\\]){0,1000})]).*", Pattern.DOTALL);
+	final Pattern referenceLabelPattern = Pattern.compile("(\\s*\\[((?:[^\\]]|\\\\]){0,1000})]).*", Pattern.DOTALL); //$NON-NLS-1$
 
 	final Pattern referenceDefinitionEndPattern = Pattern
-			.compile(":\\s*" + URI_PART + "?(?:\\s+" + TITLE_PART + ")?\\s*(.*)", Pattern.DOTALL);
+			.compile(":\\s*" + URI_PART + "?(?:\\s+" + TITLE_PART + ")?\\s*(.*)", Pattern.DOTALL); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
 
 	public PotentialBracketEndDelimiter(Line line, int offset) {
-		super(line, offset, 1, "]");
+		super(line, offset, 1, "]"); //$NON-NLS-1$
 	}
 
 	@Override
@@ -90,7 +91,7 @@ public class PotentialBracketEndDelimiter extends InlineWithText {
 					&& eligibleForReferenceDefinition(openingDelimiter, cursor);
 			Matcher matcher = cursor.hasNext()
 					? cursor.matcher(1, referenceDefinition ? referenceDefinitionEndPattern : endPattern)
-					: null;
+							: null;
 
 			List<Inline> contents = InlineParser
 					.secondPass(inlines.subList(indexOfOpeningDelimiter + 1, inlines.size()));
@@ -111,7 +112,7 @@ public class PotentialBracketEndDelimiter extends InlineWithText {
 					}
 					NamedUriWithTitle uriWithTitle = referenceName == null
 							? null
-							: context.namedUriWithTitle(referenceName);
+									: context.namedUriWithTitle(referenceName);
 					if (uriWithTitle != null) {
 						cursor.advance(size);
 
@@ -167,7 +168,7 @@ public class PotentialBracketEndDelimiter extends InlineWithText {
 
 	private String referenceName(Cursor cursor, List<Inline> contents) {
 		if (contents.isEmpty()) {
-			return "";
+			return ""; //$NON-NLS-1$
 		}
 		int start = cursor.toCursorOffset(contents.get(0).getOffset());
 		int end = cursor.toCursorOffset(getOffset());
@@ -176,9 +177,7 @@ public class PotentialBracketEndDelimiter extends InlineWithText {
 
 	private boolean containsLink(List<Inline> contents) {
 		for (Inline inline : contents) {
-			if (inline instanceof Link) {
-				return true;
-			} else if (inline instanceof InlineWithNestedContents
+			if (inline instanceof Link || inline instanceof InlineWithNestedContents
 					&& containsLink(((InlineWithNestedContents) inline).getContents())) {
 				return true;
 			}
@@ -206,7 +205,7 @@ public class PotentialBracketEndDelimiter extends InlineWithText {
 		if (startIndex > 0) {
 			for (int x = startIndex; x < indexOfContent; ++x) {
 				char c = cursor.getChar(x);
-				if ((c == '\n') || !Character.isWhitespace(c)) {
+				if (c == '\n' || !Character.isWhitespace(c)) {
 					return false;
 				}
 			}
@@ -284,7 +283,7 @@ public class PotentialBracketEndDelimiter extends InlineWithText {
 			if (title == null) {
 				title = matcher.group(5);
 				if (title == null) {
-					title = "";
+					title = ""; //$NON-NLS-1$
 				}
 			}
 		}
@@ -308,7 +307,7 @@ public class PotentialBracketEndDelimiter extends InlineWithText {
 		if (uriWithEscapes == null) {
 			uriWithEscapes = matcher.group(2);
 		}
-		uriWithEscapes = firstNonNull(uriWithEscapes, "");
+		uriWithEscapes = firstNonNull(uriWithEscapes, ""); //$NON-NLS-1$
 		return normalizeUri(uriWithEscapes);
 	}
 
@@ -334,7 +333,7 @@ public class PotentialBracketEndDelimiter extends InlineWithText {
 	}
 
 	String replaceHtmlEntities(String text, Escaper escaper) {
-		String replaced = "";
+		String replaced = ""; //$NON-NLS-1$
 		int lastEnd = 0;
 		Matcher matcher = HTML_ENTITY_PATTERN.matcher(text);
 		while (matcher.find()) {
@@ -345,7 +344,7 @@ public class PotentialBracketEndDelimiter extends InlineWithText {
 			String entityTextEquivalent = EntityReferences.instance().equivalentString(entity);
 			replaced += entityTextEquivalent == null
 					? matcher.group(1)
-					: escaper == null ? entityTextEquivalent : escaper.escape(entityTextEquivalent);
+							: escaper == null ? entityTextEquivalent : escaper.escape(entityTextEquivalent);
 			lastEnd = matcher.end(1);
 		}
 		if (lastEnd < text.length()) {
@@ -355,7 +354,7 @@ public class PotentialBracketEndDelimiter extends InlineWithText {
 	}
 
 	String toReferenceName(String stringWithBackslashEscapes) {
-		String referenceName = stringWithBackslashEscapes.replaceAll("(?s)\\\\(\\[|\\])", "$1").replaceAll("\\s+", " ");
+		String referenceName = stringWithBackslashEscapes.replaceAll("(?s)\\\\(\\[|\\])", "$1").replaceAll("\\s+", " "); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		if (CharMatcher.whitespace().matchesAllOf(referenceName)) {
 			return null;
 		}
@@ -363,7 +362,7 @@ public class PotentialBracketEndDelimiter extends InlineWithText {
 	}
 
 	String unescapeBackslashEscapes(String stringWithBackslashEscapes) {
-		return stringWithBackslashEscapes.replaceAll(CAPTURING_ESCAPED_CHARS, "$1");
+		return stringWithBackslashEscapes.replaceAll(CAPTURING_ESCAPED_CHARS, "$1"); //$NON-NLS-1$
 	}
 
 	private Optional<PotentialBracketDelimiter> findLastPotentialBracketDelimiter(List<Inline> inlines) {

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark/src/main/java/org/eclipse/mylyn/wikitext/commonmark/internal/inlines/PotentialEmphasisSpan.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark/src/main/java/org/eclipse/mylyn/wikitext/commonmark/internal/inlines/PotentialEmphasisSpan.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015 David Green.
+ * Copyright (c) 2015, 2024 David Green and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -9,6 +9,7 @@
  *
  * Contributors:
  *     David Green - initial API and implementation
+ *     Alexander Fedorov (ArSysOp) - ongoing support
  *******************************************************************************/
 
 package org.eclipse.mylyn.wikitext.commonmark.internal.inlines;
@@ -68,7 +69,7 @@ public class PotentialEmphasisSpan extends SourceSpan {
 	}
 
 	private boolean isPunctuation(char c) {
-		String punctuation = "!\"#$%&'()*+,-./:;<=>?@[\\]^_`,{|}~";
+		String punctuation = "!\"#$%&'()*+,-./:;<=>?@[\\]^_`,{|}~"; //$NON-NLS-1$
 		return punctuation.indexOf(c) >= 0;
 	}
 

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark/src/main/java/org/eclipse/mylyn/wikitext/commonmark/internal/inlines/ReferenceDefinition.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark/src/main/java/org/eclipse/mylyn/wikitext/commonmark/internal/inlines/ReferenceDefinition.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015 David Green.
+ * Copyright (c) 2015, 2024 David Green and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -9,6 +9,7 @@
  *
  * Contributors:
  *     David Green - initial API and implementation
+ *     Alexander Fedorov (ArSysOp) - ongoing support
  *******************************************************************************/
 
 package org.eclipse.mylyn.wikitext.commonmark.internal.inlines;
@@ -71,11 +72,11 @@ public class ReferenceDefinition extends Inline {
 
 	@Override
 	public String toString() {
-		return toStringHelper(ReferenceDefinition.class).add("offset", getOffset())
-				.add("length", getLength())
-				.add("name", name)
-				.add("href", ToStringHelper.toStringValue(href))
-				.add("title", title)
+		return toStringHelper(ReferenceDefinition.class).add("offset", getOffset()) //$NON-NLS-1$
+				.add("length", getLength()) //$NON-NLS-1$
+				.add("name", name) //$NON-NLS-1$
+				.add("href", ToStringHelper.toStringValue(href)) //$NON-NLS-1$
+				.add("title", title) //$NON-NLS-1$
 				.toString();
 	}
 }

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark/src/main/java/org/eclipse/mylyn/wikitext/commonmark/internal/inlines/SoftLineBreak.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark/src/main/java/org/eclipse/mylyn/wikitext/commonmark/internal/inlines/SoftLineBreak.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015 David Green.
+ * Copyright (c) 2015, 2024 David Green and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -9,6 +9,7 @@
  *
  * Contributors:
  *     David Green - initial API and implementation
+ *     Alexander Fedorov (ArSysOp) - ongoing support
  *******************************************************************************/
 
 package org.eclipse.mylyn.wikitext.commonmark.internal.inlines;
@@ -24,7 +25,7 @@ public class SoftLineBreak extends Inline {
 
 	@Override
 	public void emit(DocumentBuilder builder) {
-		builder.characters("\n");
+		builder.characters("\n"); //$NON-NLS-1$
 	}
 
 }

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark/src/main/java/org/eclipse/mylyn/wikitext/commonmark/internal/inlines/StringCharactersSpan.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark/src/main/java/org/eclipse/mylyn/wikitext/commonmark/internal/inlines/StringCharactersSpan.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015 David Green.
+ * Copyright (c) 2015, 2024 David Green and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -9,6 +9,7 @@
  *
  * Contributors:
  *     David Green - initial API and implementation
+ *     Alexander Fedorov (ArSysOp) - ongoing support
  *******************************************************************************/
 
 package org.eclipse.mylyn.wikitext.commonmark.internal.inlines;
@@ -19,7 +20,7 @@ import java.util.regex.Pattern;
 
 public class StringCharactersSpan extends SourceSpan {
 
-	private final Pattern pattern = Pattern.compile("((?: *[^\n `\\[\\]\\\\!<&*_h]+)+).*", Pattern.DOTALL);
+	private final Pattern pattern = Pattern.compile("((?: *[^\n `\\[\\]\\\\!<&*_h]+)+).*", Pattern.DOTALL); //$NON-NLS-1$
 
 	@Override
 	public Optional<? extends Inline> createInline(Cursor cursor) {

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext/META-INF/MANIFEST.MF
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext/META-INF/MANIFEST.MF
@@ -1,4 +1,5 @@
 Manifest-Version: 1.0
+Automatic-Module-Name: org.eclipse.mylyn.wikitext
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.eclipse.mylyn.wikitext
 Bundle-Version: 4.2.0.qualifier

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext/src/main/java/org/eclipse/mylyn/wikitext/internal/parser/html/AbstractSaxHtmlParser.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext/src/main/java/org/eclipse/mylyn/wikitext/internal/parser/html/AbstractSaxHtmlParser.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2021 Tasktop Technologies.
+ * Copyright (c) 2011, 2024 Tasktop Technologies and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -9,6 +9,7 @@
  *
  * Contributors:
  *     David Green - initial API and implementation
+ *     Alexander Fedorov (ArSysOp) - ongoing support
  *******************************************************************************/
 
 package org.eclipse.mylyn.wikitext.internal.parser.html;
@@ -70,7 +71,7 @@ public abstract class AbstractSaxHtmlParser {
 			"dd", //$NON-NLS-1$
 			"dt", //$NON-NLS-1$
 			"blockquote" //$NON-NLS-1$
-	);
+			);
 
 	/**
 	 * element names for elements that cause adjacent whitespace to be collapsed
@@ -83,7 +84,7 @@ public abstract class AbstractSaxHtmlParser {
 			"tbody", //$NON-NLS-1$
 			"thead", //$NON-NLS-1$
 			"tr" //$NON-NLS-1$
-	);
+			);
 
 	private static final Map<String, SpanType> elementNameToSpanType = Map.ofEntries(entry("a", SpanType.LINK), //$NON-NLS-1$
 			entry("b", SpanType.BOLD), //$NON-NLS-1$
@@ -104,7 +105,7 @@ public abstract class AbstractSaxHtmlParser {
 			entry("code", SpanType.CODE), //$NON-NLS-1$
 			entry("tt", SpanType.MONOSPACE), //$NON-NLS-1$
 			entry("mark", SpanType.MARK) //$NON-NLS-1$
-	);
+			);
 
 	private static final Map<String, BlockType> elementNameToBlockType = Map.ofEntries(
 			entry("ul", BlockType.BULLETED_LIST), //$NON-NLS-1$
@@ -123,7 +124,7 @@ public abstract class AbstractSaxHtmlParser {
 			entry("th", BlockType.TABLE_CELL_HEADER), //$NON-NLS-1$
 			entry("td", BlockType.TABLE_CELL_NORMAL), //$NON-NLS-1$
 			entry("tr", BlockType.TABLE_ROW) //$NON-NLS-1$
-	);
+			);
 
 	private static final class ElementState {
 		@SuppressWarnings("unused")
@@ -266,7 +267,7 @@ public abstract class AbstractSaxHtmlParser {
 				if (elementState.noWhitespaceTextContainer
 						&& (elementState.lastChild == null || elementState.lastChild.blockElement)
 						|| elementState.blockElement && !elementState.preserveWhitespace
-								&& elementState.textChildCount == 0 && elementState.childCount == 0
+						&& elementState.textChildCount == 0 && elementState.childCount == 0
 						|| elementState.lastChild != null && elementState.lastChild.collapsesAdjacentWhitespace) {
 					// trim left here
 					int skip = 0;
@@ -407,28 +408,28 @@ public abstract class AbstractSaxHtmlParser {
 				populateCommonAttributes(listAttributes, atts);
 				listAttributes.setStart(getAttribute(atts, "start")); //$NON-NLS-1$
 				if (listAttributes.getCssStyle() == null
-						|| !listAttributes.getCssStyle().contains("list-style-type:")) {
-					String typeAttribute = getAttribute(atts, "type");
+						|| !listAttributes.getCssStyle().contains("list-style-type:")) { //$NON-NLS-1$
+					String typeAttribute = getAttribute(atts, "type"); //$NON-NLS-1$
 					if (typeAttribute != null) {
 						String listCssType = null;
 						switch (typeAttribute) {
-							case "1":
-								listCssType = "decimal";
+							case "1": //$NON-NLS-1$
+								listCssType = "decimal"; //$NON-NLS-1$
 								break;
-							case "a":
-								listCssType = "lower-alpha";
+							case "a": //$NON-NLS-1$
+								listCssType = "lower-alpha"; //$NON-NLS-1$
 								break;
-							case "i":
-								listCssType = "lower-roman";
+							case "i": //$NON-NLS-1$
+								listCssType = "lower-roman"; //$NON-NLS-1$
 								break;
-							case "A":
-								listCssType = "upper-alpha";
+							case "A": //$NON-NLS-1$
+								listCssType = "upper-alpha"; //$NON-NLS-1$
 								break;
-							case "I":
-								listCssType = "upper-roman";
+							case "I": //$NON-NLS-1$
+								listCssType = "upper-roman"; //$NON-NLS-1$
 								break;
 						}
-						listAttributes.appendCssStyle("list-style-type: " + listCssType + ";");
+						listAttributes.appendCssStyle("list-style-type: " + listCssType + ";"); //$NON-NLS-1$ //$NON-NLS-2$
 					}
 				}
 				builder.beginBlock(BlockType.NUMERIC_LIST, listAttributes);
@@ -655,7 +656,7 @@ public abstract class AbstractSaxHtmlParser {
 	private org.eclipse.mylyn.wikitext.parser.Attributes computeAttributes(SpanType spanType, Attributes atts) {
 		org.eclipse.mylyn.wikitext.parser.Attributes attributes = spanType == SpanType.LINK
 				? new LinkAttributes()
-				: new org.eclipse.mylyn.wikitext.parser.Attributes();
+						: new org.eclipse.mylyn.wikitext.parser.Attributes();
 		populateCommonAttributes(attributes, atts);
 		if (spanType == SpanType.LINK) {
 			String href = getValue("href", atts); //$NON-NLS-1$

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext/src/main/java/org/eclipse/mylyn/wikitext/internal/parser/html/RemoveEmptySpansProcessor.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext/src/main/java/org/eclipse/mylyn/wikitext/internal/parser/html/RemoveEmptySpansProcessor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2012 Tasktop Technologies.
+ * Copyright (c) 2011, 2024 Tasktop Technologies and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -9,6 +9,7 @@
  *
  * Contributors:
  *     David Green - initial API and implementation
+ *     Alexander Fedorov (ArSysOp) - ongoing support
  *******************************************************************************/
 
 package org.eclipse.mylyn.wikitext.internal.parser.html;
@@ -45,20 +46,20 @@ class RemoveEmptySpansProcessor extends DocumentProcessor {
 						element.remove();
 						modifiedOne = true;
 					} else // a span with a single text child that is only whitespace is removed (text is retained)
-					if (childNodes.size() == 1) {
-						Node node = childNodes.get(0);
-						if (node instanceof TextNode textNode) {
-							String text = textNode.text();
-							if (text.trim().length() == 0) {
-								textNode.remove();
-								element.before(textNode);
-								element.remove();
-								modifiedOne = true;
-							}
+						if (childNodes.size() == 1) {
+							Node node = childNodes.get(0);
+							if (node instanceof TextNode textNode) {
+								String text = textNode.text();
+								if (text.trim().length() == 0) {
+									textNode.remove();
+									element.before(textNode);
+									element.remove();
+									modifiedOne = true;
+								}
 
-							normalizeTextNodes((Element) textNode.parent());
+								normalizeTextNodes((Element) textNode.parent());
+							}
 						}
-					}
 				}
 				// a br within a span that is a first or last child is moved out
 				Element parent = element.parent();
@@ -80,7 +81,7 @@ class RemoveEmptySpansProcessor extends DocumentProcessor {
 	}
 
 	private boolean isHyperlinkWithTarget(Element element) {
-		return element.tagName().equalsIgnoreCase("a") && !Strings.isNullOrEmpty(element.attr("href"));
+		return element.tagName().equalsIgnoreCase("a") && !Strings.isNullOrEmpty(element.attr("href")); //$NON-NLS-1$//$NON-NLS-2$
 	}
 
 }

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext/src/main/java/org/eclipse/mylyn/wikitext/parser/builder/DocBookDocumentBuilder.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext/src/main/java/org/eclipse/mylyn/wikitext/parser/builder/DocBookDocumentBuilder.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2007, 2013 David Green and others.
+ * Copyright (c) 2007, 2024 David Green and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -9,6 +9,7 @@
  *
  * Contributors:
  *     David Green - initial API and implementation
+ *     Alexander Fedorov (ArSysOp) - ongoing support
  *******************************************************************************/
 package org.eclipse.mylyn.wikitext.parser.builder;
 
@@ -410,10 +411,10 @@ public class DocBookDocumentBuilder extends AbstractXmlDocumentBuilder {
 					writer.writeAttribute("url", href); //$NON-NLS-1$
 				}
 			}
-				break;
+			break;
 			case MARK:
-				writer.writeStartElement("emphasis");
-				writer.writeAttribute("role", "marked");
+				writer.writeStartElement("emphasis"); //$NON-NLS-1$
+				writer.writeAttribute("role", "marked"); //$NON-NLS-1$ //$NON-NLS-2$
 				break;
 			default:
 				Logger.getLogger(DocBookDocumentBuilder.class.getName()).warning("No docbook mapping for " + type); //$NON-NLS-1$
@@ -433,29 +434,29 @@ public class DocBookDocumentBuilder extends AbstractXmlDocumentBuilder {
 		if (attributes.getCssStyle() != null) {
 			String cssStyle = attributes.getCssStyle();
 			if (cssStyle != null) {
-				Matcher typeMatcher = Pattern.compile("list-style-type:\\s+([\\w-]+);").matcher(cssStyle);
+				Matcher typeMatcher = Pattern.compile("list-style-type:\\s+([\\w-]+);").matcher(cssStyle); //$NON-NLS-1$
 				if (typeMatcher.find()) {
 					String type = typeMatcher.group(1);
 					switch (type) {
-						case "decimal":
-							type = "arabic";
+						case "decimal": //$NON-NLS-1$
+							type = "arabic"; //$NON-NLS-1$
 							break;
-						case "lower-alpha":
-							type = "loweralpha";
+						case "lower-alpha": //$NON-NLS-1$
+							type = "loweralpha"; //$NON-NLS-1$
 							break;
-						case "upper-alpha":
-							type = "upperalpha";
+						case "upper-alpha": //$NON-NLS-1$
+							type = "upperalpha"; //$NON-NLS-1$
 							break;
-						case "upper-roman":
-							type = "upperroman";
+						case "upper-roman": //$NON-NLS-1$
+							type = "upperroman"; //$NON-NLS-1$
 							break;
-						case "lower-roman":
-							type = "lowerroman";
+						case "lower-roman": //$NON-NLS-1$
+							type = "lowerroman"; //$NON-NLS-1$
 							break;
 						default:
 							break;
 					}
-					writer.writeAttribute("numeration", type);
+					writer.writeAttribute("numeration", type); //$NON-NLS-1$
 				}
 			}
 		}

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext/src/main/java/org/eclipse/mylyn/wikitext/parser/builder/JavadocShortcutUriProcessor.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext/src/main/java/org/eclipse/mylyn/wikitext/parser/builder/JavadocShortcutUriProcessor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2007, 2008 David Green and others.
+ * Copyright (c) 2007, 2024 David Green and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -7,6 +7,7 @@
  *
  * Contributors:
  *     David Green - initial API and implementation
+ *     Alexander Fedorov (ArSysOp) - ongoing support
  *******************************************************************************/
 
 package org.eclipse.mylyn.wikitext.parser.builder;
@@ -34,13 +35,13 @@ import javax.lang.model.SourceVersion;
  */
 public class JavadocShortcutUriProcessor implements UriProcessor {
 
-	private static final String TARGET = "_javadoc";
+	private static final String TARGET = "_javadoc"; //$NON-NLS-1$
 
-	private static final String JAVADOC_URI_MARKER = "@";
+	private static final String JAVADOC_URI_MARKER = "@"; //$NON-NLS-1$
 
-	private static final String JAVADOC_ABSOLUTE_URI_MARKER = "javadoc://";
+	private static final String JAVADOC_ABSOLUTE_URI_MARKER = "javadoc://"; //$NON-NLS-1$
 
-	private static final String BASE_PACKAGE_MARKER = ".";
+	private static final String BASE_PACKAGE_MARKER = "."; //$NON-NLS-1$
 
 	private final String basePackageName;
 
@@ -92,22 +93,22 @@ public class JavadocShortcutUriProcessor implements UriProcessor {
 	}
 
 	private String toTypePage(String newUri) {
-		return javadocFramePage() + "?" + newUri.replace('.', '/') + ".html";
+		return javadocFramePage() + "?" + newUri.replace('.', '/') + ".html"; //$NON-NLS-1$//$NON-NLS-2$
 	}
 
 	private String toPackagePage(String newUri) {
-		return javadocFramePage() + "?" + newUri.replace('.', '/') + "/package-summary.html";
+		return javadocFramePage() + "?" + newUri.replace('.', '/') + "/package-summary.html"; //$NON-NLS-1$ //$NON-NLS-2$
 	}
 
 	private String javadocFramePage() {
 		if (javadocRelativePath == null) {
-			return "index.html";
+			return "index.html"; //$NON-NLS-1$
 		}
 		String pageUri = javadocRelativePath;
-		if (!pageUri.endsWith("/")) {
-			pageUri += "/";
+		if (!pageUri.endsWith("/")) { //$NON-NLS-1$
+			pageUri += "/"; //$NON-NLS-1$
 		}
-		return pageUri + "index.html";
+		return pageUri + "index.html"; //$NON-NLS-1$
 	}
 
 	private String prependWithBasePackage(String uri) {

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext/src/main/java/org/eclipse/mylyn/wikitext/parser/markup/AbstractMarkupLanguage.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext/src/main/java/org/eclipse/mylyn/wikitext/parser/markup/AbstractMarkupLanguage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2009, 2021 David Green and others.
+ * Copyright (c) 2009, 2024 David Green and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -9,6 +9,7 @@
  *
  * Contributors:
  *     David Green - initial API and implementation
+ *     Alexander Fedorov (ArSysOp) - ongoing support
  *******************************************************************************/
 
 package org.eclipse.mylyn.wikitext.parser.markup;
@@ -20,6 +21,8 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Stack;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -236,9 +239,7 @@ public abstract class AbstractMarkupLanguage extends MarkupLanguage {
 		DocumentBuilder builder = parser.getBuilder();
 		builder.setLocator(state);
 
-		@SuppressWarnings("resource")
-		LocationTrackingReader reader = new LocationTrackingReader(new StringReader(markupContent));
-		try {
+		try (LocationTrackingReader reader = new LocationTrackingReader(new StringReader(markupContent))) {
 			if (asDocument) {
 				builder.beginDocument();
 			}
@@ -353,6 +354,8 @@ public abstract class AbstractMarkupLanguage extends MarkupLanguage {
 				builder.endDocument();
 			}
 			builder.flush();
+		} catch (IOException e) {
+			Logger.getLogger(getClass().getName()).log(Level.SEVERE, e.getMessage(), e);
 		} finally {
 			builder.setLocator(null);
 		}

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext/src/main/java/org/eclipse/mylyn/wikitext/parser/markup/ContentState.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext/src/main/java/org/eclipse/mylyn/wikitext/parser/markup/ContentState.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2007, 2009 David Green and others.
+ * Copyright (c) 2007, 2024 David Green and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -9,6 +9,7 @@
  *
  * Contributors:
  *     David Green - initial API and implementation
+ *     Alexander Fedorov (ArSysOp) - ongoing support
  *******************************************************************************/
 package org.eclipse.mylyn.wikitext.parser.markup;
 
@@ -62,7 +63,7 @@ public class ContentState implements Locator {
 		// know if the id is already in use without doing a two-pass parse, which we don't
 		// want to do.  Instead, we choose a prefix of '___' since the '_' is not used by
 		// the default id generator and it's unlikely to be found in a document.
-		return footnoteIdToHtmlId.computeIfAbsent(footnote, s -> "___fn" + s);
+		return footnoteIdToHtmlId.computeIfAbsent(footnote, s -> "___fn" + s); //$NON-NLS-1$
 	}
 
 	/**

--- a/mylyn.docs/wikitext/ui/org.eclipse.mylyn.wikitext.asciidoc.ui.tests/src/org/eclipse/mylyn/internal/wikitext/asciidoc/tests/AsciiDocTemplateResolverTest.java
+++ b/mylyn.docs/wikitext/ui/org.eclipse.mylyn.wikitext.asciidoc.ui.tests/src/org/eclipse/mylyn/internal/wikitext/asciidoc/tests/AsciiDocTemplateResolverTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2021 Max Rydahl Andersen and others.
+ * Copyright (c) 2015, 2024 Max Rydahl Andersen and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -9,6 +9,7 @@
  *
  * Contributors:
  *     Max Rydahl Andersen- initial API and implementation
+ *     Alexander Fedorov (ArSysOp) - ongoing support
  *******************************************************************************/
 
 package org.eclipse.mylyn.internal.wikitext.asciidoc.tests;
@@ -28,7 +29,7 @@ import org.junit.Test;
  *
  * @author Max Rydahl Andersen
  */
-@SuppressWarnings("restriction")
+@SuppressWarnings({ "nls", "restriction" })
 public class AsciiDocTemplateResolverTest {
 
 	private Templates templates;


### PR DESCRIPTION
* Add `Automatic-Module-Name` header
* Add @SuppressWarnings("nls") for tests
* Add `//NON-NLS-<n>` for non translatable strings
* Resolve trivial deprecations
* things like above