### PR TITLE
[#440] Dependabot only for folder mylyn.docs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,7 +2,7 @@
 version: 2
 updates:
   - package-ecosystem: maven
-    directory: /
+    directory: mylyn.docs
     schedule:
       interval: daily
     commit-message:


### PR DESCRIPTION
Dependabot Maven need the pom.xml so we can only use this in mylyn.docs