### PR TITLE
[#469] Prepare releng for 4.3.0

### DIFF
--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.maven/pom.xml
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.maven/pom.xml
@@ -42,12 +42,12 @@
 		<dependency>
 			<groupId>org.eclipse.mylyn.docs</groupId>
 			<artifactId>org.eclipse.mylyn.wikitext</artifactId>
-			<version>${project.version}</version>
+			<version>3.0.48.202308291007</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.mylyn.docs</groupId>
 			<artifactId>org.eclipse.mylyn.wikitext.textile</artifactId>
-			<version>${project.version}</version>
+			<version>3.0.48.202308291007</version>
 		</dependency>
 		<dependency>
 			<groupId>junit</groupId>


### PR DESCRIPTION
Switch `org.eclipse.mylyn.wikitext.maven` to fixed versions ofr Mylyn Docs until we restore Maven publishing with #459