### PR TITLE
[#459] Restore releng for publishing Maven Docs to maven central

### DIFF
--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.maven/pom.xml
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.maven/pom.xml
@@ -42,12 +42,12 @@
 		<dependency>
 			<groupId>org.eclipse.mylyn.docs</groupId>
 			<artifactId>org.eclipse.mylyn.wikitext</artifactId>
-			<version>3.0.48.202308291007</version>
+			<version>${project.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.mylyn.docs</groupId>
 			<artifactId>org.eclipse.mylyn.wikitext.textile</artifactId>
-			<version>3.0.48.202308291007</version>
+			<version>${project.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>junit</groupId>


### PR DESCRIPTION
Revert the fix for wikitext maven plugin dependencies