### PR TITLE
Check that GitLab Repository has Issues enabled before fetching repo Milestones (#501)

### DIFF
--- a/mylyn.tasks/connectors/gitlab/org.eclipse.mylyn.gitlab.core.test/META-INF/MANIFEST.MF
+++ b/mylyn.tasks/connectors/gitlab/org.eclipse.mylyn.gitlab.core.test/META-INF/MANIFEST.MF
@@ -15,6 +15,12 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.mylyn.commons.net;bundle-version="4.2.0",
  com.google.gson,
  org.eclipse.mylyn.commons.sdk.util;bundle-version="4.2.0",
- org.eclipse.mylyn.tests.util;bundle-version="4.2.0"
+ org.eclipse.mylyn.tests.util;bundle-version="4.2.0",
+ org.eclipse.mylyn.commons.repositories.http.core,
+ org.mockito.mockito-core,
+ net.bytebuddy.byte-buddy,
+ net.bytebuddy.byte-buddy-agent,
+ org.apache.httpcomponents.httpclient,
+ org.apache.httpcomponents.httpcore
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Automatic-Module-Name: org.eclipse.mylyn.gitlab.core.test

--- a/mylyn.tasks/connectors/gitlab/org.eclipse.mylyn.gitlab.core.test/src/org/eclipse/mylyn/internal/gitlab/core/GitlabRestClientTest.java
+++ b/mylyn.tasks/connectors/gitlab/org.eclipse.mylyn.gitlab.core.test/src/org/eclipse/mylyn/internal/gitlab/core/GitlabRestClientTest.java
@@ -1,0 +1,57 @@
+/*******************************************************************************
+ * Copyright © 2024 max
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html.
+ *
+ * Contributors:
+ *      See git history
+ *******************************************************************************/
+
+package org.eclipse.mylyn.internal.gitlab.core;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.apache.http.client.methods.HttpRequestBase;
+import org.eclipse.mylyn.commons.core.operations.IOperationMonitor;
+import org.eclipse.mylyn.commons.repositories.core.RepositoryLocation;
+import org.eclipse.mylyn.commons.repositories.http.core.CommonHttpClient;
+import org.eclipse.mylyn.gitlab.core.GitlabCoreActivator;
+import org.eclipse.mylyn.tasks.core.TaskRepository;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+
+class GitlabRestClientTest {
+
+	@SuppressWarnings("nls")
+	@Test
+	void ignoreMilestonesForProjectsWithIssuesDisabled() throws Exception {
+		RepositoryLocation location = new RepositoryLocation("http://localhost");
+		CommonHttpClient httpClient = Mockito.mock(CommonHttpClient.class);
+		when(httpClient.getLocation()).thenReturn(location);
+
+		GitlabRepositoryConnector connector = new GitlabRepositoryConnector();
+		String repoUrl = "http://localhost";
+		TaskRepository repository = new TaskRepository(GitlabCoreActivator.CONNECTOR_KIND, repoUrl);
+		repository.setProperty(GitlabCoreActivator.USE_PERSONAL_ACCESS_TOKEN, "true");
+		repository.setProperty(GitlabCoreActivator.PERSONAL_ACCESS_TOKEN, "test-token");
+		GitlabRestClient client = new GitlabRestClient(location, httpClient, connector, repository);
+
+		JsonObject project = new Gson().fromJson("""
+				{
+				"id": 20240428,
+				"issues_enabled": false
+				}
+				""", JsonObject.class);
+		client.getProjectMilestones(project, mock(IOperationMonitor.class, Mockito.RETURNS_SELF));
+		verify(httpClient, times(0)).execute(any(HttpRequestBase.class), any(IOperationMonitor.class));
+	}
+}

--- a/mylyn.tasks/connectors/gitlab/org.eclipse.mylyn.gitlab.core/src/org/eclipse/mylyn/internal/gitlab/core/GitlabRepositoryConnector.java
+++ b/mylyn.tasks/connectors/gitlab/org.eclipse.mylyn.gitlab.core/src/org/eclipse/mylyn/internal/gitlab/core/GitlabRepositoryConnector.java
@@ -40,6 +40,7 @@ import org.eclipse.mylyn.commons.net.AuthenticationCredentials;
 import org.eclipse.mylyn.commons.repositories.core.RepositoryLocation;
 import org.eclipse.mylyn.commons.repositories.core.auth.AuthenticationType;
 import org.eclipse.mylyn.commons.repositories.core.auth.UserCredentials;
+import org.eclipse.mylyn.commons.repositories.http.core.CommonHttpClient;
 import org.eclipse.mylyn.gitlab.core.Duration;
 import org.eclipse.mylyn.gitlab.core.GitlabConfiguration;
 import org.eclipse.mylyn.gitlab.core.GitlabCoreActivator;
@@ -356,7 +357,8 @@ public class GitlabRepositoryConnector extends AbstractRepositoryConnector {
 		UserCredentials credentials = new UserCredentials(credentials1.getUserName(), credentials1.getPassword(), null,
 				true);
 		location.setCredentials(AuthenticationType.REPOSITORY, credentials);
-		GitlabRestClient client = new GitlabRestClient(location, this, repository);
+		var httpClient = new CommonHttpClient(location);
+		GitlabRestClient client = new GitlabRestClient(location, httpClient, this, repository);
 
 		return client;
 	}


### PR DESCRIPTION
`GET /projects/:id` respond with a list of Repository feature toggle states.

Fix for #501 checks if

```json
{
...
  "issues_enabled": <boolean>
...
}
```

is set to `true`, then fetches Milestones. Otherwise, just returns an empty array.