### PR TITLE
Add org.apache.tika.core to the category.xml

### DIFF
--- a/org.eclipse.mylyn-site/category.xml
+++ b/org.eclipse.mylyn-site/category.xml
@@ -203,6 +203,7 @@
    <bundle id="org.apache.lucene.queries"/>
    <bundle id="org.apache.lucene.queryparser"/>
    <bundle id="org.apache.lucene.sandbox"/>
+   <bundle id="org.apache.tika.core"/>
    <bundle id="org.apache.xerces"/>
    <bundle id="org.apache.xml.resolver"/>
    <bundle id="org.apache.xmlrpc.client"/>


### PR DESCRIPTION
With the addition of dependencies on org.apache.tika.core, it's needed in the update site.

https://github.com/eclipse-mylyn/org.eclipse.mylyn/issues/517