### PR TITLE
Tiny improvements to the Oomph setup

### DIFF
--- a/org.eclipse.mylyn.releng/oomph/Mylyn.setup
+++ b/org.eclipse.mylyn.releng/oomph/Mylyn.setup
@@ -157,8 +157,6 @@
           name="org.eclipse.oomph.setup.maven.feature.group"/>
       <requirement
           name="org.eclipse.oomph.launches.feature.group"/>
-      <repository
-          url="http://download.eclipse.org/oomph/updates/release"/>
     </setupTask>
     <setupTask
         xsi:type="git:GitCloneTask"
@@ -492,6 +490,17 @@
         	&lt;natures>
         	&lt;/natures>
         &lt;/projectDescription>
+      </content>
+    </setupTask>
+    <setupTask
+        xsi:type="setup:ResourceCreationTask"
+        excludedTriggers="BOOTSTRAP"
+        targetURL="${git.clone.mylyn.github.admin.location|uri}/.gitignore"
+        encoding="UTF-8">
+      <content>
+        .project
+        .gitignore
+        /.settings/
       </content>
     </setupTask>
     <setupTask


### PR DESCRIPTION
- Don't specify the Oomph update site URL for the p2 director task because a site is always provide by Oomph itself.  The site varies depending on which installer is used, i.e., a nightly site for a nightly installer versus a milestone site for a milestone/release installer.
- Also create a .gitignore that ignores itself and the created .project file to ensure that the .github organization clone is not dirty.