### PR TITLE
Eliminate long maven build from the setup

### DIFF
--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.textile/.project
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.textile/.project
@@ -25,10 +25,16 @@
 			<arguments>
 			</arguments>
 		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
 	</buildSpec>
 	<natures>
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 		<nature>org.eclipse.pde.api.tools.apiAnalysisNature</nature>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
 	</natures>
 </projectDescription>

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext/.project
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext/.project
@@ -25,10 +25,16 @@
 			<arguments>
 			</arguments>
 		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
 	</buildSpec>
 	<natures>
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 		<nature>org.eclipse.pde.api.tools.apiAnalysisNature</nature>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
 	</natures>
 </projectDescription>

--- a/org.eclipse.mylyn.releng/oomph/Mylyn.setup
+++ b/org.eclipse.mylyn.releng/oomph/Mylyn.setup
@@ -402,6 +402,7 @@
     <setupTask
         xsi:type="launching:LaunchTask"
         id="launch.install"
+        disabled="true"
         predecessor="mylyn.workingsets"
         launcher="mylyn install"/>
     <setupTask


### PR DESCRIPTION
- Ensure that the two projects referenced as dependency by org.eclipse.mylyn.wikitext.maven have an m2e nature and build so that the dependencies resolve to those workspace projects.

https://github.com/eclipse-mylyn/org.eclipse.mylyn/issues/552