### PR TITLE
remove guava in wikitext, part 1 #521

### DIFF
--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.asciidoc.tests/META-INF/MANIFEST.MF
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.asciidoc.tests/META-INF/MANIFEST.MF
@@ -8,9 +8,7 @@ Bundle-Vendor: Eclipse Mylyn
 Fragment-Host: org.eclipse.mylyn.wikitext.asciidoc
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=17))"
-Import-Package: com.google.common.base;version="[33.0,34.0)",
- com.google.common.collect;version="[33.0,34.0)",
- org.eclipse.mylyn.wikitext.parser;version="[4.2,5)",
+Import-Package: org.eclipse.mylyn.wikitext.parser;version="[4.2,5)",
  org.eclipse.mylyn.wikitext.parser.builder;version="[4.2,5)",
  org.eclipse.mylyn.wikitext.parser.markup;version="[4.2,5)",
  org.eclipse.mylyn.wikitext.parser.markup.block;version="[4.2,5)",

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.asciidoc.tests/src/test/java/org/eclipse/mylyn/internal/wikitext/asciidoc/tests/AsciiDocDocumentBuilderTest.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.asciidoc.tests/src/test/java/org/eclipse/mylyn/internal/wikitext/asciidoc/tests/AsciiDocDocumentBuilderTest.java
@@ -10,6 +10,7 @@
  * Contributors:
  *     Jeremie Bresson - copied from MarkdownDocumentBuilderTest and adapted to AsciiDoc
  *     ArSysOp - ongoing support
+ *     See git history
  *******************************************************************************/
 
 package org.eclipse.mylyn.internal.wikitext.asciidoc.tests;
@@ -28,7 +29,7 @@ import org.eclipse.mylyn.wikitext.parser.LinkAttributes;
 import org.junit.Before;
 import org.junit.Test;
 
-@SuppressWarnings({ "nls", "restriction" })
+@SuppressWarnings("nls")
 public class AsciiDocDocumentBuilderTest {
 
 	private DocumentBuilder builder;

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.asciidoc.tests/src/test/java/org/eclipse/mylyn/internal/wikitext/asciidoc/tests/AsciiDocLanguageSupportTest.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.asciidoc.tests/src/test/java/org/eclipse/mylyn/internal/wikitext/asciidoc/tests/AsciiDocLanguageSupportTest.java
@@ -10,6 +10,7 @@
  * Contributors:
  *     Jeremie Bresson - initial API and implementation
  *     ArSysOp - ongoing support
+ *     See git history
  *******************************************************************************/
 
 package org.eclipse.mylyn.internal.wikitext.asciidoc.tests;
@@ -28,7 +29,7 @@ import org.junit.Test;
 /**
  * Unit Tests for {@link LanguageSupport}
  */
-@SuppressWarnings({ "nls", "restriction" })
+@SuppressWarnings("nls")
 public class AsciiDocLanguageSupportTest extends AsciiDocLanguageTestBase {
 
 	@Test

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.asciidoc/META-INF/MANIFEST.MF
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.asciidoc/META-INF/MANIFEST.MF
@@ -8,7 +8,7 @@ Bundle-Vendor: Eclipse Mylyn
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=17))"
 Import-Package: com.google.common.base;version="[33.0,34.0)",
- com.google.common.collect;version="[33.0,34.0)",
+ org.apache.commons.lang3;version="[3.14.0,4.0.0)",
  org.eclipse.mylyn.wikitext.parser;version="[4.2,5)",
  org.eclipse.mylyn.wikitext.parser.builder;version="[4.2,5)",
  org.eclipse.mylyn.wikitext.parser.markup;version="[4.2,5)",

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.asciidoc/src/main/java/org/eclipse/mylyn/wikitext/asciidoc/internal/AsciiDocDocumentBuilder.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.asciidoc/src/main/java/org/eclipse/mylyn/wikitext/asciidoc/internal/AsciiDocDocumentBuilder.java
@@ -10,6 +10,7 @@
  * Contributors:
  *     Jeremie Bresson - copied from MarkdownDocumentBuilder and adapted to AsciiDoc
  *     Alexander Fedorov (ArSysOp) - ongoing support
+ *     See git history
  *******************************************************************************/
 
 package org.eclipse.mylyn.wikitext.asciidoc.internal;
@@ -24,13 +25,12 @@ import java.util.Objects;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
+import org.apache.commons.lang3.StringUtils;
 import org.eclipse.mylyn.wikitext.asciidoc.AsciiDocLanguage;
 import org.eclipse.mylyn.wikitext.parser.Attributes;
 import org.eclipse.mylyn.wikitext.parser.ImageAttributes;
 import org.eclipse.mylyn.wikitext.parser.LinkAttributes;
 import org.eclipse.mylyn.wikitext.parser.builder.AbstractMarkupDocumentBuilder;
-
-import com.google.common.base.Strings;
 
 /**
  * a document builder that emits AsciiDoc markup
@@ -355,13 +355,13 @@ public class AsciiDocDocumentBuilder extends AbstractMarkupDocumentBuilder {
 		if (attributes instanceof ImageAttributes imageAttr) {
 			altText = imageAttr.getAlt();
 		}
-		if (!Strings.isNullOrEmpty(attributes.getTitle())) {
+		if (StringUtils.isNotEmpty(attributes.getTitle())) {
 			title = "title=\"" + attributes.getTitle() + '"'; //$NON-NLS-1$
 		}
 
 		StringBuilder sb = new StringBuilder();
 		sb.append("image:"); //$NON-NLS-1$
-		sb.append(Strings.nullToEmpty(url));
+		sb.append(StringUtils.defaultString(url));
 		sb.append("["); //$NON-NLS-1$
 		sb.append(Arrays.asList(altText, title).stream().filter(Objects::nonNull).collect(Collectors.joining(", "))); //$NON-NLS-1$
 		sb.append("]"); //$NON-NLS-1$
@@ -375,7 +375,7 @@ public class AsciiDocDocumentBuilder extends AbstractMarkupDocumentBuilder {
 		linkAttr.setTitle(attributes.getTitle());
 		linkAttr.setHref(hrefOrHashName);
 		beginSpan(SpanType.LINK, linkAttr);
-		if (Strings.isNullOrEmpty(text)) {
+		if (StringUtils.isEmpty(text)) {
 			characters(hrefOrHashName);
 		} else {
 			characters(text);

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.asciidoc/src/main/java/org/eclipse/mylyn/wikitext/asciidoc/internal/block/ListBlock.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.asciidoc/src/main/java/org/eclipse/mylyn/wikitext/asciidoc/internal/block/ListBlock.java
@@ -10,6 +10,7 @@
  * Contributors:
  *     Patrik Suzzi - Bug 481670 - [asciidoc] support for lists
  *     Alexander Fedorov (ArSysOp) - ongoing support
+ *     See git history
  *******************************************************************************/
 
 package org.eclipse.mylyn.wikitext.asciidoc.internal.block;
@@ -29,8 +30,6 @@ import org.eclipse.mylyn.wikitext.parser.ListAttributes;
 import org.eclipse.mylyn.wikitext.parser.markup.AbstractMarkupLanguage;
 import org.eclipse.mylyn.wikitext.parser.markup.Block;
 
-import com.google.common.collect.ImmutableList;
-
 /**
  * List block, matches blocks that start with <code>*</code> or, <code>#</code>
  *
@@ -44,12 +43,12 @@ public class ListBlock extends Block {
 
 	private static final String ANY_CHAR = "\\s+(.*+)"; //$NON-NLS-1$
 
-	private static final List<String> TYPE_ORDER = ImmutableList.of("arabic", "loweralpha", "lowerroman", "upperalpha", //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
+	private static final List<String> TYPE_ORDER = List.of("arabic", "loweralpha", "lowerroman", "upperalpha", //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 			"upperroman"); //$NON-NLS-1$
 
-	private static final List<String> TYPE_LISTSPEC = ImmutableList.of("1.", "a.", "i)", "A.", "I)"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$ //$NON-NLS-5$
+	private static final List<String> TYPE_LISTSPEC = List.of("1.", "a.", "i)", "A.", "I)"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$ //$NON-NLS-5$
 
-	private static final List<String> TYPE_CSS_STYLE = ImmutableList.of("decimal", "lower-alpha", "lower-roman", //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+	private static final List<String> TYPE_CSS_STYLE = List.of("decimal", "lower-alpha", "lower-roman", //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
 			"upper-alpha", "upper-roman"); //$NON-NLS-1$//$NON-NLS-2$
 
 	/** List item start */
@@ -175,7 +174,7 @@ public class ListBlock extends Block {
 	}
 
 	private void updateStyleAttribute(ListAttributes attributes, String listSpec, String styleProperty) {
-		int listTypeIndex = TYPE_ORDER.indexOf(styleProperty);
+		int listTypeIndex = styleProperty == null ? -1 : TYPE_ORDER.indexOf(styleProperty);
 		if (listTypeIndex < 0) {
 			listTypeIndex = TYPE_LISTSPEC.indexOf(listSpec);
 		}

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark.tests/META-INF/MANIFEST.MF
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark.tests/META-INF/MANIFEST.MF
@@ -8,11 +8,8 @@ Bundle-Vendor: Eclipse Mylyn
 Fragment-Host: org.eclipse.mylyn.wikitext.commonmark
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=17))"
-Import-Package: com.google.common.base;version="[33.0,34.0)",
- com.google.common.collect;version="[33.0,34.0)",
- com.google.common.escape;version="[33.0,34.0)",
- com.google.common.io;version="[33.0,34.0)",
- com.google.common.net;version="[33.0,34.0)",
+Import-Package: com.google.common.escape;version="[33.0,34.0)",
+ org.apache.commons.lang3;version="[3.14.0,4.0.0)",
  org.eclipse.mylyn.wikitext.parser;version="[4.2,5)",
  org.eclipse.mylyn.wikitext.parser.builder;version="[4.2,5)",
  org.eclipse.mylyn.wikitext.parser.builder.event;version="4.4.0",

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark.tests/src/test/java/org/eclipse/mylyn/wikitext/commonmark/internal/LineSequenceTest.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark.tests/src/test/java/org/eclipse/mylyn/wikitext/commonmark/internal/LineSequenceTest.java
@@ -10,6 +10,7 @@
  * Contributors:
  *     David Green - initial API and implementation
  *     ArSysOp - ongoing support
+ *     See git history
  *******************************************************************************/
 
 package org.eclipse.mylyn.wikitext.commonmark.internal;
@@ -61,10 +62,10 @@ public class LineSequenceTest {
 
 	@Test
 	public void toStringTest() {
-		assertEquals("LineSequence{currentLine=Line{lineNumber=0, offset=0, text=a}, nextLine=null}",
+		assertEquals("ContentLineSequence{currentLine=Line{lineNumber=0, offset=0, text=a}, nextLine=null}",
 				LineSequence.create("a\n").toString());
 		assertEquals(
-				"LineSequence{currentLine=Line{lineNumber=0, offset=0, text=a}, nextLine=Line{lineNumber=1, offset=2, text=b}}",
+				"ContentLineSequence{currentLine=Line{lineNumber=0, offset=0, text=a}, nextLine=Line{lineNumber=1, offset=2, text=b}}",
 				LineSequence.create("a\nb").toString());
 	}
 
@@ -127,7 +128,7 @@ public class LineSequenceTest {
 	private void assertLookAheadFailsFast(LineSequence lineSequence) {
 		LineSequence lookAhead = lineSequence.lookAhead();
 		lineSequence.advance();
-		assertThrows(IllegalStateException.class, () -> lookAhead.advance());
+		assertThrows(IllegalArgumentException.class, () -> lookAhead.advance());
 	}
 
 	private void assertAdvance(LineSequence lineSequence) {

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark.tests/src/test/java/org/eclipse/mylyn/wikitext/commonmark/internal/LineTest.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark.tests/src/test/java/org/eclipse/mylyn/wikitext/commonmark/internal/LineTest.java
@@ -10,6 +10,7 @@
  * Contributors:
  *     David Green - initial API and implementation
  *     ArSysOp - ongoing support
+ *     See git history
  *******************************************************************************/
 
 package org.eclipse.mylyn.wikitext.commonmark.internal;
@@ -19,10 +20,9 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
+import org.apache.commons.lang3.StringUtils;
 import org.eclipse.mylyn.wikitext.parser.Locator;
 import org.junit.Test;
-
-import com.google.common.base.Strings;
 
 @SuppressWarnings({ "nls", "restriction" })
 public class LineTest {
@@ -74,7 +74,7 @@ public class LineTest {
 		assertEquals("Line{lineNumber=1, offset=15, text=1}", new Line(1, 15, "1").toString());
 		assertEquals("Line{lineNumber=2, offset=0, text=\\t\\r\\nabc}", new Line(2, 0, "\t\r\nabc").toString());
 		assertEquals("Line{lineNumber=0, offset=0, text=aaaaaaaaaaaaaaaaaaaa...}",
-				new Line(0, 0, Strings.repeat("a", 100)).toString());
+				new Line(0, 0, StringUtils.repeat("a", 100)).toString());
 	}
 
 	@Test

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark.tests/src/test/java/org/eclipse/mylyn/wikitext/commonmark/internal/LineTest.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark.tests/src/test/java/org/eclipse/mylyn/wikitext/commonmark/internal/LineTest.java
@@ -24,7 +24,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.eclipse.mylyn.wikitext.parser.Locator;
 import org.junit.Test;
 
-@SuppressWarnings({ "nls", "restriction" })
+@SuppressWarnings("nls")
 public class LineTest {
 
 	@Test(expected = NullPointerException.class)

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark.tests/src/test/java/org/eclipse/mylyn/wikitext/commonmark/internal/SimpleLocatorTest.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark.tests/src/test/java/org/eclipse/mylyn/wikitext/commonmark/internal/SimpleLocatorTest.java
@@ -10,6 +10,7 @@
  * Contributors:
  *     David Green - initial API and implementation
  *     ArSysOp - ongoing support
+ *     See git history
  *******************************************************************************/
 
 package org.eclipse.mylyn.wikitext.commonmark.internal;
@@ -19,7 +20,7 @@ import static org.junit.Assert.assertEquals;
 import org.eclipse.mylyn.wikitext.parser.Locator;
 import org.junit.Test;
 
-@SuppressWarnings({ "nls", "restriction" })
+@SuppressWarnings("nls")
 public class SimpleLocatorTest {
 
 	@Test

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark.tests/src/test/java/org/eclipse/mylyn/wikitext/commonmark/internal/TextSegmentTest.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark.tests/src/test/java/org/eclipse/mylyn/wikitext/commonmark/internal/TextSegmentTest.java
@@ -10,6 +10,7 @@
  * Contributors:
  *     David Green - initial API and implementation
  *     ArSysOp - ongoing support
+ *     See git history
  *******************************************************************************/
 
 package org.eclipse.mylyn.wikitext.commonmark.internal;
@@ -20,9 +21,8 @@ import static org.junit.Assert.fail;
 
 import java.util.List;
 
+import org.apache.commons.lang3.StringUtils;
 import org.junit.Test;
-
-import com.google.common.base.Strings;
 
 @SuppressWarnings("nls")
 public class TextSegmentTest {
@@ -84,10 +84,10 @@ public class TextSegmentTest {
 
 	@Test
 	public void toStringTest() {
-		assertEquals("TextSegment{text=one\\ntwo\\nthree four}",
+		assertEquals("TextSegment{text=one\ntwo\nthree four}",
 				new TextSegment(createLines("one\ntwo\r\nthree four")).toString());
-		assertEquals("TextSegment{text=01234567890123456789...}",
-				new TextSegment(createLines(Strings.repeat("0123456789", 10))).toString());
+		assertEquals("TextSegment{text=0123456789012345678901234567890123456789}",
+				new TextSegment(createLines(StringUtils.repeat("0123456789", 4))).toString());
 	}
 
 	private Iterable<Line> createLines(String content) {

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark.tests/src/test/java/org/eclipse/mylyn/wikitext/commonmark/internal/ToStringHelperTest.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark.tests/src/test/java/org/eclipse/mylyn/wikitext/commonmark/internal/ToStringHelperTest.java
@@ -10,15 +10,15 @@
  * Contributors:
  *     David Green - initial API and implementation
  *     ArSysOp - ongoing support
+ *     See git history
  *******************************************************************************/
 
 package org.eclipse.mylyn.wikitext.commonmark.internal;
 
 import static org.junit.Assert.assertEquals;
 
+import org.apache.commons.lang3.StringUtils;
 import org.junit.Test;
-
-import com.google.common.base.Strings;
 
 @SuppressWarnings("nls")
 public class ToStringHelperTest {
@@ -27,7 +27,7 @@ public class ToStringHelperTest {
 		assertEquals(null, ToStringHelper.toStringValue(null));
 		assertEquals("", ToStringHelper.toStringValue(""));
 		assertEquals("abc", ToStringHelper.toStringValue("abc"));
-		assertEquals("01234567890123456789...", ToStringHelper.toStringValue(Strings.repeat("0123456789", 10)));
+		assertEquals("01234567890123456789...", ToStringHelper.toStringValue(StringUtils.repeat("0123456789", 10)));
 		assertEquals("a\\r\\n\\tb", ToStringHelper.toStringValue("a\r\n\tb"));
 	}
 }

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark.tests/src/test/java/org/eclipse/mylyn/wikitext/commonmark/internal/blocks/HorizontalRuleBlockTest.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark.tests/src/test/java/org/eclipse/mylyn/wikitext/commonmark/internal/blocks/HorizontalRuleBlockTest.java
@@ -10,6 +10,7 @@
  * Contributors:
  *     David Green - initial API and implementation
  *     ArSysOp - ongoing support
+ *     See git history
  *******************************************************************************/
 
 package org.eclipse.mylyn.wikitext.commonmark.internal.blocks;
@@ -18,10 +19,9 @@ import static org.eclipse.mylyn.wikitext.commonmark.internal.CommonMarkAsserts.a
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+import org.apache.commons.lang3.StringUtils;
 import org.eclipse.mylyn.wikitext.commonmark.internal.LineSequence;
 import org.junit.Test;
-
-import com.google.common.base.Strings;
 
 @SuppressWarnings("nls")
 public class HorizontalRuleBlockTest {
@@ -34,14 +34,14 @@ public class HorizontalRuleBlockTest {
 		assertFalse(block.canStart(LineSequence.create("a")));
 		assertFalse(block.canStart(LineSequence.create("    ***")));
 		for (char c : "*_-".toCharArray()) {
-			String hrIndicator = Strings.repeat("" + c, 3);
+			String hrIndicator = StringUtils.repeat("" + c, 3);
 			assertTrue(block.canStart(LineSequence.create("   " + hrIndicator)));
 			assertTrue(block.canStart(LineSequence.create("  " + hrIndicator)));
 			assertTrue(block.canStart(LineSequence.create(" " + hrIndicator)));
 			assertFalse(block.canStart(LineSequence.create("    " + hrIndicator)));
 			assertTrue(block.canStart(LineSequence.create(hrIndicator)));
-			assertTrue(block.canStart(LineSequence.create(Strings.repeat("" + c, 4))));
-			assertTrue(block.canStart(LineSequence.create(Strings.repeat("" + c, 14))));
+			assertTrue(block.canStart(LineSequence.create(StringUtils.repeat("" + c, 4))));
+			assertTrue(block.canStart(LineSequence.create(StringUtils.repeat("" + c, 14))));
 		}
 
 		// Bug 472390:

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark.tests/src/test/java/org/eclipse/mylyn/wikitext/commonmark/internal/inlines/InlineTest.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark.tests/src/test/java/org/eclipse/mylyn/wikitext/commonmark/internal/inlines/InlineTest.java
@@ -10,6 +10,7 @@
  * Contributors:
  *     David Green - initial API and implementation
  *     ArSysOp - ongoing support
+ *     See git history
  *******************************************************************************/
 
 package org.eclipse.mylyn.wikitext.commonmark.internal.inlines;
@@ -25,7 +26,7 @@ import org.eclipse.mylyn.wikitext.parser.DocumentBuilder;
 import org.eclipse.mylyn.wikitext.parser.Locator;
 import org.junit.Test;
 
-@SuppressWarnings({ "nls", "restriction" })
+@SuppressWarnings("nls")
 public class InlineTest {
 
 	@Test

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark.tests/src/test/java/org/eclipse/mylyn/wikitext/commonmark/internal/spec/tests/CommonMarkSpecTest.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark.tests/src/test/java/org/eclipse/mylyn/wikitext/commonmark/internal/spec/tests/CommonMarkSpecTest.java
@@ -10,11 +10,11 @@
  * Contributors:
  *     David Green - initial API and implementation
  *     ArSysOp - ongoing support
+ *     See git history
  *******************************************************************************/
 
 package org.eclipse.mylyn.wikitext.commonmark.internal.spec.tests;
 
-import static com.google.common.base.MoreObjects.toStringHelper;
 import static org.eclipse.mylyn.wikitext.commonmark.internal.CommonMarkAsserts.assertContent;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assume.assumeTrue;
@@ -35,17 +35,16 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.eclipse.mylyn.wikitext.commonmark.CommonMarkLanguage;
 import org.eclipse.mylyn.wikitext.util.LocationTrackingReader;
+import org.eclipse.mylyn.wikitext.util.WikiToStringStyle;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
-
-import com.google.common.collect.ImmutableList;
-import com.google.common.io.CharStreams;
-import com.google.common.io.Resources;
 
 @SuppressWarnings({ "nls", "restriction" })
 @RunWith(Parameterized.class)
@@ -87,7 +86,10 @@ public class CommonMarkSpecTest {
 
 		@Override
 		public String toString() {
-			return toStringHelper(Expectation.class).add("input", input).add("expected", expected).toString();
+			return new ToStringBuilder(this, WikiToStringStyle.WIKI_TO_STRING_STYLE) //
+					.append("input", input)
+					.append("expected", expected)
+					.toString();
 		}
 	}
 
@@ -123,11 +125,11 @@ public class CommonMarkSpecTest {
 
 	@Parameters //(name = "{0} test {index}")
 	public static List<Object[]> parameters() {
-		ImmutableList.Builder<Object[]> parameters = ImmutableList.builder();
+		List<Object[]> parameters = new ArrayList<>();
 
 		loadSpec(parameters);
 
-		return parameters.build();
+		return List.copyOf(parameters);
 	}
 
 	public CommonMarkSpecTest(String title, String heading, int lineNumber, Expectation expectation) {
@@ -136,7 +138,7 @@ public class CommonMarkSpecTest {
 		this.expectation = expectation;
 	}
 
-	private static void loadSpec(ImmutableList.Builder<Object[]> parameters) {
+	private static void loadSpec(List<Object[]> parameters) {
 		Pattern headingPattern = Pattern.compile("#+\\s*(.+)");
 		try {
 			String spec = loadCommonMarkSpec();
@@ -189,11 +191,11 @@ public class CommonMarkSpecTest {
 		File spec = new File(tmpFolder, String.format("spec%s.txt", SPEC_VERSION));
 		if (!spec.exists()) {
 			try (FileOutputStream out = new FileOutputStream(spec)) {
-				Resources.copy(COMMONMARK_SPEC_URI.toURL(), out);
+				IOUtils.copy(COMMONMARK_SPEC_URI.toURL(), out);
 			}
 		}
 		try (InputStream in = new FileInputStream(spec)) {
-			return CharStreams.toString(new InputStreamReader(in, StandardCharsets.UTF_8));
+			return IOUtils.toString(new InputStreamReader(in, StandardCharsets.UTF_8));
 		}
 	}
 

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark.tests/src/test/java/org/eclipse/mylyn/wikitext/commonmark/internal/spec/tests/SimplifiedHtmlDocumentBuilder.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark.tests/src/test/java/org/eclipse/mylyn/wikitext/commonmark/internal/spec/tests/SimplifiedHtmlDocumentBuilder.java
@@ -10,13 +10,13 @@
  * Contributors:
  *     David Green - initial API and implementation
  *     ArSysOp - ongoing support
+ *     See git history
  *******************************************************************************/
 
 package org.eclipse.mylyn.wikitext.commonmark.internal.spec.tests;
 
-import static com.google.common.base.MoreObjects.firstNonNull;
-
 import java.io.Writer;
+import java.util.Objects;
 
 import org.eclipse.mylyn.wikitext.parser.Attributes;
 import org.eclipse.mylyn.wikitext.parser.ImageAttributes;
@@ -35,7 +35,7 @@ public class SimplifiedHtmlDocumentBuilder extends HtmlDocumentBuilder {
 		writer.writeEmptyElement(getHtmlNsUri(), "img"); //$NON-NLS-1$
 		writer.writeAttribute("src", makeUrlAbsolute(url)); //$NON-NLS-1$
 		if (attributes instanceof ImageAttributes imageAttributes) {
-			writer.writeAttribute(getHtmlNsUri(), "alt", firstNonNull(imageAttributes.getAlt(), ""));
+			writer.writeAttribute(getHtmlNsUri(), "alt", Objects.requireNonNullElse(imageAttributes.getAlt(), ""));
 			if (imageAttributes.getTitle() != null) {
 				writer.writeAttribute(getHtmlNsUri(), "title", imageAttributes.getTitle());
 			}

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark/META-INF/MANIFEST.MF
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark/META-INF/MANIFEST.MF
@@ -12,10 +12,11 @@ Bundle-Vendor: Eclipse Mylyn
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=17))"
 Import-Package: com.google.common.base;version="[33.0,34.0)",
- com.google.common.collect;version="[33.0,34.0)",
  com.google.common.escape;version="[33.0,34.0)",
- com.google.common.io;version="[33.0,34.0)";resolution:=optional,
- com.google.common.net;version="[33.0,34.0)",
+ com.google.common.net;version="[33.2.0,34.0.0)",
+ org.apache.commons.io;version="[2.16.0,3.0.0)",
+ org.apache.commons.lang3;version="[3.14.0,4.0.0)",
+ org.apache.commons.lang3.builder;version="[3.14.0,4.0.0)",
  org.eclipse.mylyn.wikitext.parser;version="[4.2,5)",
  org.eclipse.mylyn.wikitext.parser.builder;version="[4.2,5)",
  org.eclipse.mylyn.wikitext.parser.markup;version="[4.2,5)",

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark/src/main/java/org/eclipse/mylyn/wikitext/commonmark/internal/ContentLineSequence.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark/src/main/java/org/eclipse/mylyn/wikitext/commonmark/internal/ContentLineSequence.java
@@ -9,11 +9,10 @@
  *
  * Contributors:
  *     David Green - initial API and implementation
+ *     See git history
  *******************************************************************************/
 
 package org.eclipse.mylyn.wikitext.commonmark.internal;
-
-import static com.google.common.base.Preconditions.checkArgument;
 
 import java.io.IOException;
 import java.io.StringReader;
@@ -21,6 +20,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
+import org.apache.commons.lang3.Validate;
 import org.eclipse.mylyn.wikitext.commonmark.internal.LineSequence.ForwardLineSequence;
 import org.eclipse.mylyn.wikitext.util.LocationTrackingReader;
 
@@ -62,7 +62,7 @@ class ContentLineSequence extends ForwardLineSequence {
 
 	@Override
 	Line getNextLine(int index) {
-		checkArgument(index >= 0);
+		Validate.isTrue(index >= 0);
 		while (followingLines.size() <= index) {
 			Line line = readLine();
 			if (line == null) {

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark/src/main/java/org/eclipse/mylyn/wikitext/commonmark/internal/InlineContent.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark/src/main/java/org/eclipse/mylyn/wikitext/commonmark/internal/InlineContent.java
@@ -9,9 +9,13 @@
  *
  * Contributors:
  *     David Green - initial API and implementation
+ *     See git history
  *******************************************************************************/
 
 package org.eclipse.mylyn.wikitext.commonmark.internal;
+
+import java.util.ArrayList;
+import java.util.List;
 
 import org.eclipse.mylyn.wikitext.commonmark.internal.inlines.AllCharactersSpan;
 import org.eclipse.mylyn.wikitext.commonmark.internal.inlines.AutoLinkSpan;
@@ -27,26 +31,24 @@ import org.eclipse.mylyn.wikitext.commonmark.internal.inlines.PotentialEmphasisS
 import org.eclipse.mylyn.wikitext.commonmark.internal.inlines.SourceSpan;
 import org.eclipse.mylyn.wikitext.commonmark.internal.inlines.StringCharactersSpan;
 
-import com.google.common.collect.ImmutableList;
-
 public class InlineContent {
 
 	public static InlineParser commonMarkStrict() {
-		ImmutableList.Builder<SourceSpan> spansBuilder = ImmutableList.builder();
+		List<SourceSpan> spansBuilder = new ArrayList<>();
 		addStandardSpans(spansBuilder);
 		addTerminatorSpans(spansBuilder);
-		return new InlineParser(spansBuilder.build());
+		return new InlineParser(List.copyOf(spansBuilder));
 	}
 
 	public static InlineParser markdown() {
-		ImmutableList.Builder<SourceSpan> spansBuilder = ImmutableList.builder();
+		List<SourceSpan> spansBuilder = new ArrayList<>();
 		addStandardSpans(spansBuilder);
 		spansBuilder.add(new AutoLinkWithoutDemarcationSpan());
 		addTerminatorSpans(spansBuilder);
-		return new InlineParser(spansBuilder.build());
+		return new InlineParser(List.copyOf(spansBuilder));
 	}
 
-	private static void addStandardSpans(ImmutableList.Builder<SourceSpan> spansBuilder) {
+	private static void addStandardSpans(List<SourceSpan> spansBuilder) {
 		spansBuilder.add(new LineBreakSpan());
 		spansBuilder.add(new BackslashEscapeSpan());
 		spansBuilder.add(new CodeSpan());
@@ -57,7 +59,7 @@ public class InlineContent {
 		spansBuilder.add(new PotentialBracketSpan());
 	}
 
-	private static void addTerminatorSpans(ImmutableList.Builder<SourceSpan> spansBuilder) {
+	private static void addTerminatorSpans(List<SourceSpan> spansBuilder) {
 		spansBuilder.add(new StringCharactersSpan());
 		spansBuilder.add(new AllCharactersSpan());
 	}

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark/src/main/java/org/eclipse/mylyn/wikitext/commonmark/internal/Line.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark/src/main/java/org/eclipse/mylyn/wikitext/commonmark/internal/Line.java
@@ -10,16 +10,17 @@
  * Contributors:
  *     David Green - initial API and implementation
  *     Alexander Fedorov (ArSysOp) - ongoing support
+ *     See git history
  *******************************************************************************/
 
 package org.eclipse.mylyn.wikitext.commonmark.internal;
 
-import static com.google.common.base.MoreObjects.toStringHelper;
-import static com.google.common.base.Preconditions.checkArgument;
-
 import java.util.Objects;
 
+import org.apache.commons.lang3.Validate;
+import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.eclipse.mylyn.wikitext.parser.Locator;
+import org.eclipse.mylyn.wikitext.util.WikiToStringStyle;
 
 import com.google.common.base.CharMatcher;
 
@@ -32,8 +33,8 @@ public class Line {
 	private final int lineNumber;
 
 	public Line(int lineNumber, int offset, String text) {
-		checkArgument(offset >= 0);
-		checkArgument(lineNumber >= 0);
+		Validate.isTrue(offset >= 0);
+		Validate.isTrue(lineNumber >= 0);
 		this.lineNumber = lineNumber;
 		this.offset = offset;
 		this.text = Objects.requireNonNull(text);
@@ -84,9 +85,10 @@ public class Line {
 
 	@Override
 	public String toString() {
-		return toStringHelper(Line.class).add("lineNumber", lineNumber) //$NON-NLS-1$
-				.add("offset", offset) //$NON-NLS-1$
-				.add("text", ToStringHelper.toStringValue(text)) //$NON-NLS-1$
+		return new ToStringBuilder(this, WikiToStringStyle.WIKI_TO_STRING_STYLE) //
+				.append("lineNumber", lineNumber) //$NON-NLS-1$
+				.append("offset", offset) //$NON-NLS-1$
+				.append("text", ToStringHelper.toStringValue(text)) //$NON-NLS-1$
 				.toString();
 	}
 }

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark/src/main/java/org/eclipse/mylyn/wikitext/commonmark/internal/LineSequence.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark/src/main/java/org/eclipse/mylyn/wikitext/commonmark/internal/LineSequence.java
@@ -10,16 +10,18 @@
  * Contributors:
  *     David Green - initial API and implementation
  *     Alexander Fedorov (ArSysOp) - ongoing support
+ *     See git history
  *******************************************************************************/
 
 package org.eclipse.mylyn.wikitext.commonmark.internal;
 
-import static com.google.common.base.MoreObjects.toStringHelper;
-import static com.google.common.base.Preconditions.checkArgument;
-
 import java.util.Iterator;
 import java.util.function.Function;
 import java.util.function.Predicate;
+
+import org.apache.commons.lang3.Validate;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.eclipse.mylyn.wikitext.util.WikiToStringStyle;
 
 public abstract class LineSequence implements Iterable<Line> {
 
@@ -39,7 +41,7 @@ public abstract class LineSequence implements Iterable<Line> {
 	public abstract void advance();
 
 	public void advance(int count) {
-		checkArgument(count >= 0);
+		Validate.isTrue(count >= 0);
 		for (int x = 0; x < count; ++x) {
 			advance();
 		}
@@ -67,8 +69,9 @@ public abstract class LineSequence implements Iterable<Line> {
 
 	@Override
 	public String toString() {
-		return toStringHelper(LineSequence.class).add("currentLine", getCurrentLine()) //$NON-NLS-1$
-				.add("nextLine", getNextLine()) //$NON-NLS-1$
+		return new ToStringBuilder(this, WikiToStringStyle.WIKI_TO_STRING_STYLE) //
+				.append("currentLine", getCurrentLine()) //$NON-NLS-1$
+				.append("nextLine", getNextLine()) //$NON-NLS-1$
 				.toString();
 	}
 }

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark/src/main/java/org/eclipse/mylyn/wikitext/commonmark/internal/LookAheadLineSequence.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark/src/main/java/org/eclipse/mylyn/wikitext/commonmark/internal/LookAheadLineSequence.java
@@ -9,11 +9,12 @@
  *
  * Contributors:
  *     David Green - initial API and implementation
+ *     See git history
  *******************************************************************************/
 
 package org.eclipse.mylyn.wikitext.commonmark.internal;
 
-import static com.google.common.base.Preconditions.checkState;
+import org.apache.commons.lang3.Validate;
 
 class LookAheadLineSequence extends LineSequence {
 
@@ -58,7 +59,7 @@ class LookAheadLineSequence extends LineSequence {
 	}
 
 	private void checkConcurrentModification() {
-		checkState(referenceLine == lineSequence.getCurrentLine());
+		Validate.isTrue(referenceLine == lineSequence.getCurrentLine());
 	}
 
 	@Override

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark/src/main/java/org/eclipse/mylyn/wikitext/commonmark/internal/ProcessingContextBuilder.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark/src/main/java/org/eclipse/mylyn/wikitext/commonmark/internal/ProcessingContextBuilder.java
@@ -9,6 +9,7 @@
  *
  * Contributors:
  *     David Green - initial API and implementation
+ *     See git history
  *******************************************************************************/
 
 package org.eclipse.mylyn.wikitext.commonmark.internal;
@@ -17,12 +18,11 @@ import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
 
+import org.apache.commons.lang3.StringUtils;
 import org.eclipse.mylyn.wikitext.commonmark.internal.ProcessingContext.NamedUriWithTitle;
 import org.eclipse.mylyn.wikitext.commonmark.internal.inlines.InlineParser;
 import org.eclipse.mylyn.wikitext.parser.IdGenerator;
 import org.eclipse.mylyn.wikitext.parser.markup.IdGenerationStrategy;
-
-import com.google.common.base.Strings;
 
 public class ProcessingContextBuilder {
 
@@ -33,7 +33,7 @@ public class ProcessingContextBuilder {
 	private InlineParser inlineParser;
 
 	public ProcessingContextBuilder referenceDefinition(String name, String href, String title) {
-		if (!Strings.isNullOrEmpty(name)) {
+		if (StringUtils.isNotEmpty(name)) {
 			String key = name.toLowerCase(Locale.ROOT);
 			if (!linkByName.containsKey(key)) {
 				linkByName.put(key, new NamedUriWithTitle(name, href, title));

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark/src/main/java/org/eclipse/mylyn/wikitext/commonmark/internal/SimpleLocator.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark/src/main/java/org/eclipse/mylyn/wikitext/commonmark/internal/SimpleLocator.java
@@ -10,14 +10,16 @@
  * Contributors:
  *     David Green - initial API and implementation
  *     Alexander Fedorov (ArSysOp) - ongoing support
+ *     See git history
  *******************************************************************************/
 
 package org.eclipse.mylyn.wikitext.commonmark.internal;
 
-import static com.google.common.base.MoreObjects.toStringHelper;
 import static java.util.Objects.requireNonNull;
 
+import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.eclipse.mylyn.wikitext.parser.Locator;
+import org.eclipse.mylyn.wikitext.util.WikiToStringStyle;
 
 public class SimpleLocator implements Locator {
 
@@ -76,11 +78,12 @@ public class SimpleLocator implements Locator {
 
 	@Override
 	public String toString() {
-		return toStringHelper(Locator.class).add("lineNumber", lineNumber) //$NON-NLS-1$
-				.add("lineDocumentOffset", lineDocumentOffset) //$NON-NLS-1$
-				.add("lineLength", lineLength) //$NON-NLS-1$
-				.add("lineCharacterOffset", lineCharacterOffset) //$NON-NLS-1$
-				.add("lineSegmentEndOffset", lineSegmentEndOffset) //$NON-NLS-1$
+		return new ToStringBuilder(this, WikiToStringStyle.WIKI_TO_STRING_STYLE) //
+				.append("lineNumber", lineNumber) //$NON-NLS-1$
+				.append("lineDocumentOffset", lineDocumentOffset) //$NON-NLS-1$
+				.append("lineLength", lineLength) //$NON-NLS-1$
+				.append("lineCharacterOffset", lineCharacterOffset) //$NON-NLS-1$
+				.append("lineSegmentEndOffset", lineSegmentEndOffset) //$NON-NLS-1$
 				.toString();
 	}
 }

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark/src/main/java/org/eclipse/mylyn/wikitext/commonmark/internal/TextSegment.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark/src/main/java/org/eclipse/mylyn/wikitext/commonmark/internal/TextSegment.java
@@ -10,17 +10,19 @@
  * Contributors:
  *     David Green - initial API and implementation
  *     Alexander Fedorov (ArSysOp) - ongoing support
+ *     See git history
  *******************************************************************************/
 
 package org.eclipse.mylyn.wikitext.commonmark.internal;
 
-import static com.google.common.base.MoreObjects.toStringHelper;
-import static com.google.common.base.Preconditions.checkArgument;
 import static java.util.Objects.requireNonNull;
 
 import java.util.List;
+import java.util.stream.StreamSupport;
 
-import com.google.common.collect.ImmutableList;
+import org.apache.commons.lang3.Validate;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.eclipse.mylyn.wikitext.util.WikiToStringStyle;
 
 public class TextSegment {
 
@@ -29,7 +31,7 @@ public class TextSegment {
 	private final String text;
 
 	public TextSegment(Iterable<Line> lines) {
-		this.lines = ImmutableList.copyOf(lines);
+		this.lines = List.copyOf(StreamSupport.stream(lines.spliterator(), false).toList());
 		text = computeText(this.lines);
 	}
 
@@ -53,7 +55,7 @@ public class TextSegment {
 	}
 
 	public int offsetOf(int textOffset) {
-		checkArgument(textOffset >= 0);
+		Validate.isTrue(textOffset >= 0);
 		int textOffsetOfLine = 0;
 		int remainder = textOffset;
 		for (Line line : lines) {
@@ -82,7 +84,9 @@ public class TextSegment {
 
 	@Override
 	public String toString() {
-		return toStringHelper(TextSegment.class).add("text", ToStringHelper.toStringValue(text)).toString(); //$NON-NLS-1$
+		return new ToStringBuilder(this, WikiToStringStyle.WIKI_TO_STRING_STYLE) //
+				.append("text", text) //$NON-NLS-1$
+				.toString();
 	}
 
 	public Line getLineAtOffset(int textOffset) {

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark/src/main/java/org/eclipse/mylyn/wikitext/commonmark/internal/blocks/AbstractHtmlBlock.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark/src/main/java/org/eclipse/mylyn/wikitext/commonmark/internal/blocks/AbstractHtmlBlock.java
@@ -9,15 +9,15 @@
  *
  * Contributors:
  *     David Green - initial API and implementation
+ *     See git history
  *******************************************************************************/
 
 package org.eclipse.mylyn.wikitext.commonmark.internal.blocks;
 
-import static com.google.common.base.Preconditions.checkState;
-
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import org.apache.commons.lang3.Validate;
 import org.eclipse.mylyn.wikitext.commonmark.internal.Line;
 import org.eclipse.mylyn.wikitext.commonmark.internal.LineSequence;
 import org.eclipse.mylyn.wikitext.commonmark.internal.ProcessingContext;
@@ -39,7 +39,7 @@ abstract class AbstractHtmlBlock extends SourceBlock {
 
 			if (firstLine.equals(line)) {
 				Matcher matcher = startPattern().matcher(lineText);
-				checkState(matcher.matches());
+				Validate.isTrue(matcher.matches());
 				int offset = matcher.end(1);
 				if (offset < lineText.length() - 1) {
 					Matcher closeMatcher = closePattern().matcher(lineText);

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark/src/main/java/org/eclipse/mylyn/wikitext/commonmark/internal/blocks/AtxHeaderBlock.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark/src/main/java/org/eclipse/mylyn/wikitext/commonmark/internal/blocks/AtxHeaderBlock.java
@@ -10,16 +10,16 @@
  * Contributors:
  *     David Green - initial API and implementation
  *     Alexander Fedorov (ArSysOp) - ongoing support
+ *     See git history
  *******************************************************************************/
 
 package org.eclipse.mylyn.wikitext.commonmark.internal.blocks;
-
-import static com.google.common.base.Preconditions.checkState;
 
 import java.util.Collections;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import org.apache.commons.lang3.Validate;
 import org.eclipse.mylyn.wikitext.commonmark.internal.Line;
 import org.eclipse.mylyn.wikitext.commonmark.internal.LineSequence;
 import org.eclipse.mylyn.wikitext.commonmark.internal.ProcessingContext;
@@ -37,7 +37,7 @@ public class AtxHeaderBlock extends SourceBlock {
 	public void process(ProcessingContext context, DocumentBuilder builder, LineSequence lineSequence) {
 		Line currentLine = lineSequence.getCurrentLine();
 		Matcher matcher = PATTERN.matcher(currentLine.getText());
-		checkState(matcher.matches());
+		Validate.isTrue(matcher.matches());
 
 		lineSequence.advance();
 

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark/src/main/java/org/eclipse/mylyn/wikitext/commonmark/internal/blocks/FencedCodeBlock.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark/src/main/java/org/eclipse/mylyn/wikitext/commonmark/internal/blocks/FencedCodeBlock.java
@@ -10,16 +10,16 @@
  * Contributors:
  *     David Green - initial API and implementation
  *     Alexander Fedorov (ArSysOp) - ongoing support
+ *     See git history
  *******************************************************************************/
 
 package org.eclipse.mylyn.wikitext.commonmark.internal.blocks;
-
-import static com.google.common.base.Preconditions.checkState;
 
 import java.util.Collections;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import org.apache.commons.lang3.Validate;
 import org.eclipse.mylyn.wikitext.commonmark.internal.Line;
 import org.eclipse.mylyn.wikitext.commonmark.internal.LinePredicates;
 import org.eclipse.mylyn.wikitext.commonmark.internal.LineSequence;
@@ -38,7 +38,7 @@ public class FencedCodeBlock extends SourceBlock {
 	@Override
 	public void process(ProcessingContext context, DocumentBuilder builder, LineSequence lineSequence) {
 		Matcher matcher = openingFencePattern.matcher(lineSequence.getCurrentLine().getText());
-		checkState(matcher.matches());
+		Validate.isTrue(matcher.matches());
 		String indent = matcher.group(1);
 		boolean indentedCodeBlock = indent != null && indent.length() == 4;
 		Pattern closingFencePattern = closingFencePattern(matcher);
@@ -106,7 +106,7 @@ public class FencedCodeBlock extends SourceBlock {
 
 	boolean canEnd(Line line, Line startLine) {
 		Matcher matcher = openingFencePattern.matcher(startLine.getText());
-		checkState(matcher.matches());
+		Validate.isTrue(matcher.matches());
 		Pattern closingFencePattern = closingFencePattern(matcher);
 		return closingFencePattern.matcher(line.getText()).matches();
 	}

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark/src/main/java/org/eclipse/mylyn/wikitext/commonmark/internal/blocks/IndentedCodeBlock.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark/src/main/java/org/eclipse/mylyn/wikitext/commonmark/internal/blocks/IndentedCodeBlock.java
@@ -10,16 +10,16 @@
  * Contributors:
  *     David Green - initial API and implementation
  *     Alexander Fedorov (ArSysOp) - ongoing support
+ *     See git history
  *******************************************************************************/
 
 package org.eclipse.mylyn.wikitext.commonmark.internal.blocks;
-
-import static com.google.common.base.Preconditions.checkState;
 
 import java.util.Iterator;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import org.apache.commons.lang3.Validate;
 import org.eclipse.mylyn.wikitext.commonmark.internal.Line;
 import org.eclipse.mylyn.wikitext.commonmark.internal.LinePredicates;
 import org.eclipse.mylyn.wikitext.commonmark.internal.LineSequence;
@@ -45,7 +45,7 @@ public class IndentedCodeBlock extends SourceBlock {
 			Line line = iterator.next();
 			Matcher matcher = PATTERN.matcher(line.getText());
 			if (!matcher.matches()) {
-				checkState(line.isEmpty());
+				Validate.isTrue(line.isEmpty());
 				if (iterator.hasNext()) {
 					builder.characters("\n"); //$NON-NLS-1$
 				}

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark/src/main/java/org/eclipse/mylyn/wikitext/commonmark/internal/blocks/ListBlock.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark/src/main/java/org/eclipse/mylyn/wikitext/commonmark/internal/blocks/ListBlock.java
@@ -10,17 +10,17 @@
  * Contributors:
  *     David Green - initial API and implementation
  *     Alexander Fedorov (ArSysOp) - ongoing support
+ *     See git history
  *******************************************************************************/
 
 package org.eclipse.mylyn.wikitext.commonmark.internal.blocks;
-
-import static com.google.common.base.Preconditions.checkState;
 
 import java.util.List;
 import java.util.function.Predicate;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import org.apache.commons.lang3.Validate;
 import org.eclipse.mylyn.wikitext.commonmark.internal.CommonMark;
 import org.eclipse.mylyn.wikitext.commonmark.internal.Line;
 import org.eclipse.mylyn.wikitext.commonmark.internal.LineSequence;
@@ -230,7 +230,7 @@ public class ListBlock extends BlockWithNestedBlocks {
 
 	private int calculateLineItemIndent(Line line) {
 		Matcher matcher = bulletPattern.matcher(line.getText());
-		checkState(matcher.matches());
+		Validate.isTrue(matcher.matches());
 		int start = matcher.start(6);
 		if (start == -1) {
 			start = line.getText().length() + 1;
@@ -251,14 +251,14 @@ public class ListBlock extends BlockWithNestedBlocks {
 
 	private char bulletType(Line line) {
 		Matcher matcher = bulletPattern.matcher(line.getText());
-		checkState(matcher.matches());
+		Validate.isTrue(matcher.matches());
 		String text = matcher.group(1);
 		return text.charAt(text.length() - 1);
 	}
 
 	private String listStart(Line line) {
 		Matcher matcher = bulletPattern.matcher(line.getText());
-		checkState(matcher.matches());
+		Validate.isTrue(matcher.matches());
 		String marker = matcher.group(4);
 		if ("1".equals(marker)) { //$NON-NLS-1$
 			marker = null;

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark/src/main/java/org/eclipse/mylyn/wikitext/commonmark/internal/blocks/SetextHeaderBlock.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark/src/main/java/org/eclipse/mylyn/wikitext/commonmark/internal/blocks/SetextHeaderBlock.java
@@ -10,16 +10,16 @@
  * Contributors:
  *     David Green - initial API and implementation
  *     Alexander Fedorov (ArSysOp) - ongoing support
+ *     See git history
  *******************************************************************************/
 
 package org.eclipse.mylyn.wikitext.commonmark.internal.blocks;
-
-import static com.google.common.base.Preconditions.checkState;
 
 import java.util.Collections;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import org.apache.commons.lang3.Validate;
 import org.eclipse.mylyn.wikitext.commonmark.internal.Line;
 import org.eclipse.mylyn.wikitext.commonmark.internal.LineSequence;
 import org.eclipse.mylyn.wikitext.commonmark.internal.ProcessingContext;
@@ -40,7 +40,7 @@ public class SetextHeaderBlock extends SourceBlock {
 		Line currentLine = lineSequence.getCurrentLine();
 		Line nextLine = lineSequence.getNextLine();
 		Matcher matcher = setextUnderlinePattern.matcher(nextLine.getText());
-		checkState(matcher.matches());
+		Validate.isTrue(matcher.matches());
 
 		lineSequence.advance();
 

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark/src/main/java/org/eclipse/mylyn/wikitext/commonmark/internal/inlines/CodeSpan.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark/src/main/java/org/eclipse/mylyn/wikitext/commonmark/internal/inlines/CodeSpan.java
@@ -10,6 +10,7 @@
  * Contributors:
  *     David Green - initial API and implementation
  *     Alexander Fedorov (ArSysOp) - ongoing support
+ *     See git history
  *******************************************************************************/
 
 package org.eclipse.mylyn.wikitext.commonmark.internal.inlines;
@@ -18,7 +19,7 @@ import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import com.google.common.base.Strings;
+import org.apache.commons.lang3.StringUtils;
 
 public class CodeSpan extends SourceSpan {
 
@@ -32,7 +33,8 @@ public class CodeSpan extends SourceSpan {
 			if (matcher.matches()) {
 				String openingBackticks = matcher.group(1);
 				int backtickCount = openingBackticks.length();
-				Pattern closingPattern = Pattern.compile("(?<!`)(" + Strings.repeat("`", backtickCount) + ")([^`]|$)", //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+				Pattern closingPattern = Pattern.compile(
+						"(?<!`)(" + StringUtils.repeat("`", backtickCount) + ")([^`]|$)", //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
 						Pattern.DOTALL | Pattern.MULTILINE);
 				cursor.advance(backtickCount);
 				String textAtOffset = cursor.getTextAtOffset();

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark/src/main/java/org/eclipse/mylyn/wikitext/commonmark/internal/inlines/Cursor.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark/src/main/java/org/eclipse/mylyn/wikitext/commonmark/internal/inlines/Cursor.java
@@ -9,16 +9,16 @@
  *
  * Contributors:
  *     David Green - initial API and implementation
+ *     See git history
  *******************************************************************************/
 
 package org.eclipse.mylyn.wikitext.commonmark.internal.inlines;
-
-import static com.google.common.base.Preconditions.checkArgument;
 
 import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import org.apache.commons.lang3.Validate;
 import org.eclipse.mylyn.wikitext.commonmark.internal.Line;
 import org.eclipse.mylyn.wikitext.commonmark.internal.TextSegment;
 
@@ -106,7 +106,7 @@ public class Cursor {
 
 	public char getPrevious(int offset) {
 		int charOffset = textOffset - offset;
-		checkArgument(charOffset >= 0);
+		Validate.isTrue(charOffset >= 0);
 		return text.charAt(charOffset);
 	}
 
@@ -115,7 +115,7 @@ public class Cursor {
 	}
 
 	public char getNext(int offset) {
-		checkArgument(offset >= 0);
+		Validate.isTrue(offset >= 0);
 		return text.charAt(textOffset + offset);
 	}
 
@@ -124,7 +124,7 @@ public class Cursor {
 	}
 
 	public String getTextAtOffset(int length) {
-		checkArgument(length > 0);
+		Validate.isTrue(length > 0);
 		return text.substring(textOffset, textOffset + length);
 	}
 
@@ -133,7 +133,7 @@ public class Cursor {
 	}
 
 	public boolean hasNext(int offset) {
-		checkArgument(offset > 0);
+		Validate.isTrue(offset > 0);
 		return textOffset + offset < text.length();
 	}
 
@@ -142,7 +142,7 @@ public class Cursor {
 	}
 
 	public Matcher matcher(int offset, Pattern pattern) {
-		checkArgument(offset >= 0 && offset + textOffset < text.length());
+		Validate.isTrue(offset >= 0 && offset + textOffset < text.length());
 		Objects.requireNonNull(pattern);
 		Matcher matcher = pattern.matcher(text);
 		matcher.region(textOffset + offset, text.length());
@@ -156,14 +156,14 @@ public class Cursor {
 	}
 
 	public void advance(int count) {
-		checkArgument(count >= 0);
+		Validate.isTrue(count >= 0);
 		for (int x = 0; x < count; ++x) {
 			advance();
 		}
 	}
 
 	public void rewind(int count) {
-		checkArgument(count >= 0);
+		Validate.isTrue(count >= 0);
 		for (int x = 0; x < count; ++x) {
 			rewind();
 		}

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark/src/main/java/org/eclipse/mylyn/wikitext/commonmark/internal/inlines/Image.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark/src/main/java/org/eclipse/mylyn/wikitext/commonmark/internal/inlines/Image.java
@@ -10,19 +10,20 @@
  * Contributors:
  *     David Green - initial API and implementation
  *     Alexander Fedorov (ArSysOp) - ongoing support
+ *     See git history
  *******************************************************************************/
 
 package org.eclipse.mylyn.wikitext.commonmark.internal.inlines;
 
-import static com.google.common.base.MoreObjects.toStringHelper;
-
 import java.util.List;
 import java.util.Objects;
 
+import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.eclipse.mylyn.wikitext.commonmark.internal.Line;
 import org.eclipse.mylyn.wikitext.commonmark.internal.ToStringHelper;
 import org.eclipse.mylyn.wikitext.parser.DocumentBuilder;
 import org.eclipse.mylyn.wikitext.parser.ImageAttributes;
+import org.eclipse.mylyn.wikitext.util.WikiToStringStyle;
 
 public class Image extends InlineWithNestedContents {
 
@@ -72,11 +73,12 @@ public class Image extends InlineWithNestedContents {
 
 	@Override
 	public String toString() {
-		return toStringHelper(Image.class).add("offset", getOffset()) //$NON-NLS-1$
-				.add("length", getLength()) //$NON-NLS-1$
-				.add("src", ToStringHelper.toStringValue(src)) //$NON-NLS-1$
-				.add("title", title) //$NON-NLS-1$
-				.add("contents", getContents()) //$NON-NLS-1$
+		return new ToStringBuilder(this, WikiToStringStyle.WIKI_TO_STRING_STYLE) //
+				.append("offset", getOffset()) //$NON-NLS-1$
+				.append("length", getLength()) //$NON-NLS-1$
+				.append("src", ToStringHelper.toStringValue(src)) //$NON-NLS-1$
+				.append("title", title) //$NON-NLS-1$
+				.append("contents", getContents()) //$NON-NLS-1$
 				.toString();
 	}
 }

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark/src/main/java/org/eclipse/mylyn/wikitext/commonmark/internal/inlines/Inline.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark/src/main/java/org/eclipse/mylyn/wikitext/commonmark/internal/inlines/Inline.java
@@ -10,23 +10,24 @@
  * Contributors:
  *     David Green - initial API and implementation
  *     Alexander Fedorov (ArSysOp) - ongoing support
+ *     See git history
  *******************************************************************************/
 
 package org.eclipse.mylyn.wikitext.commonmark.internal.inlines;
-
-import static com.google.common.base.MoreObjects.toStringHelper;
-import static com.google.common.base.Preconditions.checkArgument;
 
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 
+import org.apache.commons.lang3.Validate;
+import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.eclipse.mylyn.wikitext.commonmark.internal.Line;
 import org.eclipse.mylyn.wikitext.commonmark.internal.ProcessingContext;
 import org.eclipse.mylyn.wikitext.commonmark.internal.ProcessingContextBuilder;
 import org.eclipse.mylyn.wikitext.commonmark.internal.SimpleLocator;
 import org.eclipse.mylyn.wikitext.parser.DocumentBuilder;
 import org.eclipse.mylyn.wikitext.parser.Locator;
+import org.eclipse.mylyn.wikitext.util.WikiToStringStyle;
 
 public abstract class Inline {
 
@@ -40,8 +41,8 @@ public abstract class Inline {
 		this.line = Objects.requireNonNull(line);
 		this.offset = offset;
 		this.length = length;
-		checkArgument(offset >= 0);
-		checkArgument(length > 0);
+		Validate.isTrue(offset >= 0);
+		Validate.isTrue(length > 0);
 	}
 
 	public int getOffset() {
@@ -95,6 +96,9 @@ public abstract class Inline {
 
 	@Override
 	public String toString() {
-		return toStringHelper(getClass()).add("offset", getOffset()).add("length", getLength()).toString(); //$NON-NLS-1$//$NON-NLS-2$
+		return new ToStringBuilder(this, WikiToStringStyle.WIKI_TO_STRING_STYLE) //
+				.append("offset", getOffset()) //$NON-NLS-1$
+				.append("length", getLength()) //$NON-NLS-1$
+				.toString();
 	}
 }

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark/src/main/java/org/eclipse/mylyn/wikitext/commonmark/internal/inlines/InlineParser.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark/src/main/java/org/eclipse/mylyn/wikitext/commonmark/internal/inlines/InlineParser.java
@@ -101,7 +101,7 @@ public class InlineParser {
 			@Override
 			public void entityReference(String entity) {
 				stringBuilder
-				.append(Objects.requireNonNullElse(EntityReferences.instance().equivalentString(entity), ""));
+						.append(Objects.requireNonNullElse(EntityReferences.instance().equivalentString(entity), "")); //$NON-NLS-1$
 			}
 		};
 		for (Inline inline : contents) {

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark/src/main/java/org/eclipse/mylyn/wikitext/commonmark/internal/inlines/InlineParser.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark/src/main/java/org/eclipse/mylyn/wikitext/commonmark/internal/inlines/InlineParser.java
@@ -10,15 +10,15 @@
  * Contributors:
  *     David Green - initial API and implementation
  *     Alexander Fedorov (ArSysOp) - ongoing support
+ *     See git history
  *******************************************************************************/
 
 package org.eclipse.mylyn.wikitext.commonmark.internal.inlines;
 
-import static com.google.common.base.MoreObjects.firstNonNull;
-
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 
 import org.eclipse.mylyn.wikitext.commonmark.internal.ProcessingContext;
@@ -100,7 +100,8 @@ public class InlineParser {
 
 			@Override
 			public void entityReference(String entity) {
-				stringBuilder.append(firstNonNull(EntityReferences.instance().equivalentString(entity), "")); //$NON-NLS-1$
+				stringBuilder
+				.append(Objects.requireNonNullElse(EntityReferences.instance().equivalentString(entity), ""));
 			}
 		};
 		for (Inline inline : contents) {

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark/src/main/java/org/eclipse/mylyn/wikitext/commonmark/internal/inlines/InlineWithNestedContents.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark/src/main/java/org/eclipse/mylyn/wikitext/commonmark/internal/inlines/InlineWithNestedContents.java
@@ -10,16 +10,17 @@
  * Contributors:
  *     David Green - initial API and implementation
  *     Alexander Fedorov (ArSysOp) - ongoing support
+ *     See git history
  *******************************************************************************/
 
 package org.eclipse.mylyn.wikitext.commonmark.internal.inlines;
 
-import static com.google.common.base.MoreObjects.toStringHelper;
-
 import java.util.List;
 import java.util.Objects;
 
+import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.eclipse.mylyn.wikitext.commonmark.internal.Line;
+import org.eclipse.mylyn.wikitext.util.WikiToStringStyle;
 
 public abstract class InlineWithNestedContents extends Inline {
 
@@ -53,9 +54,10 @@ public abstract class InlineWithNestedContents extends Inline {
 
 	@Override
 	public String toString() {
-		return toStringHelper(getClass()).add("offset", getOffset()) //$NON-NLS-1$
-				.add("length", getLength()) //$NON-NLS-1$
-				.add("contents", getContents()) //$NON-NLS-1$
+		return new ToStringBuilder(this, WikiToStringStyle.WIKI_TO_STRING_STYLE) //
+				.append("offset", getOffset()) //$NON-NLS-1$
+				.append("length", getLength()) //$NON-NLS-1$
+				.append("contents", getContents()) //$NON-NLS-1$
 				.toString();
 	}
 }

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark/src/main/java/org/eclipse/mylyn/wikitext/commonmark/internal/inlines/InlineWithText.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark/src/main/java/org/eclipse/mylyn/wikitext/commonmark/internal/inlines/InlineWithText.java
@@ -10,15 +10,16 @@
  * Contributors:
  *     David Green - initial API and implementation
  *     Alexander Fedorov (ArSysOp) - ongoing support
+ *     See git history
  *******************************************************************************/
 
 package org.eclipse.mylyn.wikitext.commonmark.internal.inlines;
 
-import static com.google.common.base.MoreObjects.toStringHelper;
-
 import java.util.Objects;
 
+import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.eclipse.mylyn.wikitext.commonmark.internal.Line;
+import org.eclipse.mylyn.wikitext.util.WikiToStringStyle;
 
 abstract class InlineWithText extends Inline {
 
@@ -52,9 +53,10 @@ abstract class InlineWithText extends Inline {
 
 	@Override
 	public String toString() {
-		return toStringHelper(getClass()).add("offset", getOffset()) //$NON-NLS-1$
-				.add("length", getLength()) //$NON-NLS-1$
-				.add("text", getText()) //$NON-NLS-1$
+		return new ToStringBuilder(this, WikiToStringStyle.WIKI_TO_STRING_STYLE) //
+				.append("offset", getOffset()) //$NON-NLS-1$
+				.append("length", getLength()) //$NON-NLS-1$
+				.append("text", getText()) //$NON-NLS-1$
 				.toString();
 	}
 }

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark/src/main/java/org/eclipse/mylyn/wikitext/commonmark/internal/inlines/InlinesSubstitution.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark/src/main/java/org/eclipse/mylyn/wikitext/commonmark/internal/inlines/InlinesSubstitution.java
@@ -9,15 +9,15 @@
  *
  * Contributors:
  *     David Green - initial API and implementation
+ *     See git history
  *******************************************************************************/
 
 package org.eclipse.mylyn.wikitext.commonmark.internal.inlines;
 
 import static java.util.Objects.requireNonNull;
 
+import java.util.ArrayList;
 import java.util.List;
-
-import com.google.common.collect.ImmutableList;
 
 class InlinesSubstitution {
 
@@ -34,7 +34,7 @@ class InlinesSubstitution {
 	}
 
 	public List<Inline> apply(List<Inline> inlines) {
-		ImmutableList.Builder<Inline> builder = ImmutableList.builder();
+		List<Inline> builder = new ArrayList<>();
 
 		boolean inReplacementSegment = false;
 		for (Inline inline : inlines) {
@@ -49,6 +49,6 @@ class InlinesSubstitution {
 				inReplacementSegment = false;
 			}
 		}
-		return builder.build();
+		return List.copyOf(builder);
 	}
 }

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark/src/main/java/org/eclipse/mylyn/wikitext/commonmark/internal/inlines/Link.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark/src/main/java/org/eclipse/mylyn/wikitext/commonmark/internal/inlines/Link.java
@@ -10,20 +10,21 @@
  * Contributors:
  *     David Green - initial API and implementation
  *     Alexander Fedorov (ArSysOp) - ongoing support
+ *     See git history
  *******************************************************************************/
 
 package org.eclipse.mylyn.wikitext.commonmark.internal.inlines;
 
-import static com.google.common.base.MoreObjects.toStringHelper;
-
 import java.util.List;
 import java.util.Objects;
 
+import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.eclipse.mylyn.wikitext.commonmark.internal.Line;
 import org.eclipse.mylyn.wikitext.commonmark.internal.ToStringHelper;
 import org.eclipse.mylyn.wikitext.parser.DocumentBuilder;
 import org.eclipse.mylyn.wikitext.parser.DocumentBuilder.SpanType;
 import org.eclipse.mylyn.wikitext.parser.LinkAttributes;
+import org.eclipse.mylyn.wikitext.util.WikiToStringStyle;
 
 public class Link extends InlineWithNestedContents {
 
@@ -73,11 +74,12 @@ public class Link extends InlineWithNestedContents {
 
 	@Override
 	public String toString() {
-		return toStringHelper(Link.class).add("offset", getOffset()) //$NON-NLS-1$
-				.add("length", getLength()) //$NON-NLS-1$
-				.add("href", ToStringHelper.toStringValue(href)) //$NON-NLS-1$
-				.add("title", title) //$NON-NLS-1$
-				.add("contents", getContents()) //$NON-NLS-1$
+		return new ToStringBuilder(this, WikiToStringStyle.WIKI_TO_STRING_STYLE) //
+				.append("offset", getOffset()) //$NON-NLS-1$
+				.append("length", getLength()) //$NON-NLS-1$
+				.append("href", ToStringHelper.toStringValue(href)) //$NON-NLS-1$
+				.append("title", title) //$NON-NLS-1$
+				.append("contents", getContents()) //$NON-NLS-1$
 				.toString();
 	}
 }

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark/src/main/java/org/eclipse/mylyn/wikitext/commonmark/internal/inlines/PotentialBracketEndDelimiter.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark/src/main/java/org/eclipse/mylyn/wikitext/commonmark/internal/inlines/PotentialBracketEndDelimiter.java
@@ -10,11 +10,10 @@
  * Contributors:
  *     David Green - initial API and implementation
  *     Alexander Fedorov (ArSysOp) - ongoing support
+ *     See git history
  *******************************************************************************/
 
 package org.eclipse.mylyn.wikitext.commonmark.internal.inlines;
-
-import static com.google.common.base.MoreObjects.firstNonNull;
 
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
@@ -24,6 +23,7 @@ import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import org.apache.commons.lang3.StringUtils;
 import org.eclipse.mylyn.wikitext.commonmark.internal.Line;
 import org.eclipse.mylyn.wikitext.commonmark.internal.ProcessingContext;
 import org.eclipse.mylyn.wikitext.commonmark.internal.ProcessingContext.NamedUriWithTitle;
@@ -31,7 +31,6 @@ import org.eclipse.mylyn.wikitext.parser.DocumentBuilder;
 import org.eclipse.mylyn.wikitext.parser.builder.EntityReferences;
 
 import com.google.common.base.CharMatcher;
-import com.google.common.base.Strings;
 import com.google.common.escape.Escaper;
 import com.google.common.net.UrlEscapers;
 
@@ -133,7 +132,7 @@ public class PotentialBracketEndDelimiter extends InlineWithText {
 					String title = linkTitle(matcher);
 
 					if (!(referenceDefinition
-							&& (Strings.isNullOrEmpty(uri) || hasContentOnSameLine(matcher, cursor)))) {
+							&& (StringUtils.isEmpty(uri) || hasContentOnSameLine(matcher, cursor)))) {
 						String referenceName = null;
 						if (referenceDefinition) {
 							referenceName = toReferenceName(referenceName(cursor, contents));
@@ -307,7 +306,7 @@ public class PotentialBracketEndDelimiter extends InlineWithText {
 		if (uriWithEscapes == null) {
 			uriWithEscapes = matcher.group(2);
 		}
-		uriWithEscapes = firstNonNull(uriWithEscapes, ""); //$NON-NLS-1$
+		uriWithEscapes = Objects.requireNonNullElse(uriWithEscapes, ""); //$NON-NLS-1$
 		return normalizeUri(uriWithEscapes);
 	}
 

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark/src/main/java/org/eclipse/mylyn/wikitext/commonmark/internal/inlines/PotentialEmphasisDelimiter.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark/src/main/java/org/eclipse/mylyn/wikitext/commonmark/internal/inlines/PotentialEmphasisDelimiter.java
@@ -9,17 +9,17 @@
  *
  * Contributors:
  *     David Green - initial API and implementation
+ *     See git history
  *******************************************************************************/
 
 package org.eclipse.mylyn.wikitext.commonmark.internal.inlines;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
 import org.eclipse.mylyn.wikitext.commonmark.internal.Line;
 import org.eclipse.mylyn.wikitext.parser.DocumentBuilder;
-
-import com.google.common.collect.ImmutableList;
 
 class PotentialEmphasisDelimiter extends InlineWithText {
 
@@ -58,7 +58,7 @@ class PotentialEmphasisDelimiter extends InlineWithText {
 			Inline emphasis = createEmphasis(openingDelimiter.getLine(), spanOffset, spanLength, delimiterSize,
 					contents);
 
-			ImmutableList.Builder<Inline> substitutionInlines = ImmutableList.builder();
+			List<Inline> substitutionInlines = new ArrayList<>();
 			if (delimiterSize < openingDelimiter.getLength()) {
 				substitutionInlines.add(createPotentialOpeningDelimiter(openingDelimiter, delimiterSize));
 			}
@@ -67,7 +67,7 @@ class PotentialEmphasisDelimiter extends InlineWithText {
 				substitutionInlines.add(createPotentialClosingDelimiter(delimiterSize));
 			}
 
-			return Optional.of(new InlinesSubstitution(openingDelimiter, this, substitutionInlines.build()));
+			return Optional.of(new InlinesSubstitution(openingDelimiter, this, List.copyOf(substitutionInlines)));
 		}
 		return Optional.empty();
 	}

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark/src/main/java/org/eclipse/mylyn/wikitext/commonmark/internal/inlines/ReferenceDefinition.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark/src/main/java/org/eclipse/mylyn/wikitext/commonmark/internal/inlines/ReferenceDefinition.java
@@ -10,15 +10,16 @@
  * Contributors:
  *     David Green - initial API and implementation
  *     Alexander Fedorov (ArSysOp) - ongoing support
+ *     See git history
  *******************************************************************************/
 
 package org.eclipse.mylyn.wikitext.commonmark.internal.inlines;
 
-import static com.google.common.base.MoreObjects.toStringHelper;
 import static java.util.Objects.requireNonNull;
 
 import java.util.Objects;
 
+import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.eclipse.mylyn.wikitext.commonmark.internal.Line;
 import org.eclipse.mylyn.wikitext.commonmark.internal.ProcessingContextBuilder;
 import org.eclipse.mylyn.wikitext.commonmark.internal.ToStringHelper;
@@ -72,11 +73,11 @@ public class ReferenceDefinition extends Inline {
 
 	@Override
 	public String toString() {
-		return toStringHelper(ReferenceDefinition.class).add("offset", getOffset()) //$NON-NLS-1$
-				.add("length", getLength()) //$NON-NLS-1$
-				.add("name", name) //$NON-NLS-1$
-				.add("href", ToStringHelper.toStringValue(href)) //$NON-NLS-1$
-				.add("title", title) //$NON-NLS-1$
+		return new ToStringBuilder(ReferenceDefinition.class).append("offset", getOffset()) //$NON-NLS-1$
+				.append("length", getLength()) //$NON-NLS-1$
+				.append("name", name) //$NON-NLS-1$
+				.append("href", ToStringHelper.toStringValue(href)) //$NON-NLS-1$
+				.append("title", title) //$NON-NLS-1$
 				.toString();
 	}
 }

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.confluence.tests/META-INF/MANIFEST.MF
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.confluence.tests/META-INF/MANIFEST.MF
@@ -8,8 +8,7 @@ Bundle-Vendor: Eclipse Mylyn
 Fragment-Host: org.eclipse.mylyn.wikitext.confluence
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=17))"
-Import-Package: com.google.common.base;version="[33.0,34.0)",
- com.google.common.io;version="[33.0.0,34.0.0)",
+Import-Package: org.apache.commons.io;version="[2.16.0,3.0.0)",
  org.eclipse.mylyn.wikitext.html;version="4.4.0",
  org.eclipse.mylyn.wikitext.parser;version="[4.2,5)",
  org.eclipse.mylyn.wikitext.parser.builder;version="[4.2,5)",

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.confluence.tests/src/test/java/org/eclipse/mylyn/wikitext/confluence/internal/tests/ConfluenceDocumentBuilderTest.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.confluence.tests/src/test/java/org/eclipse/mylyn/wikitext/confluence/internal/tests/ConfluenceDocumentBuilderTest.java
@@ -10,6 +10,7 @@
  * Contributors:
  *     David Green - initial API and implementation
  *     ArSysOp - ongoing support
+ *     See git history
  *******************************************************************************/
 
 package org.eclipse.mylyn.wikitext.confluence.internal.tests;
@@ -31,7 +32,7 @@ import org.junit.Test;
  * @author David Green
  * @see ConfluenceDocumentBuilder
  */
-@SuppressWarnings({ "nls", "restriction" })
+@SuppressWarnings("nls")
 public class ConfluenceDocumentBuilderTest {
 
 	private final StringWriter out = new StringWriter();

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.confluence.tests/src/test/java/org/eclipse/mylyn/wikitext/confluence/tests/ConfluenceLanguageTest.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.confluence.tests/src/test/java/org/eclipse/mylyn/wikitext/confluence/tests/ConfluenceLanguageTest.java
@@ -11,6 +11,7 @@
  *     David Green - initial API and implementation
  *     Patrick Boisclair - tests for bug 354077
  *     ArSysOp - ongoing support
+ *     See git history
  *******************************************************************************/
 package org.eclipse.mylyn.wikitext.confluence.tests;
 
@@ -27,6 +28,7 @@ import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
 import java.util.regex.Pattern;
 
+import org.apache.commons.io.IOUtils;
 import org.eclipse.mylyn.wikitext.confluence.ConfluenceLanguage;
 import org.eclipse.mylyn.wikitext.parser.builder.DocBookDocumentBuilder;
 import org.eclipse.mylyn.wikitext.parser.builder.HtmlDocumentBuilder;
@@ -35,8 +37,6 @@ import org.eclipse.mylyn.wikitext.toolkit.AbstractMarkupGenerationTest;
 import org.eclipse.mylyn.wikitext.toolkit.RecordingDocumentBuilder;
 import org.eclipse.mylyn.wikitext.util.ServiceLocator;
 import org.junit.Test;
-
-import com.google.common.io.Resources;
 
 /**
  * @author David Green
@@ -1306,7 +1306,7 @@ public class ConfluenceLanguageTest extends AbstractMarkupGenerationTest<Conflue
 	 */
 	@Test
 	public void testHangOnBug318695() throws IOException {
-		String content = Resources.toString(ConfluenceLanguageTest.class.getResource("resources/bug318695.confluence"),
+		String content = IOUtils.toString(ConfluenceLanguageTest.class.getResource("resources/bug318695.confluence"),
 				StandardCharsets.UTF_8);
 		parser.setBuilder(new HtmlDocumentBuilder(new StringWriter()));
 		parser.parse(new StringReader(content));
@@ -1318,7 +1318,7 @@ public class ConfluenceLanguageTest extends AbstractMarkupGenerationTest<Conflue
 	 */
 	@Test
 	public void stackOverflowWithLargeContentOnBug424387() throws IOException {
-		String content = Resources.toString(ConfluenceLanguageTest.class.getResource("resources/bug424387.confluence"),
+		String content = IOUtils.toString(ConfluenceLanguageTest.class.getResource("resources/bug424387.confluence"),
 				StandardCharsets.UTF_8);
 		parser.setBuilder(new HtmlDocumentBuilder(new StringWriter()));
 		parser.parse(new StringReader(content));
@@ -1330,7 +1330,7 @@ public class ConfluenceLanguageTest extends AbstractMarkupGenerationTest<Conflue
 	 */
 	@Test
 	public void stackOverflowWithLargeContentInTable() throws IOException {
-		String content = Resources.toString(ConfluenceLanguageTest.class.getResource("resources/bug533397.confluence"),
+		String content = IOUtils.toString(ConfluenceLanguageTest.class.getResource("resources/bug533397.confluence"),
 				StandardCharsets.UTF_8);
 		parser.setBuilder(new HtmlDocumentBuilder(new StringWriter()));
 		parser.parse(new StringReader(content));

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.confluence/META-INF/MANIFEST.MF
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.confluence/META-INF/MANIFEST.MF
@@ -8,7 +8,7 @@ Bundle-Vendor: Eclipse Mylyn
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=17))"
 Import-Package: com.google.common.base;version="[33.0,34.0)",
- com.google.common.io;version="[33.0.0,34.0.0)";resolution:=optional,
+ org.apache.commons.lang3;version="[3.14.0,4.0.0)",
  org.eclipse.mylyn.wikitext.confluence,
  org.eclipse.mylyn.wikitext.confluence.internal,
  org.eclipse.mylyn.wikitext.confluence.internal.block,

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.confluence/src/main/java/org/eclipse/mylyn/wikitext/confluence/internal/ConfluenceDocumentBuilder.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.confluence/src/main/java/org/eclipse/mylyn/wikitext/confluence/internal/ConfluenceDocumentBuilder.java
@@ -10,11 +10,10 @@
  * Contributors:
  *     David Green - initial API and implementation
  *     ArSysOp - ongoing support
+ *     See git history
  *******************************************************************************/
 
 package org.eclipse.mylyn.wikitext.confluence.internal;
-
-import static com.google.common.base.Preconditions.checkState;
 
 import java.io.IOException;
 import java.io.StringWriter;
@@ -25,6 +24,8 @@ import java.util.logging.Logger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Validate;
 import org.eclipse.mylyn.wikitext.confluence.ConfluenceLanguage;
 import org.eclipse.mylyn.wikitext.confluence.internal.util.Colors;
 import org.eclipse.mylyn.wikitext.parser.Attributes;
@@ -35,7 +36,6 @@ import org.eclipse.mylyn.wikitext.parser.builder.AbstractMarkupDocumentBuilder;
 import org.eclipse.mylyn.wikitext.parser.builder.EntityReferences;
 
 import com.google.common.base.CharMatcher;
-import com.google.common.base.Strings;
 
 /**
  * a document builder that emits Confluence markup
@@ -188,7 +188,8 @@ public class ConfluenceDocumentBuilder extends AbstractMarkupDocumentBuilder {
 			boolean contentIsEmpty = content.equals(prefix);
 
 			if (!contentIsEmpty || emitWhenEmpty) {
-				checkState(content.startsWith(prefix), "Expected content to start with prefix \"%s\"", content, prefix); //$NON-NLS-1$
+				Validate.isTrue(content.startsWith(prefix), "Expected content to start with prefix \"%s\"", content, //$NON-NLS-1$
+						prefix);
 				content = content.substring(prefix.length());
 
 				if (requireAdjacentSeparator && !isSpanSuffixAdjacentToSpanPrefix()) {
@@ -217,7 +218,7 @@ public class ConfluenceDocumentBuilder extends AbstractMarkupDocumentBuilder {
 		}
 
 		private boolean isSpanSuffixAdjacentToSpanPrefix() {
-			if (!Strings.isNullOrEmpty(prefix) && isSpanMarkup(getLastChar()) && isSpanMarkup(prefix.charAt(0))) {
+			if (StringUtils.isNotEmpty(prefix) && isSpanMarkup(getLastChar()) && isSpanMarkup(prefix.charAt(0))) {
 				return true;
 			}
 			return false;
@@ -274,14 +275,14 @@ public class ConfluenceDocumentBuilder extends AbstractMarkupDocumentBuilder {
 		protected void emitContent(String content) throws IOException {
 			//[Example|http://example.com|title]
 			// [Example|http://example.com]
-			if (!Strings.isNullOrEmpty(content)) {
+			if (StringUtils.isNotEmpty(content)) {
 				super.emitContent(content);
 				super.emitContent(" | ");//$NON-NLS-1$
 			}
 			if (attributes.getHref() != null) {
 				super.emitContent(attributes.getHref());
 			}
-			if (!Strings.isNullOrEmpty(attributes.getTitle())) {
+			if (StringUtils.isNotEmpty(attributes.getTitle())) {
 				super.emitContent(" | ");//$NON-NLS-1$
 				super.emitContent(attributes.getTitle());
 			}
@@ -296,7 +297,7 @@ public class ConfluenceDocumentBuilder extends AbstractMarkupDocumentBuilder {
 
 		@Override
 		protected void emitContent(String content) throws IOException {
-			if (Strings.isNullOrEmpty(content) || content.trim().isEmpty()) {
+			if (StringUtils.isEmpty(content) || content.trim().isEmpty()) {
 				content = " "; //$NON-NLS-1$
 			}
 			super.emitContent(content);
@@ -615,10 +616,10 @@ public class ConfluenceDocumentBuilder extends AbstractMarkupDocumentBuilder {
 	private void writeImageAttributes(Attributes attributes) throws IOException {
 		if (attributes instanceof ImageAttributes imageAttributes) {
 			String attributeMarkup = ""; //$NON-NLS-1$
-			if (!Strings.isNullOrEmpty(imageAttributes.getAlt())) {
+			if (StringUtils.isNotEmpty(imageAttributes.getAlt())) {
 				attributeMarkup = "alt=\"" + imageAttributes.getAlt() + "\""; //$NON-NLS-1$ //$NON-NLS-2$
 			}
-			if (!Strings.isNullOrEmpty(imageAttributes.getTitle())) {
+			if (StringUtils.isNotEmpty(imageAttributes.getTitle())) {
 				if (!attributeMarkup.isEmpty()) {
 					attributeMarkup += ","; //$NON-NLS-1$
 				}

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.creole.tests/META-INF/MANIFEST.MF
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.creole.tests/META-INF/MANIFEST.MF
@@ -8,8 +8,7 @@ Bundle-Vendor: Eclipse Mylyn
 Fragment-Host: org.eclipse.mylyn.wikitext.creole
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=17))"
-Import-Package: com.google.common.base;version="[33.0,34.0)",
- org.eclipse.mylyn.wikitext.html;version="4.4.0",
+Import-Package: org.eclipse.mylyn.wikitext.html;version="4.4.0",
  org.eclipse.mylyn.wikitext.parser;version="[4.2,5)",
  org.eclipse.mylyn.wikitext.parser.builder;version="[4.2,5)",
  org.eclipse.mylyn.wikitext.parser.markup;version="[4.2,5)",

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.creole.tests/src/test/java/org/eclipse/mylyn/internal/wikitext/creole/tests/documentbuilder/AbstractCreoleDocumentBuilderTest.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.creole.tests/src/test/java/org/eclipse/mylyn/internal/wikitext/creole/tests/documentbuilder/AbstractCreoleDocumentBuilderTest.java
@@ -10,6 +10,7 @@
  * Contributors:
  *     Kevin de Vlaming - initial API and implementation
  *     ArSysOp - ongoing support
+ *     See git history
  *******************************************************************************/
 
 package org.eclipse.mylyn.internal.wikitext.creole.tests.documentbuilder;
@@ -25,7 +26,6 @@ import org.junit.Before;
 /**
  * @author Kevin de Vlaming
  */
-@SuppressWarnings("restriction")
 public abstract class AbstractCreoleDocumentBuilderTest {
 
 	protected DocumentBuilder builder;

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.creole.tests/src/test/java/org/eclipse/mylyn/internal/wikitext/creole/tests/documentbuilder/CreoleDocumentBuilderBlockTest.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.creole.tests/src/test/java/org/eclipse/mylyn/internal/wikitext/creole/tests/documentbuilder/CreoleDocumentBuilderBlockTest.java
@@ -10,6 +10,7 @@
  * Contributors:
  *     Kevin de Vlaming - initial API and implementation
  *     ArSysOp - ongoing support
+ *     See git history
  *******************************************************************************/
 
 package org.eclipse.mylyn.internal.wikitext.creole.tests.documentbuilder;
@@ -25,7 +26,7 @@ import org.junit.Test;
  * @see http://www.wikicreole.org/wiki/Elements
  * @author Kevin de Vlaming
  */
-@SuppressWarnings({ "nls", "restriction" })
+@SuppressWarnings("nls")
 public class CreoleDocumentBuilderBlockTest extends AbstractCreoleDocumentBuilderTest {
 	@Test
 	public void testParagraph() {

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.creole.tests/src/test/java/org/eclipse/mylyn/internal/wikitext/creole/tests/documentbuilder/CreoleDocumentBuilderLinkImageTest.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.creole.tests/src/test/java/org/eclipse/mylyn/internal/wikitext/creole/tests/documentbuilder/CreoleDocumentBuilderLinkImageTest.java
@@ -10,6 +10,7 @@
  * Contributors:
  *     Kevin de Vlaming - initial API and implementation
  *     ArSysOp - ongoing support
+ *     See git history
  *******************************************************************************/
 
 package org.eclipse.mylyn.internal.wikitext.creole.tests.documentbuilder;
@@ -25,7 +26,7 @@ import org.junit.Test;
  * @see http://www.wikicreole.org/wiki/Elements
  * @author Kevin de Vlaming
  */
-@SuppressWarnings({ "nls", "restriction" })
+@SuppressWarnings("nls")
 public class CreoleDocumentBuilderLinkImageTest extends AbstractCreoleDocumentBuilderTest {
 	@Test
 	public void testLink() {

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.creole.tests/src/test/java/org/eclipse/mylyn/internal/wikitext/creole/tests/documentbuilder/CreoleDocumentBuilderListTest.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.creole.tests/src/test/java/org/eclipse/mylyn/internal/wikitext/creole/tests/documentbuilder/CreoleDocumentBuilderListTest.java
@@ -10,6 +10,7 @@
  * Contributors:
  *     Kevin de Vlaming - initial API and implementation
  *     ArSysOp - ongoing support
+ *     See git history
  *******************************************************************************/
 
 package org.eclipse.mylyn.internal.wikitext.creole.tests.documentbuilder;
@@ -25,7 +26,7 @@ import org.junit.Test;
  * @see http://www.wikicreole.org/wiki/Elements
  * @author Kevin de Vlaming
  */
-@SuppressWarnings({ "nls", "restriction" })
+@SuppressWarnings("nls")
 public class CreoleDocumentBuilderListTest extends AbstractCreoleDocumentBuilderTest {
 	@Test
 	public void testListBulleted() {

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.creole.tests/src/test/java/org/eclipse/mylyn/internal/wikitext/creole/tests/documentbuilder/CreoleDocumentBuilderSpanTest.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.creole.tests/src/test/java/org/eclipse/mylyn/internal/wikitext/creole/tests/documentbuilder/CreoleDocumentBuilderSpanTest.java
@@ -10,6 +10,7 @@
  * Contributors:
  *     Kevin de Vlaming - initial API and implementation
  *     ArSysOp - ongoing support
+ *     See git history
  *******************************************************************************/
 
 package org.eclipse.mylyn.internal.wikitext.creole.tests.documentbuilder;
@@ -22,7 +23,7 @@ import org.junit.Test;
  * @see http://www.wikicreole.org/wiki/Elements
  * @author Kevin de Vlaming
  */
-@SuppressWarnings({ "nls", "restriction" })
+@SuppressWarnings("nls")
 public class CreoleDocumentBuilderSpanTest extends AbstractCreoleDocumentBuilderTest {
 	@Test
 	public void testItalic() {

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.creole.tests/src/test/java/org/eclipse/mylyn/internal/wikitext/creole/tests/documentbuilder/CreoleDocumentBuilderTableTest.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.creole.tests/src/test/java/org/eclipse/mylyn/internal/wikitext/creole/tests/documentbuilder/CreoleDocumentBuilderTableTest.java
@@ -10,6 +10,7 @@
  * Contributors:
  *     Kevin de Vlaming - initial API and implementation
  *     ArSysOp - ongoing support
+ *     See git history
  *******************************************************************************/
 
 package org.eclipse.mylyn.internal.wikitext.creole.tests.documentbuilder;
@@ -26,7 +27,7 @@ import org.junit.Test;
  * @see http://www.wikicreole.org/wiki/Elements
  * @author Kevin de Vlaming
  */
-@SuppressWarnings({ "nls", "restriction" })
+@SuppressWarnings("nls")
 public class CreoleDocumentBuilderTableTest extends AbstractCreoleDocumentBuilderTest {
 	@Test
 	public void testTableWithEmptyCells() {

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.creole.tests/src/test/java/org/eclipse/mylyn/internal/wikitext/creole/tests/documentbuilder/CreoleDocumentBuilderTest.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.creole.tests/src/test/java/org/eclipse/mylyn/internal/wikitext/creole/tests/documentbuilder/CreoleDocumentBuilderTest.java
@@ -10,6 +10,7 @@
  * Contributors:
  *     Kevin de Vlaming - initial API and implementation
  *     ArSysOp - ongoing support
+ *     See git history
  *******************************************************************************/
 
 package org.eclipse.mylyn.internal.wikitext.creole.tests.documentbuilder;
@@ -22,7 +23,7 @@ import org.junit.Test;
  * @see http://www.wikicreole.org/wiki/Elements
  * @author Kevin de Vlaming
  */
-@SuppressWarnings({ "nls", "restriction" })
+@SuppressWarnings("nls")
 public class CreoleDocumentBuilderTest extends AbstractCreoleDocumentBuilderTest {
 	@Test
 	public void testLineBreak() {

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.creole/META-INF/MANIFEST.MF
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.creole/META-INF/MANIFEST.MF
@@ -7,7 +7,7 @@ Bundle-Name: Mylyn WikiText Creole
 Bundle-Vendor: Eclipse Mylyn
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=17))"
-Import-Package: com.google.common.base;version="[33.0,34.0)",
+Import-Package: org.apache.commons.lang3;version="[3.14.0,4.0.0)",
  org.eclipse.mylyn.wikitext.parser;version="[4.2,5)",
  org.eclipse.mylyn.wikitext.parser.builder;version="[4.2,5)",
  org.eclipse.mylyn.wikitext.parser.markup;version="[4.2,5)",

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.creole/src/main/java/org/eclipse/mylyn/wikitext/creole/internal/CreoleDocumentBuilder.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.creole/src/main/java/org/eclipse/mylyn/wikitext/creole/internal/CreoleDocumentBuilder.java
@@ -10,6 +10,7 @@
  * Contributors:
  *     Kevin de Vlaming - initial API and implementation
  *     ArSysOp - ongoing support
+ *     See git history
  *******************************************************************************/
 
 package org.eclipse.mylyn.wikitext.creole.internal;
@@ -19,14 +20,13 @@ import java.io.StringWriter;
 import java.io.Writer;
 import java.util.logging.Logger;
 
+import org.apache.commons.lang3.StringUtils;
 import org.eclipse.mylyn.wikitext.creole.CreoleLanguage;
 import org.eclipse.mylyn.wikitext.parser.Attributes;
 import org.eclipse.mylyn.wikitext.parser.ImageAttributes;
 import org.eclipse.mylyn.wikitext.parser.LinkAttributes;
 import org.eclipse.mylyn.wikitext.parser.builder.AbstractMarkupDocumentBuilder;
 import org.eclipse.mylyn.wikitext.parser.builder.EntityReferences;
-
-import com.google.common.base.Strings;
 
 /**
  * a document builder that emits Creole markup
@@ -148,14 +148,14 @@ public class CreoleDocumentBuilder extends AbstractMarkupDocumentBuilder {
 		protected void emitContent(String content) throws IOException {
 			// [[http://url.com|label]]
 			CreoleDocumentBuilder.this.emitContent("[["); //$NON-NLS-1$
-			if (!Strings.isNullOrEmpty(attributes.getHref())) {
+			if (StringUtils.isNotEmpty(attributes.getHref())) {
 				CreoleDocumentBuilder.this.emitContent(attributes.getHref());
 
 			}
-			if (!Strings.isNullOrEmpty(attributes.getHref()) && !Strings.isNullOrEmpty(content)) {
+			if (StringUtils.isNotEmpty(attributes.getHref()) && StringUtils.isNotEmpty(content)) {
 				CreoleDocumentBuilder.this.emitContent('|');
 			}
-			if (!Strings.isNullOrEmpty(content)) {
+			if (StringUtils.isNotEmpty(content)) {
 				CreoleDocumentBuilder.this.emitContent(content);
 			}
 			CreoleDocumentBuilder.this.emitContent("]]"); //$NON-NLS-1$
@@ -171,7 +171,7 @@ public class CreoleDocumentBuilder extends AbstractMarkupDocumentBuilder {
 
 		@Override
 		protected void emitContent(String content) throws IOException {
-			if (Strings.isNullOrEmpty(content) || content.trim().isEmpty()) {
+			if (StringUtils.isEmpty(content) || content.trim().isEmpty()) {
 				content = " "; //$NON-NLS-1$
 			}
 			super.emitContent(content);
@@ -289,10 +289,10 @@ public class CreoleDocumentBuilder extends AbstractMarkupDocumentBuilder {
 
 	private void writeImageAttributes(Block imageBlock, Attributes attributes) throws IOException {
 		if (attributes instanceof ImageAttributes) {
-			if (!Strings.isNullOrEmpty(((ImageAttributes) attributes).getAlt())) {
+			if (StringUtils.isNotEmpty(((ImageAttributes) attributes).getAlt())) {
 				imageBlock.write('|');
 				imageBlock.write(((ImageAttributes) attributes).getAlt());
-			} else if (!Strings.isNullOrEmpty(((ImageAttributes) attributes).getTitle())) {
+			} else if (StringUtils.isNotEmpty(((ImageAttributes) attributes).getTitle())) {
 				imageBlock.write('|');
 				imageBlock.write(((ImageAttributes) attributes).getTitle());
 			}
@@ -313,10 +313,10 @@ public class CreoleDocumentBuilder extends AbstractMarkupDocumentBuilder {
 	public void imageLink(Attributes linkAttributes, Attributes imageAttributes, String href, String imageUrl) {
 		String altText = ""; //$NON-NLS-1$
 		if (imageAttributes instanceof ImageAttributes
-				&& !Strings.isNullOrEmpty(((ImageAttributes) imageAttributes).getAlt())) {
+				&& StringUtils.isNotEmpty(((ImageAttributes) imageAttributes).getAlt())) {
 			altText = ((ImageAttributes) imageAttributes).getAlt();
 		}
-		link(linkAttributes, href, "{{" + Strings.nullToEmpty(imageUrl) + "}}" + altText); //$NON-NLS-1$ //$NON-NLS-2$
+		link(linkAttributes, href, "{{" + StringUtils.defaultString(imageUrl) + "}}" + altText); //$NON-NLS-1$ //$NON-NLS-2$
 	}
 
 	@Override

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.html.tests/META-INF/MANIFEST.MF
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.html.tests/META-INF/MANIFEST.MF
@@ -8,9 +8,7 @@ Bundle-Vendor: Eclipse Mylyn
 Fragment-Host: org.eclipse.mylyn.wikitext.html
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=17))"
-Import-Package: com.google.common.base;version="[33.0,34.0)",
- com.google.common.collect;version="[33.0,34.0)",
- com.google.common.io;version="[33.0.0,34.0.0)",
+Import-Package: org.apache.commons.io;version="[2.16.0,3.0.0)",
  org.eclipse.mylyn.wikitext.parser;version="[4.2,5)",
  org.eclipse.mylyn.wikitext.parser.builder;version="[4.2,5)",
  org.eclipse.mylyn.wikitext.parser.builder.event;version="4.4.0",

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.html.tests/src/test/java/org/eclipse/mylyn/wikitext/html/HtmlLanguageBuilderTest.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.html.tests/src/test/java/org/eclipse/mylyn/wikitext/html/HtmlLanguageBuilderTest.java
@@ -10,6 +10,7 @@
  * Contributors:
  *     David Green - initial API and implementation
  *     ArSysOp - ongoing support
+ *     See git history
  *******************************************************************************/
 
 package org.eclipse.mylyn.wikitext.html;
@@ -108,7 +109,7 @@ public class HtmlLanguageBuilderTest {
 
 	@Test
 	public void createWithoutName() {
-		IllegalStateException ise = assertThrows(IllegalStateException.class,
+		IllegalArgumentException ise = assertThrows(IllegalArgumentException.class,
 				() -> builder.add(BlockType.PARAGRAPH).create());
 		assertTrue(ise.getMessage().contains("Name must be provided to create an HtmlLanguage"));
 	}

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.html.tests/src/test/java/org/eclipse/mylyn/wikitext/html/internal/BlockStrategiesTest.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.html.tests/src/test/java/org/eclipse/mylyn/wikitext/html/internal/BlockStrategiesTest.java
@@ -10,6 +10,7 @@
  * Contributors:
  *     David Green - initial API and implementation
  *     ArSysOp - ongoing support
+ *     See git history
  *******************************************************************************/
 
 package org.eclipse.mylyn.wikitext.html.internal;
@@ -27,7 +28,6 @@ import org.eclipse.mylyn.wikitext.parser.Attributes;
 import org.eclipse.mylyn.wikitext.parser.DocumentBuilder.BlockType;
 import org.junit.Test;
 
-@SuppressWarnings("restriction")
 public class BlockStrategiesTest {
 
 	@Test(expected = NullPointerException.class)

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.html.tests/src/test/java/org/eclipse/mylyn/wikitext/html/internal/HtmlSubsetLanguageTest.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.html.tests/src/test/java/org/eclipse/mylyn/wikitext/html/internal/HtmlSubsetLanguageTest.java
@@ -10,6 +10,7 @@
  * Contributors:
  *     David Green - initial API and implementation
  *     ArSysOp - ongoing support
+ *     See git history
  *******************************************************************************/
 
 package org.eclipse.mylyn.wikitext.html.internal;
@@ -72,7 +73,7 @@ public class HtmlSubsetLanguageTest {
 
 	@Test
 	public void createWithUnsupportedSubstituted() {
-		IllegalStateException ise = assertThrows(IllegalStateException.class,
+		IllegalArgumentException ise = assertThrows(IllegalArgumentException.class,
 				() -> new HtmlSubsetLanguage("Test", null, 6, Set.of(BlockType.PARAGRAPH), Set.of(SpanType.BOLD),
 						Map.of(SpanType.ITALIC, "italic"), Collections.emptyList(), false, true));
 		assertTrue(ise.getMessage()

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.html.tests/src/test/java/org/eclipse/mylyn/wikitext/html/internal/SpanStrategiesTest.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.html.tests/src/test/java/org/eclipse/mylyn/wikitext/html/internal/SpanStrategiesTest.java
@@ -10,6 +10,7 @@
  * Contributors:
  *     David Green - initial API and implementation
  *     ArSysOp - ongoing support
+ *     See git history
  *******************************************************************************/
 
 package org.eclipse.mylyn.wikitext.html.internal;
@@ -26,7 +27,7 @@ import org.eclipse.mylyn.wikitext.parser.Attributes;
 import org.eclipse.mylyn.wikitext.parser.DocumentBuilder.SpanType;
 import org.junit.Test;
 
-@SuppressWarnings({ "nls", "restriction" })
+@SuppressWarnings("nls")
 public class SpanStrategiesTest {
 
 	@Test(expected = NullPointerException.class)

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.html.tests/src/test/java/org/eclipse/mylyn/wikitext/html/tests/HtmlLanguageTest.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.html.tests/src/test/java/org/eclipse/mylyn/wikitext/html/tests/HtmlLanguageTest.java
@@ -10,6 +10,7 @@
  * Contributors:
  *     David Green - initial API and implementation
  *     ArSysOp - ongoing support
+ *     See git history
  *******************************************************************************/
 
 package org.eclipse.mylyn.wikitext.html.tests;
@@ -25,6 +26,7 @@ import java.io.Writer;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 
+import org.apache.commons.io.IOUtils;
 import org.eclipse.mylyn.wikitext.html.HtmlLanguage;
 import org.eclipse.mylyn.wikitext.parser.Attributes;
 import org.eclipse.mylyn.wikitext.parser.DocumentBuilder;
@@ -35,8 +37,6 @@ import org.eclipse.mylyn.wikitext.parser.markup.MarkupLanguage;
 import org.eclipse.mylyn.wikitext.util.ServiceLocator;
 import org.jsoup.Jsoup;
 import org.junit.Test;
-
-import com.google.common.io.Resources;
 
 @SuppressWarnings({ "nls", "restriction" })
 public class HtmlLanguageTest {
@@ -165,7 +165,7 @@ public class HtmlLanguageTest {
 		try {
 			String fileName = HtmlLanguageTest.class.getSimpleName() + '_' + resourceName;
 			URL resource = HtmlLanguageTest.class.getResource(fileName);
-			return convertToUnixLineEndings(Resources.toString(resource, StandardCharsets.UTF_8));
+			return convertToUnixLineEndings(IOUtils.toString(resource, StandardCharsets.UTF_8));
 		} catch (IOException e) {
 			throw new RuntimeException(e);
 		}

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.html/META-INF/MANIFEST.MF
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.html/META-INF/MANIFEST.MF
@@ -10,7 +10,7 @@ Bundle-Vendor: Eclipse Mylyn
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=17))"
 Import-Package: com.google.common.base;version="[33.0,34.0)",
- com.google.common.collect;version="[33.0,34.0)",
+ org.apache.commons.lang3;version="[3.14.0,4.0.0)",
  org.eclipse.mylyn.wikitext.parser;version="[4.2,5)",
  org.eclipse.mylyn.wikitext.parser.builder;version="[4.2,5)",
  org.eclipse.mylyn.wikitext.parser.css;version="[4.2,5)",

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.html/src/main/java/org/eclipse/mylyn/wikitext/html/HtmlLanguageBuilder.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.html/src/main/java/org/eclipse/mylyn/wikitext/html/HtmlLanguageBuilder.java
@@ -9,12 +9,11 @@
  *
  * Contributors:
  *     David Green - initial API and implementation
+ *     See git history
  *******************************************************************************/
 
 package org.eclipse.mylyn.wikitext.html;
 
-import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Preconditions.checkState;
 import static java.util.Objects.requireNonNull;
 
 import java.util.ArrayList;
@@ -24,6 +23,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Validate;
 import org.eclipse.mylyn.wikitext.html.internal.FontElementStrategy;
 import org.eclipse.mylyn.wikitext.html.internal.HtmlSubsetLanguage;
 import org.eclipse.mylyn.wikitext.html.internal.LiteralHtmlDocumentHandler;
@@ -35,8 +36,6 @@ import org.eclipse.mylyn.wikitext.parser.DocumentBuilder.SpanType;
 import org.eclipse.mylyn.wikitext.parser.builder.HtmlDocumentBuilder;
 import org.eclipse.mylyn.wikitext.parser.builder.HtmlDocumentHandler;
 import org.eclipse.mylyn.wikitext.parser.markup.MarkupLanguage;
-
-import com.google.common.base.Strings;
 
 /**
  * Provides a way to build HTML languages that support a specific set of HTML tags.
@@ -77,10 +76,10 @@ public class HtmlLanguageBuilder {
 	 */
 	public HtmlLanguageBuilder name(String name) {
 		requireNonNull(name, "Must provide a name"); //$NON-NLS-1$
-		checkArgument(!Strings.isNullOrEmpty(name), "Name must not be empty"); //$NON-NLS-1$
-		checkArgument(!name.equalsIgnoreCase(HtmlLanguage.NAME_HTML), "Name must not be equal to %s", //$NON-NLS-1$
+		Validate.isTrue(StringUtils.isNotEmpty(name), "Name must not be empty"); //$NON-NLS-1$
+		Validate.isTrue(!name.equalsIgnoreCase(HtmlLanguage.NAME_HTML), "Name must not be equal to %s", //$NON-NLS-1$
 				HtmlLanguage.NAME_HTML);
-		checkArgument(name.equals(name.trim()), "Name must not have leading or trailing whitespace"); //$NON-NLS-1$
+		Validate.isTrue(name.equals(name.trim()), "Name must not have leading or trailing whitespace"); //$NON-NLS-1$
 		this.name = name;
 		return this;
 	}
@@ -140,7 +139,7 @@ public class HtmlLanguageBuilder {
 	 * @return this builder
 	 */
 	public HtmlLanguageBuilder addHeadings(int level) {
-		checkArgument(level > 0 && level <= 6, "Heading level must be between 1 and 6"); //$NON-NLS-1$
+		Validate.isTrue(level > 0 && level <= 6, "Heading level must be between 1 and 6"); //$NON-NLS-1$
 		headingLevel = level;
 		return this;
 	}
@@ -201,7 +200,7 @@ public class HtmlLanguageBuilder {
 	}
 
 	public HtmlLanguage create() {
-		checkState(name != null, "Name must be provided to create an HtmlLanguage"); //$NON-NLS-1$
+		Validate.isTrue(name != null, "Name must be provided to create an HtmlLanguage"); //$NON-NLS-1$
 
 		return new HtmlSubsetLanguage(name, documentHandler, headingLevel, blockTypes, spanTypes,
 				spanTypeToElementNameSubstitution, spanElementStrategies, xhtmlStrict, supportsImages);

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.html/src/main/java/org/eclipse/mylyn/wikitext/html/internal/BlockStrategies.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.html/src/main/java/org/eclipse/mylyn/wikitext/html/internal/BlockStrategies.java
@@ -9,12 +9,10 @@
  *
  * Contributors:
  *     David Green - initial API and implementation
+ *     See git history
  *******************************************************************************/
 
 package org.eclipse.mylyn.wikitext.html.internal;
-
-import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Preconditions.checkState;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -22,6 +20,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import org.apache.commons.lang3.Validate;
 import org.eclipse.mylyn.wikitext.parser.DocumentBuilder.BlockType;
 
 class BlockStrategies extends ElementStrategies<BlockType, BlockStrategy, HtmlElementStrategy<BlockType>> {
@@ -54,8 +53,8 @@ class BlockStrategies extends ElementStrategies<BlockType, BlockStrategy, HtmlEl
 
 	private static void addAlternatives(Map<BlockType, List<BlockType>> alternatives, BlockType blockType,
 			BlockType... blockTypes) {
-		checkState(!alternatives.containsKey(blockType), "Duplicate %s", blockType); //$NON-NLS-1$
-		checkArgument(blockTypes.length > 0);
+		Validate.isTrue(!alternatives.containsKey(blockType), "Duplicate %s", blockType); //$NON-NLS-1$
+		Validate.isTrue(blockTypes.length > 0);
 		alternatives.put(blockType, List.of(blockTypes));
 	}
 

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.html/src/main/java/org/eclipse/mylyn/wikitext/html/internal/CompositeSpanStrategy.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.html/src/main/java/org/eclipse/mylyn/wikitext/html/internal/CompositeSpanStrategy.java
@@ -9,17 +9,18 @@
  *
  * Contributors:
  *     David Green - initial API and implementation
+ *     See git history
  *******************************************************************************/
 
 package org.eclipse.mylyn.wikitext.html.internal;
 
 import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 import org.eclipse.mylyn.wikitext.parser.Attributes;
 import org.eclipse.mylyn.wikitext.parser.DocumentBuilder;
 import org.eclipse.mylyn.wikitext.parser.DocumentBuilder.SpanType;
-
-import com.google.common.collect.Lists;
 
 class CompositeSpanStrategy implements SpanStrategy {
 
@@ -38,7 +39,10 @@ class CompositeSpanStrategy implements SpanStrategy {
 
 	@Override
 	public void endSpan(DocumentBuilder builder) {
-		for (SpanStrategy strategy : Lists.reverse(delegates)) {
+		for (SpanStrategy strategy : IntStream.range(0, delegates.size())
+				.map(i -> delegates.size() - 1 - i)
+				.mapToObj(delegates::get)
+				.collect(Collectors.toList())) {
 			strategy.endSpan(builder);
 		}
 	}

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.html/src/main/java/org/eclipse/mylyn/wikitext/html/internal/HtmlSubsetDocumentBuilder.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.html/src/main/java/org/eclipse/mylyn/wikitext/html/internal/HtmlSubsetDocumentBuilder.java
@@ -9,11 +9,11 @@
  *
  * Contributors:
  *     David Green - initial API and implementation
+ *     See git history
  *******************************************************************************/
 
 package org.eclipse.mylyn.wikitext.html.internal;
 
-import static com.google.common.base.Preconditions.checkState;
 import static java.util.Objects.requireNonNull;
 
 import java.io.Writer;
@@ -21,6 +21,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.Stack;
 
+import org.apache.commons.lang3.Validate;
 import org.eclipse.mylyn.wikitext.parser.Attributes;
 import org.eclipse.mylyn.wikitext.parser.DocumentBuilder;
 import org.eclipse.mylyn.wikitext.parser.builder.HtmlDocumentBuilder;
@@ -57,12 +58,12 @@ public class HtmlSubsetDocumentBuilder extends DocumentBuilder {
 	}
 
 	void setSupportedBlockTypes(Set<BlockType> blockTypes) {
-		checkState(blockStrategyState.isEmpty());
+		Validate.isTrue(blockStrategyState.isEmpty());
 		blockStrategies = new BlockStrategies(blockTypes);
 	}
 
 	void setSupportedSpanTypes(Set<SpanType> spanTypes, List<SpanHtmlElementStrategy> spanElementStrategies) {
-		checkState(spanStrategyState.isEmpty());
+		Validate.isTrue(spanStrategyState.isEmpty());
 		spanStrategies = new SpanStrategies(spanTypes, spanElementStrategies);
 	}
 

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.html/src/main/java/org/eclipse/mylyn/wikitext/html/internal/HtmlSubsetLanguage.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.html/src/main/java/org/eclipse/mylyn/wikitext/html/internal/HtmlSubsetLanguage.java
@@ -9,12 +9,11 @@
  *
  * Contributors:
  *     David Green - initial API and implementation
+ *     See git history
  *******************************************************************************/
 
 package org.eclipse.mylyn.wikitext.html.internal;
 
-import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Preconditions.checkState;
 import static java.util.Objects.requireNonNull;
 
 import java.io.Writer;
@@ -23,6 +22,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 
+import org.apache.commons.lang3.Validate;
 import org.eclipse.mylyn.wikitext.html.HtmlLanguage;
 import org.eclipse.mylyn.wikitext.parser.DocumentBuilder.BlockType;
 import org.eclipse.mylyn.wikitext.parser.DocumentBuilder.SpanType;
@@ -51,7 +51,7 @@ public class HtmlSubsetLanguage extends HtmlLanguage {
 			List<SpanHtmlElementStrategy> spanElementStrategies, boolean xhtmlStrict, boolean supportsImages) {
 		setName(requireNonNull(name));
 		this.documentHandler = documentHandler;
-		checkArgument(headingLevel >= 0 && headingLevel <= 6, "headingLevel must be between 0 and 6"); //$NON-NLS-1$
+		Validate.isTrue(headingLevel >= 0 && headingLevel <= 6, "headingLevel must be between 0 and 6"); //$NON-NLS-1$
 		this.headingLevel = headingLevel;
 		supportedBlockTypes = Set.copyOf(requireNonNull(blockTypes));
 		supportedSpanTypes = Set.copyOf(requireNonNull(spanTypes));
@@ -112,7 +112,7 @@ public class HtmlSubsetLanguage extends HtmlLanguage {
 
 	private void assertSubstitutedAreSupported() {
 		for (SpanType spanType : tagNameSubstitutions.keySet()) {
-			checkState(supportedSpanTypes.contains(spanType),
+			Validate.isTrue(supportedSpanTypes.contains(spanType),
 					"SpanType [%s] is unsupported. Cannot add substitution to unsupported span types.", spanType); //$NON-NLS-1$
 		}
 	}

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.html/src/main/java/org/eclipse/mylyn/wikitext/html/internal/SpanStrategies.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.html/src/main/java/org/eclipse/mylyn/wikitext/html/internal/SpanStrategies.java
@@ -9,12 +9,10 @@
  *
  * Contributors:
  *     David Green - initial API and implementation
+ *     See git history
  *******************************************************************************/
 
 package org.eclipse.mylyn.wikitext.html.internal;
-
-import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Preconditions.checkState;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -25,6 +23,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import org.apache.commons.lang3.Validate;
 import org.eclipse.mylyn.wikitext.parser.Attributes;
 import org.eclipse.mylyn.wikitext.parser.DocumentBuilder.SpanType;
 import org.eclipse.mylyn.wikitext.parser.css.CssParser;
@@ -51,8 +50,8 @@ public class SpanStrategies extends ElementStrategies<SpanType, SpanStrategy, Sp
 
 	private static void addAlternatives(Map<SpanType, List<SpanType>> alternatives, SpanType spanType,
 			SpanType... spanTypes) {
-		checkState(!alternatives.containsKey(spanType), "Duplicate %s", spanType); //$NON-NLS-1$
-		checkArgument(spanTypes.length > 0);
+		Validate.isTrue(!alternatives.containsKey(spanType), "Duplicate %s", spanType); //$NON-NLS-1$
+		Validate.isTrue(spanTypes.length > 0);
 		alternatives.put(spanType, List.of(spanTypes));
 	}
 

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.markdown.tests/META-INF/MANIFEST.MF
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.markdown.tests/META-INF/MANIFEST.MF
@@ -8,8 +8,7 @@ Bundle-Vendor: Eclipse Mylyn
 Fragment-Host: org.eclipse.mylyn.wikitext.markdown
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=17))"
-Import-Package: com.google.common.base;version="[33.0,34.0)",
- org.eclipse.mylyn.wikitext.parser;version="[4.2,5)",
+Import-Package: org.eclipse.mylyn.wikitext.parser;version="[4.2,5)",
  org.eclipse.mylyn.wikitext.parser.builder;version="[4.2,5)",
  org.eclipse.mylyn.wikitext.parser.markup;version="[4.2,5)",
  org.eclipse.mylyn.wikitext.parser.markup.phrase;version="[4.2,5)",

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.markdown.tests/src/test/java/org/eclipse/mylyn/internal/wikitext/markdown/tests/MarkdownDocumentBuilderTest.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.markdown.tests/src/test/java/org/eclipse/mylyn/internal/wikitext/markdown/tests/MarkdownDocumentBuilderTest.java
@@ -11,6 +11,7 @@
  *     Leo Dos Santos - initial API and implementation
  *     Pierre-Yves B. <pyvesdev@gmail.com> - Bug 509033 - markdown misses support for ~~strike~~
  *     ArSysOp - ongoing support
+ *     See git history
  *******************************************************************************/
 
 package org.eclipse.mylyn.internal.wikitext.markdown.tests;
@@ -33,7 +34,7 @@ import org.junit.Test;
  * @see http://daringfireball.net/projects/markdown/syntax
  * @author Leo Dos Santos
  */
-@SuppressWarnings({ "nls", "restriction" })
+@SuppressWarnings("nls")
 public class MarkdownDocumentBuilderTest {
 
 	private DocumentBuilder builder;

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.markdown/META-INF/MANIFEST.MF
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.markdown/META-INF/MANIFEST.MF
@@ -7,6 +7,7 @@ Bundle-Name: Mylyn WikiText Markdown
 Bundle-Vendor: Eclipse Mylyn
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Import-Package: com.google.common.base;version="[33.0,34.0)",
+ org.apache.commons.lang3;version="[3.14.0,4.0.0)",
  org.eclipse.mylyn.wikitext.parser;version="[4.2,5)",
  org.eclipse.mylyn.wikitext.parser.builder;version="[4.2,5)",
  org.eclipse.mylyn.wikitext.parser.markup;version="[4.2,5)",

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.markdown/src/main/java/org/eclipse/mylyn/wikitext/markdown/internal/MarkdownDocumentBuilder.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.markdown/src/main/java/org/eclipse/mylyn/wikitext/markdown/internal/MarkdownDocumentBuilder.java
@@ -10,6 +10,7 @@
  * Contributors:
  *     Leo Dos Santos - initial API and implementation
  *     Pierre-Yves B. <pyvesdev@gmail.com> - Bug 509033 - markdown misses support for ~~strike~~
+ *     See git history
  *******************************************************************************/
 
 package org.eclipse.mylyn.wikitext.markdown.internal;
@@ -25,6 +26,7 @@ import java.util.logging.Logger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import org.apache.commons.lang3.StringUtils;
 import org.eclipse.mylyn.wikitext.markdown.MarkdownLanguage;
 import org.eclipse.mylyn.wikitext.parser.Attributes;
 import org.eclipse.mylyn.wikitext.parser.ImageAttributes;
@@ -32,7 +34,6 @@ import org.eclipse.mylyn.wikitext.parser.LinkAttributes;
 import org.eclipse.mylyn.wikitext.parser.builder.AbstractMarkupDocumentBuilder;
 
 import com.google.common.base.CharMatcher;
-import com.google.common.base.Strings;
 
 /**
  * a document builder that emits Markdown markup
@@ -211,7 +212,7 @@ public class MarkdownDocumentBuilder extends AbstractMarkupDocumentBuilder {
 			if (getPreviousBlock().getBlockType() == BlockType.NUMERIC_LIST) {
 				prefix = count + ". "; //$NON-NLS-1$
 			}
-			String indent = Strings.repeat(" ", prefix.length()); //$NON-NLS-1$
+			String indent = StringUtils.repeat(" ", prefix.length()); //$NON-NLS-1$
 
 			MarkdownDocumentBuilder.this.emitContent(prefix);
 			// split out content by line
@@ -223,7 +224,7 @@ public class MarkdownDocumentBuilder extends AbstractMarkupDocumentBuilder {
 				if (lines > 0 && !line.trim().isEmpty()) {
 					int indexOfFirstNonSpace = CharMatcher.isNot(' ').indexIn(line);
 					if (indexOfFirstNonSpace >= 4) {
-						line = Strings.repeat(" ", 4) + line; //$NON-NLS-1$
+						line = StringUtils.repeat(" ", 4) + line; //$NON-NLS-1$
 					} else {
 						line = indent + line;
 					}
@@ -258,7 +259,7 @@ public class MarkdownDocumentBuilder extends AbstractMarkupDocumentBuilder {
 
 			MarkdownDocumentBuilder.this.emitContent('(');
 			MarkdownDocumentBuilder.this.emitContent(attributes.getHref());
-			if (!Strings.isNullOrEmpty(attributes.getTitle())) {
+			if (StringUtils.isNotEmpty(attributes.getTitle())) {
 				MarkdownDocumentBuilder.this.emitContent(" \""); //$NON-NLS-1$
 				MarkdownDocumentBuilder.this.emitContent(attributes.getTitle());
 				MarkdownDocumentBuilder.this.emitContent('"');
@@ -395,12 +396,12 @@ public class MarkdownDocumentBuilder extends AbstractMarkupDocumentBuilder {
 		String altText = ""; //$NON-NLS-1$
 		String title = ""; //$NON-NLS-1$
 		if (attributes instanceof ImageAttributes imageAttr) {
-			altText = Strings.nullToEmpty(imageAttr.getAlt());
+			altText = StringUtils.defaultString(imageAttr.getAlt());
 		}
-		if (!Strings.isNullOrEmpty(attributes.getTitle())) {
+		if (StringUtils.isNotEmpty(attributes.getTitle())) {
 			title = " \"" + attributes.getTitle() + '"'; //$NON-NLS-1$
 		}
-		return "![" + altText + "](" + Strings.nullToEmpty(url) + title + ')'; //$NON-NLS-1$ //$NON-NLS-2$
+		return "![" + altText + "](" + StringUtils.defaultString(url) + title + ')'; //$NON-NLS-1$ //$NON-NLS-2$
 	}
 
 	@Override

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.maven/pom.xml
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.maven/pom.xml
@@ -70,6 +70,11 @@
 			<artifactId>guava</artifactId>
 			<version>${guava.version}</version>
 		</dependency>
+		<dependency>
+		    <groupId>org.apache.commons</groupId>
+		    <artifactId>commons-lang3</artifactId>
+		    <version>3.14.0</version>
+		</dependency>
 	</dependencies>
 	<build>
 		<plugins>

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.maven/src/main/java/org/eclipse/mylyn/wikitext/maven/internal/SourceFileTraversal.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.maven/src/main/java/org/eclipse/mylyn/wikitext/maven/internal/SourceFileTraversal.java
@@ -10,14 +10,16 @@
  * Contributors:
  *     David Green - initial API and implementation
  *     ArSysOp - ongoing support
+ *     See git history
  *******************************************************************************/
 
 package org.eclipse.mylyn.wikitext.maven.internal;
 
-import static com.google.common.base.Preconditions.checkArgument;
 import static java.util.Objects.requireNonNull;
 
 import java.io.File;
+
+import org.apache.commons.lang3.Validate;
 
 public class SourceFileTraversal {
 
@@ -29,8 +31,8 @@ public class SourceFileTraversal {
 
 	public SourceFileTraversal(File root) {
 		this.root = requireNonNull(root);
-		checkArgument(root.exists(), "Root folder must exist"); //$NON-NLS-1$
-		checkArgument(root.isDirectory(), "Root folder must be a folder"); //$NON-NLS-1$
+		Validate.isTrue(root.exists(), "Root folder must exist"); //$NON-NLS-1$
+		Validate.isTrue(root.isDirectory(), "Root folder must be a folder"); //$NON-NLS-1$
 	}
 
 	public void traverse(Visitor visitor) {

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.maven/src/test/java/org/eclipse/mylyn/wikitext/maven/internal/MarkupToEclipseHelpMojoTest.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.maven/src/test/java/org/eclipse/mylyn/wikitext/maven/internal/MarkupToEclipseHelpMojoTest.java
@@ -10,11 +10,11 @@
  * Contributors:
  *     David Green - initial API and implementation
  *     ArSysOp - ongoing support
+ *     See git history
  *******************************************************************************/
 
 package org.eclipse.mylyn.wikitext.maven.internal;
 
-import static com.google.common.base.Preconditions.checkState;
 import static java.util.Objects.requireNonNull;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -37,6 +37,7 @@ import java.nio.file.Files;
 import java.util.Arrays;
 import java.util.UUID;
 
+import org.apache.commons.lang3.Validate;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.eclipse.mylyn.wikitext.parser.builder.HtmlDocumentBuilder;
@@ -68,11 +69,12 @@ public class MarkupToEclipseHelpMojoTest {
 	private File calculateSourceFolder() {
 		URL resource = MarkupToEclipseHelpMojoTest.class.getResource("/test.textile");
 		requireNonNull(resource);
-		checkState(resource.getProtocol().equals("file"), "Expecting resource to have the file protocol: %s", resource);
+		Validate.isTrue(resource.getProtocol().equals("file"), "Expecting resource to have the file protocol: %s",
+				resource);
 		String path = resource.getPath();
 		File file = new File(path);
-		checkState(file.exists(), "Expecting file to exist: %s", file);
-		checkState(file.isFile(), "Expecting file to be a file: %s", file);
+		Validate.isTrue(file.exists(), "Expecting file to exist: %s", file);
+		Validate.isTrue(file.isFile(), "Expecting file to be a file: %s", file);
 		return file.getParentFile();
 	}
 

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.mediawiki.tests/META-INF/MANIFEST.MF
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.mediawiki.tests/META-INF/MANIFEST.MF
@@ -8,8 +8,8 @@ Bundle-Vendor: Eclipse Mylyn
 Fragment-Host: org.eclipse.mylyn.wikitext.mediawiki
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=17))"
-Import-Package: com.google.common.base;version="[33.0.0,34.0.0)",
- com.google.common.io;version="[33.0,34.0)",
+Import-Package: org.apache.commons.io;version="[2.16.0,3.0.0)",
+ org.apache.commons.lang3;version="[3.14.0,4.0.0)",
  org.eclipse.mylyn.wikitext.parser.builder;version="4.4.0",
  org.eclipse.mylyn.wikitext.parser.markup;version="[4.2,5)",
  org.eclipse.mylyn.wikitext.parser.outline;version="[4.2,5)",

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.mediawiki.tests/src/test/java/org/eclipse/mylyn/wikitext/mediawiki/internal/tests/MediaWikiLanguageTest.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.mediawiki.tests/src/test/java/org/eclipse/mylyn/wikitext/mediawiki/internal/tests/MediaWikiLanguageTest.java
@@ -11,6 +11,7 @@
  *     David Green - initial API and implementation
  *     Jeremie Bresson - Bug 381506, 381912, 391850, 304495, 396545
  *     ArSysOp - ongoing support
+ *     See git history
  *******************************************************************************/
 package org.eclipse.mylyn.wikitext.mediawiki.internal.tests;
 
@@ -30,6 +31,7 @@ import java.util.Locale;
 import java.util.Set;
 import java.util.regex.Pattern;
 
+import org.apache.commons.io.IOUtils;
 import org.eclipse.mylyn.wikitext.mediawiki.MediaWikiLanguage;
 import org.eclipse.mylyn.wikitext.mediawiki.Template;
 import org.eclipse.mylyn.wikitext.parser.builder.DocBookDocumentBuilder;
@@ -42,8 +44,6 @@ import org.eclipse.mylyn.wikitext.util.ServiceLocator;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-
-import com.google.common.io.Resources;
 
 /**
  * @author David Green
@@ -1491,7 +1491,7 @@ public class MediaWikiLanguageTest extends AbstractMarkupGenerationTest<MediaWik
 	}
 
 	private String readFully(String resource) throws IOException {
-		return Resources.toString(MediaWikiLanguageTest.class.getResource(resource), StandardCharsets.UTF_8);
+		return IOUtils.toString(MediaWikiLanguageTest.class.getResource(resource), StandardCharsets.UTF_8);
 	}
 
 	private void assertContainsPattern(String html, Pattern pattern) {

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.mediawiki.tests/src/test/java/org/eclipse/mylyn/wikitext/mediawiki/tests/TestWikiTemplateResolver.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.mediawiki.tests/src/test/java/org/eclipse/mylyn/wikitext/mediawiki/tests/TestWikiTemplateResolver.java
@@ -10,17 +10,18 @@
  * Contributors:
  *     Jeremie Bresson - initial API and implementation
  *     ArSysOp - ongoing support
+ *     See git history
  *******************************************************************************/
 
 package org.eclipse.mylyn.wikitext.mediawiki.tests;
 
-import static com.google.common.base.Preconditions.checkState;
 import static java.util.Objects.requireNonNull;
 
 import java.io.IOException;
 import java.net.URL;
 import java.util.Map;
 
+import org.apache.commons.lang3.Validate;
 import org.eclipse.mylyn.wikitext.mediawiki.WikiTemplateResolver;
 
 /**
@@ -47,7 +48,7 @@ class TestWikiTemplateResolver extends WikiTemplateResolver {
 	protected String readContent(URL pathUrl) throws IOException {
 		requireNonNull(serverContent, "Please specify some server content for the tests.");
 		String key = pathUrl.toString();
-		checkState(serverContent.containsKey(key), "Server content not found for key: %s", key);
+		Validate.isTrue(serverContent.containsKey(key), "Server content not found for key: %s", key);
 		return serverContent.get(key);
 	}
 

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.mediawiki/META-INF/MANIFEST.MF
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.mediawiki/META-INF/MANIFEST.MF
@@ -7,7 +7,7 @@ Bundle-Name: Mylyn WikiText MediaWiki
 Bundle-Vendor: Eclipse Mylyn
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=17))"
-Import-Package: com.google.common.io;version="[33.0,34.0)",
+Import-Package: org.apache.commons.io;version="[2.16.0,3.0.0)",
  org.eclipse.mylyn.wikitext.parser;version="[4.2,5)",
  org.eclipse.mylyn.wikitext.parser.markup;version="[4.2,5)",
  org.eclipse.mylyn.wikitext.parser.markup.block;version="[4.2,5)",

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.mediawiki/src/main/java/org/eclipse/mylyn/wikitext/mediawiki/WikiTemplateResolver.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.mediawiki/src/main/java/org/eclipse/mylyn/wikitext/mediawiki/WikiTemplateResolver.java
@@ -9,6 +9,7 @@
  *
  * Contributors:
  *     David Green - initial API and implementation
+ *     See git history
  *******************************************************************************/
 
 package org.eclipse.mylyn.wikitext.mediawiki;
@@ -21,7 +22,7 @@ import java.text.MessageFormat;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import com.google.common.io.Resources;
+import org.apache.commons.io.IOUtils;
 
 /**
  * compute the contents of a template based on
@@ -57,7 +58,7 @@ public class WikiTemplateResolver extends TemplateResolver {
 					Template template = new Template();
 					String basicName = templateName.toLowerCase().startsWith("template:") //$NON-NLS-1$
 							? templateName.substring(templateName.lastIndexOf(':') + 1)
-							: templateName;
+									: templateName;
 					template.setName(basicName);
 					template.setTemplateMarkup(content);
 					return template;
@@ -71,7 +72,7 @@ public class WikiTemplateResolver extends TemplateResolver {
 	}
 
 	protected String readContent(URL url) throws IOException {
-		return Resources.toString(url, StandardCharsets.UTF_8);
+		return IOUtils.toString(url, StandardCharsets.UTF_8);
 	}
 
 	private URL computeRawUrl(String path) {
@@ -84,8 +85,8 @@ public class WikiTemplateResolver extends TemplateResolver {
 			return new URL(qualifiedUrl);
 		} catch (IOException e) {
 			Logger.getLogger(WikiTemplateResolver.class.getName())
-					.log(Level.WARNING,
-							MessageFormat.format("Cannot compute raw URL for {0}: {1}", path, e.getMessage()), e); //$NON-NLS-1$
+			.log(Level.WARNING,
+					MessageFormat.format("Cannot compute raw URL for {0}: {1}", path, e.getMessage()), e); //$NON-NLS-1$
 			return null;
 		}
 	}

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.tests/META-INF/MANIFEST.MF
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.tests/META-INF/MANIFEST.MF
@@ -7,7 +7,7 @@ Bundle-Name: Mylyn WikiText Integration Tests
 Bundle-Vendor: Eclipse Mylyn
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Bundle: org.eclipse.mylyn.wikitext.textile
-Import-Package: com.google.common.io;version="[33.0.0,34.0.0)",
+Import-Package: org.apache.commons.io;version="[2.16.0,3.0.0)",
  org.eclipse.mylyn.wikitext.confluence;version="[4.3.0,5.0.0)",
  org.eclipse.mylyn.wikitext.internal.parser.html,
  org.eclipse.mylyn.wikitext.mediawiki;version="[4.3.0,5.0.0)",

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.tests/src/test/java/org/eclipse/mylyn/wikitext/parser/builder/tests/HtmlDocumentBuilderTest.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.tests/src/test/java/org/eclipse/mylyn/wikitext/parser/builder/tests/HtmlDocumentBuilderTest.java
@@ -10,6 +10,7 @@
  * Contributors:
  *     David Green - initial API and implementation
  *     ArSysOp - ongoing support
+ *     See git history
  *******************************************************************************/
 
 package org.eclipse.mylyn.wikitext.parser.builder.tests;
@@ -25,6 +26,7 @@ import java.io.StringWriter;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 
+import org.apache.commons.io.IOUtils;
 import org.eclipse.mylyn.wikitext.parser.Attributes;
 import org.eclipse.mylyn.wikitext.parser.DocumentBuilder.BlockType;
 import org.eclipse.mylyn.wikitext.parser.DocumentBuilder.SpanType;
@@ -37,8 +39,6 @@ import org.eclipse.mylyn.wikitext.parser.builder.UriProcessor;
 import org.eclipse.mylyn.wikitext.util.XmlStreamWriter;
 import org.junit.Before;
 import org.junit.Test;
-
-import com.google.common.io.Resources;
 
 @SuppressWarnings({ "nls", "restriction" })
 public class HtmlDocumentBuilderTest {
@@ -410,7 +410,7 @@ public class HtmlDocumentBuilderTest {
 		try {
 			String fileName = HtmlDocumentBuilderTest.class.getSimpleName() + '_' + resourceName + ".xml";
 			URL resource = HtmlDocumentBuilderTest.class.getResource(fileName);
-			return convertToUnixLineEndings(Resources.toString(resource, StandardCharsets.UTF_8));
+			return convertToUnixLineEndings(IOUtils.toString(resource, StandardCharsets.UTF_8));
 		} catch (IOException e) {
 			throw new RuntimeException(e);
 		}

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.tests/src/test/java/org/eclipse/mylyn/wikitext/parser/builder/tests/SplittingHtmlDocumentBuilderTest.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.tests/src/test/java/org/eclipse/mylyn/wikitext/parser/builder/tests/SplittingHtmlDocumentBuilderTest.java
@@ -10,6 +10,7 @@
  * Contributors:
  *     David Green - initial API and implementation
  *     ArSysOp - ongoing support
+ *     See git history
  *******************************************************************************/
 
 package org.eclipse.mylyn.wikitext.parser.builder.tests;
@@ -25,6 +26,7 @@ import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.nio.charset.StandardCharsets;
 
+import org.apache.commons.io.IOUtils;
 import org.eclipse.mylyn.wikitext.parser.MarkupParser;
 import org.eclipse.mylyn.wikitext.parser.builder.HtmlDocumentBuilder;
 import org.eclipse.mylyn.wikitext.splitter.DefaultSplittingStrategy;
@@ -36,8 +38,6 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
-
-import com.google.common.io.Resources;
 
 @SuppressWarnings({ "nls", "restriction" })
 public class SplittingHtmlDocumentBuilderTest {
@@ -103,9 +103,9 @@ public class SplittingHtmlDocumentBuilderTest {
 
 	private void assertFileContents(String resource, File outputFile) throws IOException {
 		String resourcePath = "resources/SplittingHtmlDocumentBuilderTest_" + resource;
-		String resourceContents = convertToUnixLineEndings(Resources
+		String resourceContents = convertToUnixLineEndings(IOUtils
 				.toString(SplittingHtmlDocumentBuilderTest.class.getResource(resourcePath), StandardCharsets.UTF_8));
-		String actualContents = Resources.toString(outputFile.toURI().toURL(), StandardCharsets.UTF_8);
+		String actualContents = IOUtils.toString(outputFile.toURI().toURL(), StandardCharsets.UTF_8);
 		assertEquals(format("Resource {0} differs", resourcePath), resourceContents, actualContents);
 	}
 

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.tests/src/test/java/org/eclipse/mylyn/wikitext/parser/builder/tests/XslfoDocumentBuilderIntegrationTest.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.tests/src/test/java/org/eclipse/mylyn/wikitext/parser/builder/tests/XslfoDocumentBuilderIntegrationTest.java
@@ -11,6 +11,7 @@
  *     David Green - initial API and implementation
  *     Torkild U. Resheim - bugs 336592 and 336813
  *     ArSysOp - ongoing support
+ *     See git history
  *******************************************************************************/
 
 package org.eclipse.mylyn.wikitext.parser.builder.tests;
@@ -25,6 +26,7 @@ import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.util.regex.Pattern;
 
+import org.apache.commons.io.IOUtils;
 import org.eclipse.mylyn.wikitext.mediawiki.MediaWikiLanguage;
 import org.eclipse.mylyn.wikitext.parser.MarkupParser;
 import org.eclipse.mylyn.wikitext.parser.builder.XslfoDocumentBuilder;
@@ -34,8 +36,6 @@ import org.eclipse.mylyn.wikitext.textile.TextileLanguage;
 import org.eclipse.mylyn.wikitext.util.DefaultXmlStreamWriter;
 import org.junit.Before;
 import org.junit.Test;
-
-import com.google.common.io.Resources;
 
 /**
  * @author David Green
@@ -309,7 +309,7 @@ public class XslfoDocumentBuilderIntegrationTest {
 		URL resource = XslfoDocumentBuilderIntegrationTest.class.getResource(
 				"resources/" + XslfoDocumentBuilderIntegrationTest.class.getSimpleName() + "_" + resourceName);
 		try {
-			return Resources.toString(resource, StandardCharsets.UTF_8);
+			return IOUtils.toString(resource, StandardCharsets.UTF_8);
 		} catch (IOException e) {
 			throw new RuntimeException(e);
 		}

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.tests/src/test/java/org/eclipse/mylyn/wikitext/parser/markup/tests/MarkupLanguageProviderTest.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.tests/src/test/java/org/eclipse/mylyn/wikitext/parser/markup/tests/MarkupLanguageProviderTest.java
@@ -10,6 +10,7 @@
  * Contributors:
  *     David Green - initial API and implementation
  *     ArSysOp - ongoing support
+ *     See git history
  *******************************************************************************/
 
 package org.eclipse.mylyn.wikitext.parser.markup.tests;
@@ -66,7 +67,8 @@ public class MarkupLanguageProviderTest {
 				return Set.of(new MockMarkupLanguage("Test"), new MockMarkupLanguage("Test"));
 			}
 		};
-		IllegalStateException ise = assertThrows(IllegalStateException.class, () -> provider.getMarkupLanguages());
+		IllegalArgumentException ise = assertThrows(IllegalArgumentException.class,
+				() -> provider.getMarkupLanguages());
 		assertTrue(ise.getMessage().contains("Language name 'Test' must not be provided more than once"));
 	}
 

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.tests/src/test/java/org/eclipse/mylyn/wikitext/parser/tests/AttributesTest.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.tests/src/test/java/org/eclipse/mylyn/wikitext/parser/tests/AttributesTest.java
@@ -10,6 +10,7 @@
  * Contributors:
  *     David Green - initial API and implementation
  *     ArSysOp - ongoing support
+ *     See git history
  *******************************************************************************/
 
 package org.eclipse.mylyn.wikitext.parser.tests;
@@ -20,7 +21,7 @@ import static org.junit.Assert.assertNotNull;
 import org.eclipse.mylyn.wikitext.parser.Attributes;
 import org.junit.Test;
 
-@SuppressWarnings({ "nls", "restriction" })
+@SuppressWarnings("nls")
 public class AttributesTest {
 
 	@Test

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.textile.tests/src/test/java/org/eclipse/mylyn/wikitext/textile/internal/tests/TextileTest.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.textile.tests/src/test/java/org/eclipse/mylyn/wikitext/textile/internal/tests/TextileTest.java
@@ -10,6 +10,7 @@
  * Contributors:
  *     David Green - initial API and implementation
  *     ArSysOp - ongoing support
+ *     See git history
  *******************************************************************************/
 package org.eclipse.mylyn.wikitext.textile.internal.tests;
 
@@ -27,7 +28,7 @@ import org.junit.Test;
 /**
  * @author David Green
  */
-@SuppressWarnings({ "nls", "restriction" })
+@SuppressWarnings("nls")
 public class TextileTest {
 	@Test
 	public void testExplicitHeaderStartsNewBlock() {

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.textile/META-INF/MANIFEST.MF
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.textile/META-INF/MANIFEST.MF
@@ -7,7 +7,9 @@ Bundle-Name: Mylyn WikiText Textile
 Bundle-Vendor: Eclipse Mylyn
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=17))"
-Import-Package: com.google.common.base;version="[33.0,34.0)",
+Import-Package: com.google.common.base;version="[33.2.0,34.0.0)",
+ org.apache.commons.collections4;version="[4.4.0,5.0.0)",
+ org.apache.commons.collections4.multimap;version="[4.4.0,5.0.0)",
  org.eclipse.mylyn.wikitext.parser;version="[4.2,5)",
  org.eclipse.mylyn.wikitext.parser.builder;version="[4.2,5)",
  org.eclipse.mylyn.wikitext.parser.markup;version="[4.2,5)",

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.toolkit/META-INF/MANIFEST.MF
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.toolkit/META-INF/MANIFEST.MF
@@ -7,8 +7,8 @@ Bundle-Name: Mylyn WikiText Toolkit
 Bundle-Vendor: Eclipse Mylyn
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=17))"
-Import-Package: com.google.common.base;version="[33.0,34.0)",
- com.google.common.io;version="[33.0,34.0)",
+Import-Package: org.apache.commons.io;version="[2.16.0,3.0.0)",
+ org.apache.commons.lang3;version="[3.14.0,4.0.0)",
  org.eclipse.mylyn.wikitext.parser;version="[4.2,5)",
  org.eclipse.mylyn.wikitext.parser.builder;version="[4.2,5)",
  org.eclipse.mylyn.wikitext.parser.markup;version="[4.2,5)",

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.toolkit/src/main/java/org/eclipse/mylyn/wikitext/toolkit/TestResources.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.toolkit/src/main/java/org/eclipse/mylyn/wikitext/toolkit/TestResources.java
@@ -10,6 +10,7 @@
  * Contributors:
  *     David Green - initial API and implementation
  *     ArSysOp - ongoing support
+ *     See git history
  *******************************************************************************/
 package org.eclipse.mylyn.wikitext.toolkit;
 
@@ -19,7 +20,7 @@ import java.io.IOException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 
-import com.google.common.io.Resources;
+import org.apache.commons.io.IOUtils;
 
 /**
  * @since 3.0
@@ -31,7 +32,7 @@ public class TestResources {
 		try {
 			URL url = relativeToClass.getResource(path);
 			requireNonNull(url, String.format("Resource %s not found relative to %s", path, relativeToClass.getName()));
-			return convertToUnixLineEndings(Resources.toString(url, StandardCharsets.UTF_8));
+			return convertToUnixLineEndings(IOUtils.toString(url, StandardCharsets.UTF_8));
 		} catch (IOException e) {
 			throw new RuntimeException(e);
 		}

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.toolkit/src/main/java/org/eclipse/mylyn/wikitext/toolkit/TimeoutActionRule.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.toolkit/src/main/java/org/eclipse/mylyn/wikitext/toolkit/TimeoutActionRule.java
@@ -13,13 +13,13 @@
  *******************************************************************************/
 package org.eclipse.mylyn.wikitext.toolkit;
 
-import static com.google.common.base.Preconditions.checkArgument;
 import static java.util.Objects.requireNonNull;
 
 import java.time.Duration;
 import java.util.Timer;
 import java.util.TimerTask;
 
+import org.apache.commons.lang3.Validate;
 import org.junit.rules.TestRule;
 import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
@@ -38,7 +38,7 @@ public abstract class TimeoutActionRule implements TestRule {
 	 */
 	public TimeoutActionRule(Duration timeoutDuration) {
 		this.timeoutDuration = requireNonNull(timeoutDuration, "Must specify a timeout duration");
-		checkArgument(timeoutDuration.toMillis() > 100L, "Timeout must be > 100ms");
+		Validate.isTrue(timeoutDuration.toMillis() > 100L, "Timeout must be > 100ms");
 	}
 
 	/**

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext/META-INF/MANIFEST.MF
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext/META-INF/MANIFEST.MF
@@ -8,13 +8,16 @@ Bundle-Vendor: Eclipse Mylyn
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=17))"
 Import-Package: com.google.common.base;version="[33.0,34.0)",
- com.google.common.collect;version="[33.0,34.0)",
  com.google.common.escape;version="[33.0,34.0)",
  com.google.common.xml;version="[33.0,34.0)",
  javax.lang.model,
  javax.xml.namespace,
  javax.xml.parsers,
  javax.xml.stream,
+ org.apache.commons.collections4;version="[4.4.0,5.0.0)",
+ org.apache.commons.collections4.multimap;version="[4.4.0,5.0.0)",
+ org.apache.commons.lang3;version="[3.14.0,4.0.0)",
+ org.apache.commons.lang3.builder;version="[3.14.0,4.0.0)",
  org.jsoup;version="[1.17,2)",
  org.jsoup.internal;version="[1.17,2)",
  org.jsoup.nodes;version="[1.17,2)",

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext/src/main/java/org/eclipse/mylyn/wikitext/internal/parser/html/RemoveEmptySpansProcessor.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext/src/main/java/org/eclipse/mylyn/wikitext/internal/parser/html/RemoveEmptySpansProcessor.java
@@ -10,18 +10,18 @@
  * Contributors:
  *     David Green - initial API and implementation
  *     Alexander Fedorov (ArSysOp) - ongoing support
+ *     See git history
  *******************************************************************************/
 
 package org.eclipse.mylyn.wikitext.internal.parser.html;
 
 import java.util.List;
 
+import org.apache.commons.lang3.StringUtils;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
 import org.jsoup.nodes.Node;
 import org.jsoup.nodes.TextNode;
-
-import com.google.common.base.Strings;
 
 /**
  * @author David Green
@@ -81,7 +81,7 @@ class RemoveEmptySpansProcessor extends DocumentProcessor {
 	}
 
 	private boolean isHyperlinkWithTarget(Element element) {
-		return element.tagName().equalsIgnoreCase("a") && !Strings.isNullOrEmpty(element.attr("href")); //$NON-NLS-1$//$NON-NLS-2$
+		return element.tagName().equalsIgnoreCase("a") && StringUtils.isNotEmpty(element.attr("href")); //$NON-NLS-1$//$NON-NLS-2$
 	}
 
 }

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext/src/main/java/org/eclipse/mylyn/wikitext/parser/builder/HtmlEntities.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext/src/main/java/org/eclipse/mylyn/wikitext/parser/builder/HtmlEntities.java
@@ -9,34 +9,35 @@
  *
  * Contributors:
  *     David Green - initial API and implementation
+ *     See git history
  *******************************************************************************/
 
 package org.eclipse.mylyn.wikitext.parser.builder;
-
-import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Preconditions.checkState;
 
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.text.Normalizer;
+import java.util.Collection;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import org.apache.commons.collections4.MultiValuedMap;
+import org.apache.commons.collections4.multimap.ArrayListValuedHashMap;
+import org.apache.commons.lang3.Validate;
+
 import com.google.common.base.CharMatcher;
 import com.google.common.base.Splitter;
-import com.google.common.collect.ImmutableListMultimap;
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ListMultimap;
 
 class HtmlEntities {
 
 	private static HtmlEntities instance = new HtmlEntities();
 
-	private static ListMultimap<String, String> readHtmlEntities() {
-		ImmutableListMultimap.Builder<String, String> builder = ImmutableListMultimap.builder();
+	private static MultiValuedMap<String, String> readHtmlEntities() {
+		MultiValuedMap<String, String> builder = new ArrayListValuedHashMap<>();
 
 		try (BufferedReader reader = new BufferedReader(
 				new InputStreamReader(HtmlDocumentBuilder.class.getResourceAsStream("html-entity-references.txt"), //$NON-NLS-1$
@@ -46,7 +47,7 @@ class HtmlEntities {
 			String line;
 			while ((line = reader.readLine()) != null) {
 				List<String> lineItems = splitter.splitToList(line);
-				checkState(lineItems.size() > 1);
+				Validate.isTrue(lineItems.size() > 1);
 				for (int x = 1; x < lineItems.size(); ++x) {
 					builder.put(lineItems.get(0), lineItems.get(x));
 				}
@@ -54,14 +55,17 @@ class HtmlEntities {
 		} catch (IOException e) {
 			throw new RuntimeException(e);
 		}
-		return builder.build();
+		// FIXME Breaks API (returns UnmodifiableCollection instead of List)
+//			return MultiMapUtils.unmodifiableMultiValuedMap(builder);
+		return builder;
+
 	}
 
 	public static HtmlEntities instance() {
 		return instance;
 	}
 
-	private final ListMultimap<String, String> nameToNumericEntityReferences;
+	private final MultiValuedMap<String, String> nameToNumericEntityReferences;
 
 	private final Map<String, String> nameToStringEquivalent;
 
@@ -71,7 +75,7 @@ class HtmlEntities {
 	}
 
 	public List<String> nameToEntityReferences(String name) {
-		return nameToNumericEntityReferences.get(name);
+		return (List<String>) nameToNumericEntityReferences.get(name);
 	}
 
 	public String nameToStringEquivalent(String name) {
@@ -79,21 +83,23 @@ class HtmlEntities {
 	}
 
 	private Map<String, String> createNameToStringEquivalent(
-			ListMultimap<String, String> nameToNumericEntityReferences) {
-		ImmutableMap.Builder<String, String> mapBuilder = ImmutableMap.builder();
+			MultiValuedMap<String, String> nameToNumericEntityReferences) {
+		Map<String, String> mapBuilder = new HashMap<>();
 		for (String name : nameToNumericEntityReferences.keySet()) {
 			mapBuilder.put(name, stringEquivalent(nameToNumericEntityReferences.get(name)));
 		}
-		return mapBuilder.build();
+		return Map.copyOf(mapBuilder);
 	}
 
-	private String stringEquivalent(List<String> values) {
-		return Normalizer.normalize(values.stream().map(this::numericEntityToString).collect(Collectors.joining()),
+
+	private String stringEquivalent(Collection<String> collection) {
+		return Normalizer.normalize(
+				collection.stream().map(this::numericEntityToString).collect(Collectors.joining()),
 				Normalizer.Form.NFC);
 	}
 
 	private String numericEntityToString(String s) {
-		checkArgument(s.charAt(0) == '#');
+		Validate.isTrue(s.charAt(0) == '#');
 		return String.valueOf((char) Integer.parseInt(s.substring(1)));
 	}
 }

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext/src/main/java/org/eclipse/mylyn/wikitext/parser/markup/MarkupLanguage.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext/src/main/java/org/eclipse/mylyn/wikitext/parser/markup/MarkupLanguage.java
@@ -9,16 +9,16 @@
  *
  * Contributors:
  *     David Green - initial API and implementation
+ *     See git history
  *******************************************************************************/
 package org.eclipse.mylyn.wikitext.parser.markup;
-
-import static com.google.common.base.Preconditions.checkArgument;
 
 import java.io.Writer;
 import java.util.Collections;
 import java.util.Objects;
 import java.util.Set;
 
+import org.apache.commons.lang3.Validate;
 import org.eclipse.mylyn.wikitext.parser.DocumentBuilder;
 import org.eclipse.mylyn.wikitext.parser.MarkupParser;
 import org.eclipse.mylyn.wikitext.util.ServiceLocator;
@@ -125,7 +125,7 @@ public abstract class MarkupLanguage implements Cloneable {
 	 */
 	public void setFileExtensions(Set<String> fileExtensions) {
 		Objects.requireNonNull(fileExtensions, "Must specify file extensions"); //$NON-NLS-1$
-		checkArgument(!fileExtensions.isEmpty(), "File extensions must not be empty"); //$NON-NLS-1$
+		Validate.isTrue(!fileExtensions.isEmpty(), "File extensions must not be empty"); //$NON-NLS-1$
 		this.fileExtensions = Set.copyOf(fileExtensions);
 	}
 

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext/src/main/java/org/eclipse/mylyn/wikitext/parser/markup/MarkupLanguageProvider.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext/src/main/java/org/eclipse/mylyn/wikitext/parser/markup/MarkupLanguageProvider.java
@@ -9,16 +9,16 @@
  *
  * Contributors:
  *     David Green - initial API and implementation
+ *     See git history
  *******************************************************************************/
 
 package org.eclipse.mylyn.wikitext.parser.markup;
-
-import static com.google.common.base.Preconditions.checkState;
 
 import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
 
+import org.apache.commons.lang3.Validate;
 import org.eclipse.mylyn.wikitext.util.ServiceLocator;
 
 /**
@@ -45,7 +45,7 @@ public abstract class MarkupLanguageProvider {
 		Set<String> names = new HashSet<>();
 		for (MarkupLanguage language : languages) {
 			Objects.requireNonNull(language.getName(), "Provided languages must have a name"); //$NON-NLS-1$
-			checkState(names.add(language.getName()), "Language name '%s' must not be provided more than once", //$NON-NLS-1$
+			Validate.isTrue(names.add(language.getName()), "Language name '%s' must not be provided more than once", //$NON-NLS-1$
 					language.getName());
 		}
 	}

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext/src/main/java/org/eclipse/mylyn/wikitext/parser/util/MarkupToEclipseToc.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext/src/main/java/org/eclipse/mylyn/wikitext/parser/util/MarkupToEclipseToc.java
@@ -9,15 +9,15 @@
  *
  * Contributors:
  *     David Green - initial API and implementation
+ *     See git history
  *******************************************************************************/
 package org.eclipse.mylyn.wikitext.parser.util;
-
-import static com.google.common.base.Preconditions.checkArgument;
 
 import java.io.StringWriter;
 import java.io.Writer;
 import java.util.List;
 
+import org.apache.commons.lang3.Validate;
 import org.eclipse.mylyn.wikitext.parser.markup.MarkupLanguage;
 import org.eclipse.mylyn.wikitext.parser.outline.OutlineItem;
 import org.eclipse.mylyn.wikitext.parser.outline.OutlineParser;
@@ -186,7 +186,7 @@ public class MarkupToEclipseToc {
 	 *            a number >= 0 and <= 6
 	 */
 	public void setAnchorLevel(int anchorLevel) {
-		checkArgument(anchorLevel >= 0 && anchorLevel <= 6, "The anchor level must be >= 0 and <= 6"); //$NON-NLS-1$
+		Validate.isTrue(anchorLevel >= 0 && anchorLevel <= 6, "The anchor level must be >= 0 and <= 6"); //$NON-NLS-1$
 		this.anchorLevel = anchorLevel;
 	}
 

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext/src/main/java/org/eclipse/mylyn/wikitext/splitter/SplittingHtmlDocumentBuilder.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext/src/main/java/org/eclipse/mylyn/wikitext/splitter/SplittingHtmlDocumentBuilder.java
@@ -9,10 +9,9 @@
  *
  * Contributors:
  *     David Green - initial API and implementation
+ *     See git history
  *******************************************************************************/
 package org.eclipse.mylyn.wikitext.splitter;
-
-import static com.google.common.base.Preconditions.checkState;
 
 import java.io.File;
 import java.io.FileOutputStream;
@@ -22,6 +21,7 @@ import java.io.Writer;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 
+import org.apache.commons.lang3.Validate;
 import org.eclipse.mylyn.wikitext.parser.Attributes;
 import org.eclipse.mylyn.wikitext.parser.DocumentBuilder;
 import org.eclipse.mylyn.wikitext.parser.ImageAttributes;
@@ -484,7 +484,7 @@ public class SplittingHtmlDocumentBuilder extends DocumentBuilder {
 				pageItem = item;
 			}
 		}
-		checkState(pageItem != null);
+		Validate.notNull(pageItem);
 		emitToc(outline, 0);
 	}
 

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext/src/main/java/org/eclipse/mylyn/wikitext/util/ServiceLocator.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext/src/main/java/org/eclipse/mylyn/wikitext/util/ServiceLocator.java
@@ -9,10 +9,9 @@
  *
  * Contributors:
  *     David Green - initial API and implementation
+ *     See git history
  *******************************************************************************/
 package org.eclipse.mylyn.wikitext.util;
-
-import static com.google.common.base.Preconditions.checkArgument;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -25,6 +24,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Enumeration;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.ServiceLoader;
@@ -34,13 +34,12 @@ import java.util.logging.Logger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import org.apache.commons.collections4.MultiValuedMap;
+import org.apache.commons.collections4.multimap.ArrayListValuedHashMap;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Validate;
 import org.eclipse.mylyn.wikitext.parser.markup.MarkupLanguage;
 import org.eclipse.mylyn.wikitext.parser.markup.MarkupLanguageProvider;
-
-import com.google.common.base.Strings;
-import com.google.common.collect.HashMultimap;
-import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Multimap;
 
 /**
  * A service locator for use both inside and outside of an Eclipse environment. Provides access to markup languages by name.
@@ -117,7 +116,7 @@ public class ServiceLocator {
 	 *             if the provided language name is null or if no implementation is available for the given language
 	 */
 	public MarkupLanguage getMarkupLanguage(final String languageName) throws IllegalArgumentException {
-		checkArgument(!Strings.isNullOrEmpty(languageName), "Must provide a languageName"); //$NON-NLS-1$
+		Validate.isTrue(StringUtils.isNotEmpty(languageName), "Must provide a languageName"); //$NON-NLS-1$
 		Pattern classNamePattern = Pattern.compile("\\s*([^\\s#]+)?#?.*"); //$NON-NLS-1$
 		// first try Java services (jar-based)
 		final List<String> names = new ArrayList<>();
@@ -177,7 +176,7 @@ public class ServiceLocator {
 		}
 		throw new IllegalArgumentException(MessageFormat.format(Messages.getString("ServiceLocator.4"), //$NON-NLS-1$
 				languageName, buf.length() == 0
-						? Messages.getString("ServiceLocator.5") //$NON-NLS-1$
+				? Messages.getString("ServiceLocator.5") //$NON-NLS-1$
 						: Messages.getString("ServiceLocator.6") + buf)); //$NON-NLS-1$
 	}
 
@@ -194,14 +193,14 @@ public class ServiceLocator {
 	}
 
 	private Set<MarkupLanguage> filterDuplicates(Set<MarkupLanguage> markupLanguages) {
-		Multimap<String, Class<?>> markupLanguageClassesByName = HashMultimap.create();
-		ImmutableSet.Builder<MarkupLanguage> builder = ImmutableSet.builder();
+		MultiValuedMap<String, Class<?>> markupLanguageClassesByName = new ArrayListValuedHashMap<>();
+		Set<MarkupLanguage> builder = new LinkedHashSet<>();
 		for (MarkupLanguage language : markupLanguages) {
 			if (markupLanguageClassesByName.put(language.getName(), language.getClass())) {
 				builder.add(language);
 			}
 		}
-		return builder.build();
+		return Set.copyOf(builder);
 	}
 
 	public static void setImplementation(Class<? extends ServiceLocator> implementationClass) {
@@ -243,7 +242,7 @@ public class ServiceLocator {
 	void logFailure(String className, Exception e) {
 		// very unusual, but inform the user in a stand-alone way
 		Logger.getLogger(ServiceLocator.class.getName())
-				.log(Level.WARNING, MessageFormat.format(Messages.getString("ServiceLocator.0"), className), e); //$NON-NLS-1$
+		.log(Level.WARNING, MessageFormat.format(Messages.getString("ServiceLocator.0"), className), e); //$NON-NLS-1$
 	}
 
 	/**

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext/src/main/java/org/eclipse/mylyn/wikitext/util/WikiToStringStyle.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext/src/main/java/org/eclipse/mylyn/wikitext/util/WikiToStringStyle.java
@@ -1,0 +1,34 @@
+/*******************************************************************************
+ * Copyright (c) 2024 George Lindholm
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html.
+ *
+ * Contributors:
+ *      See git history
+ *******************************************************************************/
+
+package org.eclipse.mylyn.wikitext.util;
+
+import org.apache.commons.lang3.builder.ToStringStyle;
+
+/**
+ * Duplicate Guava's ToStringHelper() format
+ *
+ * @since 4.4
+ */
+public class WikiToStringStyle extends ToStringStyle {
+	private static final long serialVersionUID = 1L;
+
+	public static final WikiToStringStyle WIKI_TO_STRING_STYLE = new WikiToStringStyle();
+
+	private WikiToStringStyle() {
+		setUseShortClassName(true);
+		setUseIdentityHashCode(false);
+		setFieldSeparator(", "); //$NON-NLS-1$
+		setContentStart("{"); //$NON-NLS-1$
+		setContentEnd("}"); //$NON-NLS-1$
+		setNullText("null"); //$NON-NLS-1$
+	}
+}

--- a/mylyn.docs/wikitext/core/pom.xml
+++ b/mylyn.docs/wikitext/core/pom.xml
@@ -83,6 +83,10 @@
 							${project.artifactId}.internal*;x-internal:=true,${project.artifactId}*</Export-Package>
 						<Import-Package>!java.*, com.google.common*;
 							version="[${guava.osgi},${guava.osgi.upper})", *</Import-Package>
+						<Import-Package>!java.*, org.apache.commons.collections4*;
+							version="[4.4.0,5.0.0)", *</Import-Package>
+						<Import-Package>!java.*, org.apache.commons.lang3*;
+							version="[3.14.0,4.0.0)", *</Import-Package>
 					</instructions>
 				</configuration>
 			</plugin>

--- a/mylyn.docs/wikitext/ui/org.eclipse.mylyn.wikitext.help.ui/pom.xml
+++ b/mylyn.docs/wikitext/ui/org.eclipse.mylyn.wikitext.help.ui/pom.xml
@@ -119,6 +119,16 @@
 						<artifactId>guava</artifactId>
 						<version>33.2.1-jre</version>
 					</dependency>
+					<dependency>
+					    <groupId>org.apache.commons</groupId>
+					    <artifactId>commons-collections4</artifactId>
+					    <version>4.4</version>
+					</dependency>
+					<dependency>
+					    <groupId>org.apache.commons</groupId>
+					    <artifactId>commons-lang3</artifactId>
+					    <version>3.14.0</version>
+					</dependency>
 				</dependencies>
 			</plugin>
 		</plugins>

--- a/mylyn.docs/wikitext/ui/org.eclipse.mylyn.wikitext.osgi.tests/META-INF/MANIFEST.MF
+++ b/mylyn.docs/wikitext/ui/org.eclipse.mylyn.wikitext.osgi.tests/META-INF/MANIFEST.MF
@@ -3,6 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Mylyn WikiText Core Tests
 Bundle-SymbolicName: org.eclipse.mylyn.wikitext.osgi.tests
 Fragment-Host: org.eclipse.mylyn.wikitext.osgi;bundle-version="4.4.0"
+Import-Package: org.apache.commons.lang3;version="3.14.0"
 Bundle-Version: 4.4.0.qualifier
 Bundle-Vendor: Eclipse.org
 Bundle-RequiredExecutionEnvironment: JavaSE-17

--- a/mylyn.docs/wikitext/ui/org.eclipse.mylyn.wikitext.osgi.tests/src/org/eclipse/mylyn/wikitext/core/osgi/MockMarkupLanguage.java
+++ b/mylyn.docs/wikitext/ui/org.eclipse.mylyn.wikitext.osgi.tests/src/org/eclipse/mylyn/wikitext/core/osgi/MockMarkupLanguage.java
@@ -9,21 +9,20 @@
  *
  * Contributors:
  *     David Green - initial API and implementation
+ *     See git history
  *******************************************************************************/
 
 package org.eclipse.mylyn.wikitext.core.osgi;
 
-import static com.google.common.base.Preconditions.checkArgument;
-
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Validate;
 import org.eclipse.mylyn.wikitext.parser.MarkupParser;
 import org.eclipse.mylyn.wikitext.parser.markup.MarkupLanguage;
-
-import com.google.common.base.Strings;
 
 @SuppressWarnings("restriction")
 public class MockMarkupLanguage extends MarkupLanguage {
 	public MockMarkupLanguage(String name) {
-		checkArgument(!Strings.isNullOrEmpty(name));
+		Validate.isTrue(StringUtils.isNotEmpty(name));
 		setName(name);
 	}
 

--- a/mylyn.docs/wikitext/ui/org.eclipse.mylyn.wikitext.osgi.tests/src/org/eclipse/mylyn/wikitext/core/osgi/OsgiServiceLocatorTest.java
+++ b/mylyn.docs/wikitext/ui/org.eclipse.mylyn.wikitext.osgi.tests/src/org/eclipse/mylyn/wikitext/core/osgi/OsgiServiceLocatorTest.java
@@ -9,6 +9,7 @@
  *
  * Contributors:
  *     David Green - initial API and implementation
+ *     See git history
  *******************************************************************************/
 package org.eclipse.mylyn.wikitext.core.osgi;
 
@@ -32,8 +33,6 @@ import org.eclipse.mylyn.wikitext.util.ServiceLocator;
 import org.junit.Test;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
-
-import com.google.common.base.Throwables;
 
 @SuppressWarnings({ "nls", "restriction" })
 public class OsgiServiceLocatorTest {
@@ -110,7 +109,9 @@ public class OsgiServiceLocatorTest {
 			doReturn(1234L).when(bundle).getBundleId();
 			doReturn(markupLanguage).when(bundle).loadClass(eq(markupLanguage.getName()));
 		} catch (Exception e) {
-			Throwables.throwIfUnchecked(e);
+			if (e instanceof RuntimeException) {
+				throw (RuntimeException) e;
+			}
 			throw new RuntimeException(e);
 		}
 		return bundle;

--- a/mylyn.docs/wikitext/ui/org.eclipse.mylyn.wikitext.osgi/META-INF/MANIFEST.MF
+++ b/mylyn.docs/wikitext/ui/org.eclipse.mylyn.wikitext.osgi/META-INF/MANIFEST.MF
@@ -10,5 +10,5 @@ Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.eclipse.mylyn.wikitext;bundle-version="4.4.0"
 Export-Package: org.eclipse.mylyn.wikitext.core.osgi;x-internal:=true
-Import-Package: org.osgi.framework;version="1.5.0",
- com.google.common.base;version="[33.0.0,34.0.0)"
+Import-Package: org.apache.commons.lang3;version="[3.14.0,4.0.0)",
+ org.osgi.framework;version="1.5.0"

--- a/mylyn.docs/wikitext/ui/org.eclipse.mylyn.wikitext.osgi/src/org/eclipse/mylyn/wikitext/core/osgi/OsgiServiceLocator.java
+++ b/mylyn.docs/wikitext/ui/org.eclipse.mylyn.wikitext.osgi/src/org/eclipse/mylyn/wikitext/core/osgi/OsgiServiceLocator.java
@@ -9,11 +9,11 @@
  *
  * Contributors:
  *     David Green - initial API and implementation
+ *     See git history
  *******************************************************************************/
 
 package org.eclipse.mylyn.wikitext.core.osgi;
 
-import static com.google.common.base.Preconditions.checkState;
 import static java.util.Objects.requireNonNull;
 
 import java.net.URL;
@@ -27,6 +27,7 @@ import java.util.Set;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
 
+import org.apache.commons.lang3.Validate;
 import org.eclipse.mylyn.wikitext.util.ServiceLocator;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
@@ -96,7 +97,7 @@ public class OsgiServiceLocator extends ServiceLocator {
 		for (Bundle bundle : bundles().toArray(Bundle[]::new)) {
 			for (String resourceName : getClasspathServiceResourceNames()) {
 				int indexOf = resourceName.indexOf(SERVICES_SLASH);
-				checkState(indexOf >= 0, resourceName);
+				Validate.isTrue(indexOf >= 0, resourceName);
 
 				String path = resourceName.substring(0, indexOf + SERVICES_SLASH.length() - 1);
 				String file = resourceName.substring(indexOf + SERVICES_SLASH.length());

--- a/mylyn.docs/wikitext/ui/org.eclipse.mylyn.wikitext.tasks.ui/src/org/eclipse/mylyn/wikitext/tasks/ui/editor/MarkupTaskEditorExtension.java
+++ b/mylyn.docs/wikitext/ui/org.eclipse.mylyn.wikitext.tasks.ui/src/org/eclipse/mylyn/wikitext/tasks/ui/editor/MarkupTaskEditorExtension.java
@@ -11,6 +11,7 @@
  *     David Green - initial API and implementation
  *     Frank Becker - improvements for bug 304910
  *     Tasktop Technologies - improvements
+ *     See git history
  *******************************************************************************/
 package org.eclipse.mylyn.wikitext.tasks.ui.editor;
 
@@ -74,7 +75,7 @@ import org.eclipse.ui.texteditor.SourceViewerDecorationSupport;
  * @since 1.0
  */
 public class MarkupTaskEditorExtension<MarkupLanguageType extends MarkupLanguage> extends AbstractTaskEditorExtension
-		implements IAdaptable {
+implements IAdaptable {
 
 	private static final String MARKUP_SOURCE_CONTEXT_ID = "org.eclipse.mylyn.wikitext.tasks.ui.markupSourceContext"; //$NON-NLS-1$
 
@@ -147,8 +148,8 @@ public class MarkupTaskEditorExtension<MarkupLanguageType extends MarkupLanguage
 
 		if (JFaceResources.getFontRegistry().hasValueFor(WikiTextTasksUiPlugin.FONT_REGISTRY_KEY_DEFAULT_FONT)) {
 			markupViewer.getTextWidget()
-					.setFont(
-							JFaceResources.getFontRegistry().get(WikiTextTasksUiPlugin.FONT_REGISTRY_KEY_DEFAULT_FONT));
+			.setFont(
+					JFaceResources.getFontRegistry().get(WikiTextTasksUiPlugin.FONT_REGISTRY_KEY_DEFAULT_FONT));
 		}
 		if (JFaceResources.getFontRegistry().hasValueFor(WikiTextTasksUiPlugin.FONT_REGISTRY_KEY_MONOSPACE_FONT)) {
 			markupViewer.setDefaultMonospaceFont(
@@ -218,7 +219,6 @@ public class MarkupTaskEditorExtension<MarkupLanguageType extends MarkupLanguage
 		return createEditor(taskRepository, parent, style, null);
 	}
 
-	@SuppressWarnings("unchecked")
 	@Override
 	public SourceViewer createEditor(TaskRepository taskRepository, Composite parent, int style, IAdaptable context) {
 		final MarkupLanguageType markupLanguageCopy = createRepositoryMarkupLanguage(taskRepository);
@@ -348,7 +348,6 @@ public class MarkupTaskEditorExtension<MarkupLanguageType extends MarkupLanguage
 			};
 		}
 
-		@SuppressWarnings("unchecked")
 		@Override
 		protected Map<String, IAdaptable> getHyperlinkDetectorTargets(ISourceViewer sourceViewer) {
 			Map<String, IAdaptable> hyperlinkDetectorTargets = super.getHyperlinkDetectorTargets(sourceViewer);
@@ -400,7 +399,6 @@ public class MarkupTaskEditorExtension<MarkupLanguageType extends MarkupLanguage
 			markupHyperlinksFirst = false;
 		}
 
-		@SuppressWarnings("unchecked")
 		@Override
 		protected Map<String, IAdaptable> getHyperlinkDetectorTargets(ISourceViewer sourceViewer) {
 			Map<String, IAdaptable> hyperlinkDetectorTargets = super.getHyperlinkDetectorTargets(sourceViewer);

--- a/mylyn.docs/wikitext/ui/org.eclipse.mylyn.wikitext.ui.tests/META-INF/MANIFEST.MF
+++ b/mylyn.docs/wikitext/ui/org.eclipse.mylyn.wikitext.ui.tests/META-INF/MANIFEST.MF
@@ -44,7 +44,8 @@ Export-Package: org.eclipse.mylyn.internal.wikitext.ui;x-internal:=true,
  org.eclipse.mylyn.wikitext.textile.tests;x-internal:=true,
  org.eclipse.mylyn.wikitext.textile.tests.resources;x-internal:=true,
  org.eclipse.mylyn.wikitext.ui.annotation;x-internal:=true
-Import-Package: com.google.common.base;version="33.0.0",
- com.google.common.io;version="33.0.0"
+Import-Package: org.apache.commons.io;version="[2.16.0,3.0.0)",
+ org.apache.commons.lang3;version="[3.14.0,4.0.0)",
+ org.apache.commons.lang3.builder;version="[3.14.0,4.0.0)"
 Bundle-Localization: plugin
 Bundle-ActivationPolicy: lazy

--- a/mylyn.docs/wikitext/ui/org.eclipse.mylyn.wikitext.ui.tests/src/org/eclipse/mylyn/internal/wikitext/ui/ScreenshotOnTimeoutRule.java
+++ b/mylyn.docs/wikitext/ui/org.eclipse.mylyn.wikitext.ui.tests/src/org/eclipse/mylyn/internal/wikitext/ui/ScreenshotOnTimeoutRule.java
@@ -9,6 +9,7 @@
  *
  * Contributors:
  *     David Green - initial API and implementation
+ *     See git history
  *******************************************************************************/
 
 package org.eclipse.mylyn.internal.wikitext.ui;
@@ -24,7 +25,9 @@ import java.time.Duration;
 import java.util.Arrays;
 import java.util.List;
 
+import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.eclipse.mylyn.wikitext.toolkit.TimeoutActionRule;
+import org.eclipse.mylyn.wikitext.util.WikiToStringStyle;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.custom.StyledText;
 import org.eclipse.swt.graphics.GC;
@@ -38,9 +41,6 @@ import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Label;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.swt.widgets.Text;
-
-import com.google.common.base.MoreObjects;
-import com.google.common.base.MoreObjects.ToStringHelper;
 
 @SuppressWarnings({ "nls", "restriction" })
 public class ScreenshotOnTimeoutRule extends TimeoutActionRule {
@@ -121,19 +121,19 @@ public class ScreenshotOnTimeoutRule extends TimeoutActionRule {
 	}
 
 	private String description(Control control) {
-		ToStringHelper builder = MoreObjects.toStringHelper(control.getClass());
+		ToStringBuilder builder = new ToStringBuilder(this, WikiToStringStyle.WIKI_TO_STRING_STYLE);
 		if (control instanceof StyledText styled) {
-			builder.add("text", styled.getText());
+			builder.append("text", styled.getText());
 		}
 		if (control instanceof Text text) {
-			builder.add("text", text.getText());
+			builder.append("text", text.getText());
 		}
 		if (control instanceof Button b) {
-			builder.add("text", b.getText());
+			builder.append("text", b.getText());
 		}
 		if (control instanceof Label l) {
-			builder.add("text", l.getText());
+			builder.append("text", l.getText());
 		}
-		return builder.add("tooltip", control.getToolTipText()).toString();
+		return builder.append("tooltip", control.getToolTipText()).toString();
 	}
 }

--- a/mylyn.docs/wikitext/ui/org.eclipse.mylyn.wikitext.ui.tests/src/org/eclipse/mylyn/wikitext/textile/tests/TextileLanguageTasksTest.java
+++ b/mylyn.docs/wikitext/ui/org.eclipse.mylyn.wikitext.ui.tests/src/org/eclipse/mylyn/wikitext/textile/tests/TextileLanguageTasksTest.java
@@ -10,6 +10,7 @@
  * Contributors:
  *     David Green - initial API and implementation
  *     ArSysOp - ongoing support
+ *     See git history
  *******************************************************************************/
 
 package org.eclipse.mylyn.wikitext.textile.tests;
@@ -18,6 +19,7 @@ import java.io.IOException;
 import java.io.StringWriter;
 import java.nio.charset.StandardCharsets;
 
+import org.apache.commons.io.IOUtils;
 import org.eclipse.mylyn.internal.wikitext.ui.util.Util;
 import org.eclipse.mylyn.wikitext.parser.MarkupParser;
 import org.eclipse.mylyn.wikitext.parser.builder.HtmlDocumentBuilder;
@@ -26,8 +28,6 @@ import org.eclipse.mylyn.wikitext.tests.EclipseRuntimeRequired;
 import org.eclipse.mylyn.wikitext.textile.TextileLanguage;
 import org.junit.Before;
 import org.junit.Test;
-
-import com.google.common.io.Resources;
 
 /**
  * tests for Textile that involve the tasks plug-in and dependencies on the Eclipse runtime.
@@ -63,7 +63,7 @@ public class TextileLanguageTasksTest {
 		StringWriter out = new StringWriter();
 		parser.setBuilder(new HtmlDocumentBuilder(out));
 
-		String content = Resources.toString(
+		String content = IOUtils.toString(
 				TextileLanguageTasksTest.class.getResource("resources/subversive-bug-report.txt"),
 				StandardCharsets.UTF_8);
 		parser.parse(content);

--- a/mylyn.docs/wikitext/ui/org.eclipse.mylyn.wikitext.ui/META-INF/MANIFEST.MF
+++ b/mylyn.docs/wikitext/ui/org.eclipse.mylyn.wikitext.ui/META-INF/MANIFEST.MF
@@ -44,9 +44,7 @@ Export-Package: org.eclipse.mylyn.internal.wikitext.ui;x-friends:="org.eclipse.m
  org.eclipse.mylyn.wikitext.ui.commands;x-internal:=true,
  org.eclipse.mylyn.wikitext.ui.editor;x-friends:="org.eclipse.mylyn.wikitext.tasks.ui",
  org.eclipse.mylyn.wikitext.ui.viewer;x-friends:="org.eclipse.mylyn.wikitext.tasks.ui"
-Import-Package: com.google.common.base;version="[33.0.0,34.0.0)",
- com.google.common.collect;version="[33.0.0,34.0.0)",
- com.google.common.io;version="[33.0.0,34.0.0)"
+Import-Package: org.apache.commons.io;version="[2.16.0,3.0.0)"
 Bundle-ActivationPolicy: lazy
 Bundle-Localization: plugin
 Bundle-RequiredExecutionEnvironment: JavaSE-17

--- a/mylyn.docs/wikitext/ui/org.eclipse.mylyn.wikitext.ui/src/org/eclipse/mylyn/internal/wikitext/ui/WikiTextUiPlugin.java
+++ b/mylyn.docs/wikitext/ui/org.eclipse.mylyn.wikitext.ui/src/org/eclipse/mylyn/internal/wikitext/ui/WikiTextUiPlugin.java
@@ -9,9 +9,11 @@
  *
  * Contributors:
  *     David Green - initial API and implementation
+ *     See git history
  *******************************************************************************/
 package org.eclipse.mylyn.internal.wikitext.ui;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -43,10 +45,6 @@ import org.eclipse.swt.widgets.Text;
 import org.eclipse.ui.plugin.AbstractUIPlugin;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
-
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableList.Builder;
-import com.google.common.collect.ImmutableMap;
 
 /**
  * @author David Green
@@ -332,8 +330,7 @@ public class WikiTextUiPlugin extends AbstractUIPlugin {
 
 	public Map<String, List<String>> getHyperlinkDectectorFileRefRegexes() {
 		if (fileRefRegexes == null) {
-			com.google.common.collect.ImmutableMap.Builder<String, List<String>> markupLanguageToFileRefRegexes = ImmutableMap
-					.builder();
+			Map<String, List<String>> markupLanguageToFileRefRegexes = new HashMap<>();
 
 			IExtensionPoint extensionPoint = Platform.getExtensionRegistry()
 					.getExtensionPoint(getPluginId(), EXTENSION_POINT_RELATIVE_FILE_PATH_HYPERLINK_DECTOR);
@@ -366,13 +363,13 @@ public class WikiTextUiPlugin extends AbstractUIPlugin {
 				}
 			}
 
-			fileRefRegexes = markupLanguageToFileRefRegexes.build();
+			fileRefRegexes = Map.copyOf(markupLanguageToFileRefRegexes);
 		}
 		return fileRefRegexes;
 	}
 
 	private List<String> createFielRefRegexes(IConfigurationElement element, String declaringPluginId) {
-		Builder<String> regexes = new ImmutableList.Builder<>();
+		List<String> regexes = new ArrayList<>();
 
 		for (IConfigurationElement fileRefRegexesChild : element.getChildren()) {
 			if (EXTENSION_POINT_FILE_REF_REGEX.equals(fileRefRegexesChild.getName())) {
@@ -391,7 +388,7 @@ public class WikiTextUiPlugin extends AbstractUIPlugin {
 						null);
 			}
 		}
-		return regexes.build();
+		return List.copyOf(regexes);
 	}
 
 	private String validateAndGetMarkupLanguage(IConfigurationElement element) throws Exception {

--- a/mylyn.docs/wikitext/ui/org.eclipse.mylyn.wikitext.ui/src/org/eclipse/mylyn/internal/wikitext/ui/editor/help/HelpContent.java
+++ b/mylyn.docs/wikitext/ui/org.eclipse.mylyn.wikitext.ui/src/org/eclipse/mylyn/internal/wikitext/ui/editor/help/HelpContent.java
@@ -9,6 +9,7 @@
  *
  * Contributors:
  *     David Green - initial API and implementation
+ *     See git history
  *******************************************************************************/
 package org.eclipse.mylyn.internal.wikitext.ui.editor.help;
 
@@ -19,13 +20,12 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 
+import org.apache.commons.io.IOUtils;
 import org.eclipse.mylyn.wikitext.parser.MarkupParser;
 import org.eclipse.mylyn.wikitext.parser.markup.MarkupLanguage;
 import org.eclipse.mylyn.wikitext.ui.WikiText;
 import org.eclipse.osgi.util.NLS;
 import org.osgi.framework.Bundle;
-
-import com.google.common.io.Resources;
 
 /**
  * A handle to help content. HelpContent is retrieved from a resource path from a bundle. Help content is retrieved in a locale-specific
@@ -92,7 +92,7 @@ public class HelpContent {
 	public String getContent() throws IOException {
 		try {
 			URL resource = getResource();
-			String content = Resources.toString(resource, StandardCharsets.UTF_8);
+			String content = IOUtils.toString(resource, StandardCharsets.UTF_8);
 			if (resourceContentLanguage == null || "html".equalsIgnoreCase(resourceContentLanguage)) { //$NON-NLS-1$
 				return content;
 			}

--- a/mylyn.docs/wikitext/ui/org.eclipse.mylyn.wikitext.ui/src/org/eclipse/mylyn/internal/wikitext/ui/editor/preferences/Preferences.java
+++ b/mylyn.docs/wikitext/ui/org.eclipse.mylyn.wikitext.ui/src/org/eclipse/mylyn/internal/wikitext/ui/editor/preferences/Preferences.java
@@ -9,6 +9,7 @@
  *
  * Contributors:
  *     David Green - initial API and implementation
+ *     See git history
  *******************************************************************************/
 package org.eclipse.mylyn.internal.wikitext.ui.editor.preferences;
 
@@ -19,13 +20,12 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.regex.Pattern;
 
+import org.apache.commons.io.IOUtils;
 import org.eclipse.jface.preference.IPreferenceStore;
 import org.eclipse.mylyn.internal.wikitext.ui.WikiTextUiPlugin;
 import org.eclipse.mylyn.internal.wikitext.ui.viewer.HtmlTextPresentationParser;
 import org.eclipse.mylyn.wikitext.parser.css.CssParser;
 import org.eclipse.mylyn.wikitext.parser.css.Stylesheet;
-
-import com.google.common.io.CharStreams;
 
 /**
  * @see WikiTextUiPlugin#getPreferences()
@@ -286,7 +286,7 @@ public class Preferences implements Cloneable {
 
 	private String getDefaultMarkupViewerCss() {
 		try (Reader reader = HtmlTextPresentationParser.getDefaultStylesheetContent()) {
-			return CharStreams.toString(reader);
+			return IOUtils.toString(reader);
 		} catch (IOException e) {
 			WikiTextUiPlugin.getDefault().log(e);
 			return ""; //$NON-NLS-1$

--- a/mylyn.docs/wikitext/ui/org.eclipse.mylyn.wikitext.ui/src/org/eclipse/mylyn/internal/wikitext/ui/editor/syntax/FileRefHyperlinkDetector.java
+++ b/mylyn.docs/wikitext/ui/org.eclipse.mylyn.wikitext.ui/src/org/eclipse/mylyn/internal/wikitext/ui/editor/syntax/FileRefHyperlinkDetector.java
@@ -9,10 +9,12 @@
  *
  * Contributors:
  *     Simon Scholz - initial API and implementation
+ *     See git history
  *******************************************************************************/
 
 package org.eclipse.mylyn.internal.wikitext.ui.editor.syntax;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
@@ -30,9 +32,6 @@ import org.eclipse.jface.text.ITextViewer;
 import org.eclipse.jface.text.Region;
 import org.eclipse.jface.text.hyperlink.IHyperlink;
 import org.eclipse.jface.text.hyperlink.IHyperlinkDetector;
-
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableList.Builder;
 
 public class FileRefHyperlinkDetector implements IHyperlinkDetector {
 
@@ -54,9 +53,9 @@ public class FileRefHyperlinkDetector implements IHyperlinkDetector {
 	}
 
 	private List<Pattern> createHyperlinkPattern(Collection<String> hyperlinkPattern) {
-		Builder<Pattern> hyperlinkPatternBuilder = ImmutableList.builder();
+		List<Pattern> hyperlinkPatternBuilder = new ArrayList<>();
 		hyperlinkPattern.forEach(pattern -> hyperlinkPatternBuilder.add(Pattern.compile(pattern)));
-		return hyperlinkPatternBuilder.build();
+		return List.copyOf(hyperlinkPatternBuilder);
 	}
 
 	@Override
@@ -81,7 +80,7 @@ public class FileRefHyperlinkDetector implements IHyperlinkDetector {
 	}
 
 	private Collection<IHyperlink> createHyperlinks(IRegion lineInfo, Optional<Matcher> fileRefPatternAtOffset) {
-		Builder<IHyperlink> hyperlinks = ImmutableList.builder();
+		List<IHyperlink> hyperlinks = new ArrayList<>();
 
 		fileRefPatternAtOffset.ifPresent(matcher -> {
 			IRegion regionToMatch = new Region(lineInfo.getOffset() + matcher.start(1),
@@ -94,7 +93,7 @@ public class FileRefHyperlinkDetector implements IHyperlinkDetector {
 			}
 		});
 
-		return hyperlinks.build();
+		return List.copyOf(hyperlinks);
 	}
 
 	private Optional<Matcher> getFileRefMatchAtOffset(String lineString, int offset) {

--- a/mylyn.docs/wikitext/ui/org.eclipse.mylyn.wikitext.ui/src/org/eclipse/mylyn/internal/wikitext/ui/util/IOUtil.java
+++ b/mylyn.docs/wikitext/ui/org.eclipse.mylyn.wikitext.ui/src/org/eclipse/mylyn/internal/wikitext/ui/util/IOUtil.java
@@ -9,6 +9,7 @@
  *
  * Contributors:
  *     David Green - initial API and implementation
+ *     See git history
  *******************************************************************************/
 
 package org.eclipse.mylyn.internal.wikitext.ui.util;
@@ -18,10 +19,9 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.Reader;
 
+import org.apache.commons.io.IOUtils;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.runtime.CoreException;
-
-import com.google.common.io.CharStreams;
 
 public class IOUtil {
 	/**
@@ -29,7 +29,7 @@ public class IOUtil {
 	 */
 	public static String readFully(IFile file) throws CoreException, IOException {
 		try (Reader r = new InputStreamReader(new BufferedInputStream(file.getContents()), file.getCharset())) {
-			return CharStreams.toString(r);
+			return IOUtils.toString(r);
 		}
 	}
 }

--- a/mylyn.reviews/org.eclipse.mylyn.reviews.core/META-INF/MANIFEST.MF
+++ b/mylyn.reviews/org.eclipse.mylyn.reviews.core/META-INF/MANIFEST.MF
@@ -21,9 +21,8 @@ Export-Package: org.eclipse.mylyn.reviews.core.model;x-friends:="org.eclipse.myl
  org.eclipse.mylyn.reviews.internal.core;x-internal:=true,
  org.eclipse.mylyn.reviews.internal.core.model;x-friends:="org.eclipse.mylyn.reviews.edit"
 Bundle-Vendor: Eclipse Mylyn
-Import-Package: com.google.common.collect;version="15.0.0",
- org.apache.commons.collections4;version="4.4.0",
+Import-Package: org.apache.commons.collections4;version="4.4.0",
  org.apache.commons.collections4.map;version="4.4.0",
  org.apache.commons.collections4.multimap;version="4.4.0",
  org.apache.commons.io,
- org.apache.commons.lang3;version="[3.13.0, 4.0.0)"
+ org.apache.commons.lang3;version="[3.13.0,4.0.0)"


### PR DESCRIPTION
Recreation of #530.

Replace guava constructs with native/apache commons equivalents.

Still have:
- CharMatcher
- Escaper
- Splitter

with no simple alternatives (that I've found)