### PR TITLE
Use org.glassfish.hk2.osgi-resource-locator from latest Orbit

### DIFF
--- a/mylyn.builds/org.eclipse.mylyn.jenkins.core/META-INF/MANIFEST.MF
+++ b/mylyn.builds/org.eclipse.mylyn.jenkins.core/META-INF/MANIFEST.MF
@@ -34,4 +34,4 @@ Import-Package: com.google.gson;version="2.9.1",
  org.apache.http.message;version="[4.4.4,4.5.0)",
  org.apache.http.protocol;version="[4.4.4,4.5.0)",
  org.apache.http.util;version="[4.4.4,4.5.0)",
- org.glassfish.hk2.osgiresourcelocator;version="2.4.0"
+ org.glassfish.hk2.osgiresourcelocator;version="1.0.3"

--- a/org.eclipse.mylyn-target/org.eclipse.mylyn.target.target
+++ b/org.eclipse.mylyn-target/org.eclipse.mylyn.target.target
@@ -69,12 +69,12 @@
 			<unit id="jakarta.xml.bind" version="2.3.3.v20221203-1659"/>
 			<unit id="javax.activation" version="1.2.2.v20221203-1659"/>
 			<unit id="javax.activation" version="2.0.0.v20221203-1659"/>
-			<unit id="org.glassfish.hk2.osgi-resource-locator" version="2.5.0.v20161103-1916"/>
 			<unit id="org.apache.commons.collections4" version="4.4.0.v20221112-0806"/>
 			<unit id="org.apache.commons.io" version="2.8.0.v20210415-0900"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 			<repository location="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/2024-06"/>
+			<unit id="org.glassfish.hk2.osgi-resource-locator" version="0.0.0"/>
 			<unit id="org.apache.commons.lang3" version="0.0.0"/>
 			<unit id="org.apache.commons.logging" version="0.0.0"/>
 			<unit id="org.apache.lucene.analysis-common" version="0.0.0"/>


### PR DESCRIPTION
- Use version 1.0.3 which is newer than all the current 2.x versions

https://github.com/eclipse-simrel/simrel.build/issues/438

The 2.5.0 versions are all older than the 1.0.3 version:

https://repo1.maven.org/maven2/org/glassfish/hk2/osgi-resource-locator/