### PR TITLE
577 replace orgapachecommonslang3stringescapeutils with orgapachecommonstextstringescapeutils

### DIFF
--- a/mylyn.commons/org.eclipse.mylyn.commons.core/META-INF/MANIFEST.MF
+++ b/mylyn.commons/org.eclipse.mylyn.commons.core/META-INF/MANIFEST.MF
@@ -14,7 +14,8 @@ Export-Package: org.eclipse.mylyn.commons.core,
  org.eclipse.mylyn.commons.core.storage;x-internal:=true,
  org.eclipse.mylyn.internal.commons.core;x-internal:=true,
  org.eclipse.mylyn.internal.commons.core.operations;x-internal:=true
-Import-Package: org.apache.commons.collections4.multimap;version="4.4.0"
+Import-Package: org.apache.commons.collections4.multimap;version="4.4.0",
+ org.apache.commons.text;version="[1.12.0,2.0.0)"
 Require-Bundle: org.eclipse.core.net;bundle-version="0.0.0",
  org.eclipse.core.runtime;bundle-version="0.0.0"
 Bundle-ClassPath: .

--- a/mylyn.commons/org.eclipse.mylyn.commons.core/src/org/eclipse/mylyn/commons/core/HtmlStreamTokenizer.java
+++ b/mylyn.commons/org.eclipse.mylyn.commons.core/src/org/eclipse/mylyn/commons/core/HtmlStreamTokenizer.java
@@ -315,6 +315,26 @@ public class HtmlStreamTokenizer {
 	}
 
 	/**
+	 * Returns a string with HTML escapes changed into their corresponding characters.
+	 *
+	 * @deprecated use {@link StringEscapeUtils#unescapeHtml4(String)} instead
+	 */
+	@Deprecated(forRemoval = true, since = "4.4.0")
+	public static String unescape(String s) {
+		return StringEscapeUtils.unescapeHtml4(s);
+	}
+
+	/**
+	 * Replaces (in-place) HTML escapes in a StringBuffer with their corresponding characters.
+	 *
+	 * @deprecated use {@link StringEscapeUtils#unescapeHtml4(String)} instead
+	 */
+	@Deprecated(forRemoval = true, since = "4.4.0")
+	public static StringBuffer unescape(StringBuffer sb) {
+		return sb.replace(0, sb.length(), StringEscapeUtils.unescapeHtml4(sb.toString()));
+	}
+
+	/**
 	 * Parses HTML character and entity references and returns the corresponding character.
 	 */
 	private static Character parseReference(String s) {

--- a/mylyn.commons/org.eclipse.mylyn.commons.core/src/org/eclipse/mylyn/commons/core/HtmlStreamTokenizer.java
+++ b/mylyn.commons/org.eclipse.mylyn.commons.core/src/org/eclipse/mylyn/commons/core/HtmlStreamTokenizer.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
  * Copyright (c) 2004, 2013 Tasktop Technologies and others.
- * 
+ *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
  * https://www.eclipse.org/legal/epl-2.0
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  *     Tasktop Technologies - initial API and implementation
@@ -20,9 +20,11 @@ import java.text.ParseException;
 import java.util.HashMap;
 import java.util.Locale;
 
+import org.apache.commons.text.StringEscapeUtils;
+
 /**
  * Parses HTML into tokens.
- * 
+ *
  * @author Shawn Minto
  * @since 3.7
  */
@@ -61,7 +63,7 @@ public class HtmlStreamTokenizer {
 
 	/**
 	 * Constructor.
-	 * 
+	 *
 	 * @param in
 	 *            reader for the HTML document to tokenize
 	 * @param base
@@ -286,7 +288,7 @@ public class HtmlStreamTokenizer {
 					return; // shouldn't happen if input returned by nextToken
 				}
 				if (escapeValues) {
-					attributeValue = unescape(s.substring(start, i));
+					attributeValue = StringEscapeUtils.unescapeHtml4(s.substring(start, i));
 				} else {
 					attributeValue = s.substring(start, i);
 				}
@@ -299,7 +301,7 @@ public class HtmlStreamTokenizer {
 				if (i == s.length()) {
 					return; // shouldn't happen if input returned by nextToken
 				}
-				attributeValue = unescape(s.substring(start, i));
+				attributeValue = StringEscapeUtils.unescapeHtml4(s.substring(start, i));
 				i++;
 			} else {
 				start = i;
@@ -310,74 +312,6 @@ public class HtmlStreamTokenizer {
 			}
 			tag.setAttribute(attributeName, attributeValue);
 		}
-	}
-
-	/**
-	 * Returns a string with HTML escapes changed into their corresponding characters.
-	 * 
-	 * @deprecated use {@link StringEscapeUtils#unescapeHtml(String)} instead
-	 */
-	@Deprecated
-	public static String unescape(String s) {
-		if (s.indexOf('&') == -1) {
-			return s;
-		} else {
-			StringBuffer sb = new StringBuffer(s);
-			unescape(sb);
-			return sb.toString();
-		}
-	}
-
-	/**
-	 * Replaces (in-place) HTML escapes in a StringBuffer with their corresponding characters.
-	 * 
-	 * @deprecated use {@link StringEscapeUtils#unescapeHtml(String)} instead
-	 */
-	@Deprecated
-	public static StringBuffer unescape(StringBuffer sb) {
-		int i = 0; // index into the unprocessed section of the buffer
-		int j = 0; // index into the processed section of the buffer
-
-		while (i < sb.length()) {
-			char ch = sb.charAt(i);
-			if (ch == '&') {
-				int start = i;
-				String escape = null;
-				for (i = i + 1; i < sb.length(); i++) {
-					ch = sb.charAt(i);
-					if (!Character.isLetterOrDigit(ch) && !(ch == '#' && i == start + 1)) {
-						escape = sb.substring(start + 1, i);
-						break;
-					}
-				}
-				if (i == sb.length() && i != start + 1) {
-					escape = sb.substring(start + 1);
-				}
-				if (escape != null) {
-					Character character = parseReference(escape);
-					if (character != null && !(0x0A == character || 0x0D == character || 0x09 == ch
-							|| character >= 0x20 && character <= 0xD7FF || character >= 0xE000 && character <= 0xFFFD
-							|| character >= 0x10000 && character <= 0x10FFFF)) {
-						// Character is an invalid xml character
-						// http://www.w3.org/TR/REC-xml/#charsets
-						character = null;
-					}
-					if (character != null) {
-						ch = character;
-					} else {
-						// not an HTML escape; rewind
-						i = start;
-						ch = '&';
-					}
-				}
-			}
-			sb.setCharAt(j, ch);
-			i++;
-			j++;
-		}
-
-		sb.setLength(j);
-		return sb;
 	}
 
 	/**
@@ -555,12 +489,12 @@ public class HtmlStreamTokenizer {
 
 	/*
 	 * Based on ISO 8879.
-	 * 
+	 *
 	 * Portions (c) International Organization for Standardization 1986
 	 * Permission to copy in any form is granted for use with conforming SGML
 	 * systems and applications as defined in ISO 8879, provided this notice is
 	 * included in all copies.
-	 * 
+	 *
 	 */
 	static {
 		entities = new HashMap<>();

--- a/mylyn.commons/org.eclipse.mylyn.commons.net/META-INF/MANIFEST.MF
+++ b/mylyn.commons/org.eclipse.mylyn.commons.net/META-INF/MANIFEST.MF
@@ -24,5 +24,5 @@ Import-Package: org.apache.commons.httpclient;version="3.1.0",
  org.apache.commons.httpclient.params;version="3.1.0",
  org.apache.commons.httpclient.protocol;version="3.1.0",
  org.apache.commons.httpclient.util;version="3.1.0",
- org.apache.commons.lang3;version="3.0.0",
- org.apache.commons.logging;version="[1.0.4,2.0.0)"
+ org.apache.commons.logging;version="[1.0.4,2.0.0)",
+ org.apache.commons.text;version="[1.12.0,2.0.0)"

--- a/mylyn.commons/org.eclipse.mylyn.commons.net/src/org/eclipse/mylyn/commons/net/HtmlStreamTokenizer.java
+++ b/mylyn.commons/org.eclipse.mylyn.commons.net/src/org/eclipse/mylyn/commons/net/HtmlStreamTokenizer.java
@@ -309,6 +309,25 @@ public class HtmlStreamTokenizer {
 		}
 	}
 
+	/**
+	 * Returns a string with HTML escapes changed into their corresponding characters.
+	 *
+	 * @deprecated use {@link StringEscapeUtils#unescapeHtml4(String)} instead
+	 */
+	@Deprecated(forRemoval = true, since = "4.4.0")
+	public static String unescape(String s) {
+		return StringEscapeUtils.unescapeHtml4(s);
+	}
+
+	/**
+	 * Replaces (in-place) HTML escapes in a StringBuffer with their corresponding characters.
+	 *
+	 * @deprecated use {@link StringEscapeUtils#unescapeHtml4(String)} instead
+	 */
+	@Deprecated(forRemoval = true, since = "4.4.0")
+	public static StringBuffer unescape(StringBuffer sb) {
+		return sb.replace(0, sb.length(), StringEscapeUtils.unescapeHtml4(sb.toString()));
+	}
 
 	/**
 	 * Parses HTML character and entity references and returns the corresponding character.

--- a/mylyn.commons/org.eclipse.mylyn.commons.net/src/org/eclipse/mylyn/commons/net/HtmlStreamTokenizer.java
+++ b/mylyn.commons/org.eclipse.mylyn.commons.net/src/org/eclipse/mylyn/commons/net/HtmlStreamTokenizer.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
  * Copyright (c) 2004, 2011 Tasktop Technologies and others.
- * 
+ *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
  * https://www.eclipse.org/legal/epl-2.0
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  *     Tasktop Technologies - initial API and implementation
@@ -20,11 +20,11 @@ import java.text.ParseException;
 import java.util.HashMap;
 import java.util.Locale;
 
-import org.apache.commons.lang3.StringEscapeUtils;
+import org.apache.commons.text.StringEscapeUtils;
 
 /**
  * Parses HTML into tokens.
- * 
+ *
  * @author Shawn Minto
  * @since 2.0
  * @deprecated use org.eclipse.mylyn.commons.core.HtmlStreamTokenizer instead.
@@ -65,7 +65,7 @@ public class HtmlStreamTokenizer {
 
 	/**
 	 * Constructor.
-	 * 
+	 *
 	 * @param in
 	 *            reader for the HTML document to tokenize
 	 * @param base
@@ -283,7 +283,7 @@ public class HtmlStreamTokenizer {
 					return; // shouldn't happen if input returned by nextToken
 				}
 				if (escapeValues) {
-					attributeValue = unescape(s.substring(start, i));
+					attributeValue = StringEscapeUtils.unescapeHtml4(s.substring(start, i));
 				} else {
 					attributeValue = s.substring(start, i);
 				}
@@ -296,7 +296,7 @@ public class HtmlStreamTokenizer {
 				if (i == s.length()) {
 					return; // shouldn't happen if input returned by nextToken
 				}
-				attributeValue = unescape(s.substring(start, i));
+				attributeValue = StringEscapeUtils.unescapeHtml4(s.substring(start, i));
 				i++;
 			} else {
 				start = i;
@@ -309,73 +309,6 @@ public class HtmlStreamTokenizer {
 		}
 	}
 
-	/**
-	 * Returns a string with HTML escapes changed into their corresponding characters.
-	 * 
-	 * @deprecated use {@link StringEscapeUtils#unescapeHtml(String)} instead
-	 */
-	@Deprecated
-	public static String unescape(String s) {
-		if (s.indexOf('&') == -1) {
-			return s;
-		} else {
-			StringBuffer sb = new StringBuffer(s);
-			unescape(sb);
-			return sb.toString();
-		}
-	}
-
-	/**
-	 * Replaces (in-place) HTML escapes in a StringBuffer with their corresponding characters.
-	 * 
-	 * @deprecated use {@link StringEscapeUtils#unescapeHtml(String)} instead
-	 */
-	@Deprecated
-	public static StringBuffer unescape(StringBuffer sb) {
-		int i = 0; // index into the unprocessed section of the buffer
-		int j = 0; // index into the processed section of the buffer
-
-		while (i < sb.length()) {
-			char ch = sb.charAt(i);
-			if (ch == '&') {
-				int start = i;
-				String escape = null;
-				for (i = i + 1; i < sb.length(); i++) {
-					ch = sb.charAt(i);
-					if (!Character.isLetterOrDigit(ch) && !(ch == '#' && i == start + 1)) {
-						escape = sb.substring(start + 1, i);
-						break;
-					}
-				}
-				if (i == sb.length() && i != start + 1) {
-					escape = sb.substring(start + 1);
-				}
-				if (escape != null) {
-					Character character = parseReference(escape);
-					if (character != null && !(0x0A == character || 0x0D == character || 0x09 == ch
-							|| character >= 0x20 && character <= 0xD7FF || character >= 0xE000 && character <= 0xFFFD
-							|| character >= 0x10000 && character <= 0x10FFFF)) {
-						// Character is an invalid xml character
-						// http://www.w3.org/TR/REC-xml/#charsets
-						character = null;
-					}
-					if (character != null) {
-						ch = character;
-					} else {
-						// not an HTML escape; rewind
-						i = start;
-						ch = '&';
-					}
-				}
-			}
-			sb.setCharAt(j, ch);
-			i++;
-			j++;
-		}
-
-		sb.setLength(j);
-		return sb;
-	}
 
 	/**
 	 * Parses HTML character and entity references and returns the corresponding character.
@@ -552,12 +485,12 @@ public class HtmlStreamTokenizer {
 
 	/*
 	 * Based on ISO 8879.
-	 * 
+	 *
 	 * Portions (c) International Organization for Standardization 1986
 	 * Permission to copy in any form is granted for use with conforming SGML
 	 * systems and applications as defined in ISO 8879, provided this notice is
 	 * included in all copies.
-	 * 
+	 *
 	 */
 	static {
 		entities = new HashMap<>();

--- a/mylyn.commons/org.eclipse.mylyn.commons.net/src/org/eclipse/mylyn/commons/net/WebUtil.java
+++ b/mylyn.commons/org.eclipse.mylyn.commons.net/src/org/eclipse/mylyn/commons/net/WebUtil.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
  * Copyright (c) 2004, 2024 Tasktop Technologies and others.
- * 
+ *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
  * https://www.eclipse.org/legal/epl-2.0
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  *     Tasktop Technologies - initial API and implementation
@@ -55,7 +55,7 @@ import org.apache.commons.httpclient.params.HttpMethodParams;
 import org.apache.commons.httpclient.protocol.Protocol;
 import org.apache.commons.httpclient.protocol.ProtocolSocketFactory;
 import org.apache.commons.httpclient.util.IdleConnectionTimeoutThread;
-import org.apache.commons.lang3.StringEscapeUtils;
+import org.apache.commons.text.StringEscapeUtils;
 import org.eclipse.core.net.proxy.IProxyData;
 import org.eclipse.core.net.proxy.IProxyService;
 import org.eclipse.core.runtime.Assert;
@@ -515,7 +515,7 @@ public class WebUtil {
 
 	/**
 	 * Returns the title of a web page.
-	 * 
+	 *
 	 * @throws IOException
 	 *             if a network occurs
 	 * @return the title; null, if the title could not be determined;
@@ -589,7 +589,7 @@ public class WebUtil {
 	 * <li>Headless: <code>Mylyn MyProduct HttpClient/3.1 Java/1.5.0_13 (Sun) Linux/2.6.22-14-generic (i386)</code>
 	 * <li>Eclipse:
 	 * <code>Mylyn/2.2.0 Eclipse/3.4.0 (org.eclipse.sdk.ide) HttpClient/3.1 Java/1.5.0_13 (Sun) Linux/2.6.22-14-generic (i386; en_CA)</code>
-	 * 
+	 *
 	 * @param product
 	 *            an identifier that is inserted into the returned user agent string
 	 * @return a user agent string
@@ -641,7 +641,7 @@ public class WebUtil {
 
 	/**
 	 * For standalone applications that want to provide a global proxy service.
-	 * 
+	 *
 	 * @param proxyService
 	 *            the proxy service
 	 * @since 3.0
@@ -736,7 +736,7 @@ public class WebUtil {
 
 	/**
 	 * Returns the platform default proxy for <code>url</code> or <code>null</code> if none.
-	 * 
+	 *
 	 * @since 3.5
 	 */
 	public static Proxy getProxyForUrl(String url) {
@@ -793,7 +793,7 @@ public class WebUtil {
 	/**
 	 * Releases the connection used by <code>method</code>. If <code>monitor</code> is cancelled the connection is aborted to avoid
 	 * blocking.
-	 * 
+	 *
 	 * @since 3.4
 	 */
 	public static void releaseConnection(HttpMethodBase method, IProgressMonitor monitor) {

--- a/mylyn.reviews/org.eclipse.mylyn.gerrit.core/META-INF/MANIFEST.MF
+++ b/mylyn.reviews/org.eclipse.mylyn.gerrit.core/META-INF/MANIFEST.MF
@@ -51,4 +51,5 @@ Import-Package: com.github.benmanes.caffeine.cache;version="3.1.8",
  org.apache.commons.httpclient.methods;version="3.1.0",
  org.apache.commons.httpclient.util;version="3.1.0",
  org.apache.commons.io;version="1.4.0",
- org.apache.commons.lang3;version="3.12.0"
+ org.apache.commons.lang3;version="3.12.0",
+ org.apache.commons.text;version="[1.12.0,2.0.0)"

--- a/mylyn.reviews/org.eclipse.mylyn.gerrit.core/src/org/eclipse/mylyn/internal/gerrit/core/client/GerritHtmlProcessor.java
+++ b/mylyn.reviews/org.eclipse.mylyn.gerrit.core/src/org/eclipse/mylyn/internal/gerrit/core/client/GerritHtmlProcessor.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
  * Copyright (c) 2012, 2015 Tasktop Technologies and others.
- * 
+ *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
  * https://www.eclipse.org/legal/epl-2.0
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  *     Tasktop Technologies - initial API and implementation
@@ -22,7 +22,7 @@ import java.util.regex.Pattern;
 
 import javax.swing.text.html.HTML.Tag;
 
-import org.apache.commons.lang3.StringEscapeUtils;
+import org.apache.commons.text.StringEscapeUtils;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.mylyn.commons.core.HtmlStreamTokenizer;
@@ -131,7 +131,7 @@ public class GerritHtmlProcessor {
 
 	/**
 	 * Remove everything after second to last '}'
-	 * 
+	 *
 	 * @param token
 	 *            a non-parsable Json string of the form '{ ... }}' or '{ ... } ...}' where '...' is any valid JSON
 	 */

--- a/org.eclipse.mylyn-site/category.xml
+++ b/org.eclipse.mylyn-site/category.xml
@@ -196,6 +196,7 @@
    <bundle id="org.apache.commons.collections4"/>
    <bundle id="org.apache.commons.lang3"/>
    <bundle id="org.apache.commons.logging"/>
+   <bundle id="org.apache.commons.text"/>
    <bundle id="org.apache.httpcomponents.httpclient"/>
    <bundle id="org.apache.httpcomponents.httpcore"/>
    <bundle id="org.apache.lucene.analysis-common"/>

--- a/org.eclipse.mylyn-target/org.eclipse.mylyn.target.target
+++ b/org.eclipse.mylyn-target/org.eclipse.mylyn.target.target
@@ -77,6 +77,7 @@
 			<unit id="org.glassfish.hk2.osgi-resource-locator" version="0.0.0"/>
 			<unit id="org.apache.commons.lang3" version="0.0.0"/>
 			<unit id="org.apache.commons.logging" version="0.0.0"/>
+			<unit id="org.apache.commons.text" version="0.0.0"/>
 			<unit id="org.apache.lucene.analysis-common" version="0.0.0"/>
 			<unit id="org.apache.lucene.core" version="0.0.0"/>
 			<unit id="org.apache.lucene.queries" version="0.0.0"/>

--- a/org.eclipse.mylyn.releng/launcher/mylyn verify.launch
+++ b/org.eclipse.mylyn.releng/launcher/mylyn verify.launch
@@ -2,14 +2,14 @@
 <launchConfiguration type="org.eclipse.m2e.Maven2LaunchConfigurationType">
     <intAttribute key="M2_COLORS" value="0"/>
     <booleanAttribute key="M2_DEBUG_OUTPUT" value="false"/>
-    <stringAttribute key="M2_GOALS" value="clean verify -B -fae"/>
+    <stringAttribute key="M2_GOALS" value="verify -B -fae"/>
     <booleanAttribute key="M2_NON_RECURSIVE" value="false"/>
     <booleanAttribute key="M2_OFFLINE" value="false"/>
     <stringAttribute key="M2_PROFILES" value=""/>
     <listAttribute key="M2_PROPERTIES">
         <listEntry value="maven.repo.local=${workspace_loc}/../git/org.eclipse.mylyn/.m2/repository"/>
-        <listEntry value="maven.test.failure.ignore=false"/>
-        <listEntry value="maven.test.error.ignore=false"/>
+        <listEntry value="maven.test.failure.ignore=true"/>
+        <listEntry value="maven.test.error.ignore=true"/>
         <listEntry value="dash.fail=false"/>
         <listEntry value="user.home=${system_property:user.home}"/>
     </listAttribute>
@@ -25,6 +25,5 @@
     <booleanAttribute key="org.eclipse.jdt.launching.ATTR_SHOW_CODEDETAILS_IN_EXCEPTION_MESSAGES" value="true"/>
     <booleanAttribute key="org.eclipse.jdt.launching.ATTR_USE_CLASSPATH_ONLY_JAR" value="false"/>
     <booleanAttribute key="org.eclipse.jdt.launching.ATTR_USE_START_ON_FIRST_THREAD" value="true"/>
-    <stringAttribute key="org.eclipse.jdt.launching.JRE_CONTAINER" value="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/Java/"/>
     <stringAttribute key="org.eclipse.jdt.launching.WORKING_DIRECTORY" value="${workspace_loc:/org.eclipse.mylyn-aggregator}"/>
 </launchConfiguration>

--- a/org.eclipse.mylyn.releng/launcher/mylyn verify.launch
+++ b/org.eclipse.mylyn.releng/launcher/mylyn verify.launch
@@ -2,14 +2,14 @@
 <launchConfiguration type="org.eclipse.m2e.Maven2LaunchConfigurationType">
     <intAttribute key="M2_COLORS" value="0"/>
     <booleanAttribute key="M2_DEBUG_OUTPUT" value="false"/>
-    <stringAttribute key="M2_GOALS" value="verify -B -fae"/>
+    <stringAttribute key="M2_GOALS" value="clean verify -B -fae"/>
     <booleanAttribute key="M2_NON_RECURSIVE" value="false"/>
     <booleanAttribute key="M2_OFFLINE" value="false"/>
     <stringAttribute key="M2_PROFILES" value=""/>
     <listAttribute key="M2_PROPERTIES">
         <listEntry value="maven.repo.local=${workspace_loc}/../git/org.eclipse.mylyn/.m2/repository"/>
-        <listEntry value="maven.test.failure.ignore=true"/>
-        <listEntry value="maven.test.error.ignore=true"/>
+        <listEntry value="maven.test.failure.ignore=false"/>
+        <listEntry value="maven.test.error.ignore=false"/>
         <listEntry value="dash.fail=false"/>
         <listEntry value="user.home=${system_property:user.home}"/>
     </listAttribute>
@@ -25,5 +25,6 @@
     <booleanAttribute key="org.eclipse.jdt.launching.ATTR_SHOW_CODEDETAILS_IN_EXCEPTION_MESSAGES" value="true"/>
     <booleanAttribute key="org.eclipse.jdt.launching.ATTR_USE_CLASSPATH_ONLY_JAR" value="false"/>
     <booleanAttribute key="org.eclipse.jdt.launching.ATTR_USE_START_ON_FIRST_THREAD" value="true"/>
+    <stringAttribute key="org.eclipse.jdt.launching.JRE_CONTAINER" value="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/Java/"/>
     <stringAttribute key="org.eclipse.jdt.launching.WORKING_DIRECTORY" value="${workspace_loc:/org.eclipse.mylyn-aggregator}"/>
 </launchConfiguration>


### PR DESCRIPTION
lang3.StringEscapeUtils was deprecated in 3.6 and replaced by text.StringEscapeUtils

Eclipse is showing an error complaining about 'The method ... has been removed' and I have no idea where that is coming from or how to get rid of if?

![image](https://github.com/user-attachments/assets/12b9da2a-558e-4df7-a2b3-bf5d70ec390a)
