### PR TITLE
Migrate to JUnit 5 - Jenkins #51

### DIFF
--- a/mylyn.builds/org.eclipse.mylyn.jenkins.core/src/org/eclipse/mylyn/internal/jenkins/core/client/JenkinsServerInfo.java
+++ b/mylyn.builds/org.eclipse.mylyn.jenkins.core/src/org/eclipse/mylyn/internal/jenkins/core/client/JenkinsServerInfo.java
@@ -1,13 +1,14 @@
 /*******************************************************************************
  * Copyright (c) 2010, 2011 Tasktop Technologies and others.
- * 
+ *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
  * https://www.eclipse.org/legal/epl-2.0
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  *     Tasktop Technologies - initial API and implementation
+ *     See git histpry
  *******************************************************************************/
 
 package org.eclipse.mylyn.internal.jenkins.core.client;
@@ -18,7 +19,7 @@ package org.eclipse.mylyn.internal.jenkins.core.client;
 public class JenkinsServerInfo {
 
 	public enum Type {
-		HUDSON, JENKINS
+		JENKINS
 	}
 
 	private final String version;

--- a/mylyn.builds/org.eclipse.mylyn.jenkins.core/src/org/eclipse/mylyn/internal/jenkins/core/client/RestfulJenkinsClient.java
+++ b/mylyn.builds/org.eclipse.mylyn.jenkins.core/src/org/eclipse/mylyn/internal/jenkins/core/client/RestfulJenkinsClient.java
@@ -11,6 +11,7 @@
  *     Tasktop Technologies - improvements
  *     Eike Stepper - improvements for bug 323759
  *     Benjamin Muskalla - 323920: [build] config retrival fails for jobs with whitespaces
+ *     See git histpry
  *******************************************************************************/
 
 package org.eclipse.mylyn.internal.jenkins.core.client;
@@ -470,18 +471,11 @@ public class RestfulJenkinsClient {
 			protected JenkinsServerInfo doProcess(CommonHttpResponse response, IOperationMonitor monitor)
 					throws IOException, JenkinsException, JAXBException {
 				Header header = response.getResponse().getFirstHeader("X-Jenkins"); //$NON-NLS-1$
-				Type type;
 				if (header == null) {
-					type = Type.HUDSON;
-					header = response.getResponse().getFirstHeader("X-Hudson"); //$NON-NLS-1$
-					if (header == null) {
-						throw new JenkinsException(NLS.bind("{0} does not appear to be a Hudson or Jenkins instance", //$NON-NLS-1$
-								baseUrl()));
-					}
-				} else {
-					type = Type.JENKINS;
+					throw new JenkinsException(NLS.bind("{0} does not appear to be a Jenkins instance", //$NON-NLS-1$
+							baseUrl()));
 				}
-				JenkinsServerInfo info = new JenkinsServerInfo(type, header.getValue());
+				JenkinsServerInfo info = new JenkinsServerInfo(Type.JENKINS, header.getValue());
 				return info;
 			}
 		}.run();

--- a/mylyn.builds/org.eclipse.mylyn.jenkins.tests/META-INF/MANIFEST.MF
+++ b/mylyn.builds/org.eclipse.mylyn.jenkins.tests/META-INF/MANIFEST.MF
@@ -16,7 +16,11 @@ Require-Bundle: org.eclipse.core.runtime;bundle-version="0.0.0",
  org.eclipse.search;bundle-version="0.0.0",
  org.eclipse.ui;bundle-version="0.0.0",
  org.eclipse.ui.workbench.texteditor;bundle-version="0.0.0",
- org.junit;bundle-version="4.8.2"
+ junit-jupiter-api;bundle-version="5.10.3",
+ junit-platform-suite-api;bundle-version="1.10.3",
+ junit-platform-suite-engine;bundle-version="1.10.3",
+ junit-platform-suite-commons;bundle-version="1.10.3",
+ org.hamcrest;bundle-version="2.2.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-Vendor: Eclipse Mylyn
 Export-Package: org.eclipse.mylyn.jenkins.tests;x-internal:=true,

--- a/mylyn.builds/org.eclipse.mylyn.jenkins.tests/src/org/eclipse/mylyn/jenkins/tests/AllJenkinsTests.java
+++ b/mylyn.builds/org.eclipse.mylyn.jenkins.tests/src/org/eclipse/mylyn/jenkins/tests/AllJenkinsTests.java
@@ -7,71 +7,25 @@
  *
  * Contributors:
  *     Tasktop Technologies - initial API and implementation
+ *     See git history
  *******************************************************************************/
 
 package org.eclipse.mylyn.jenkins.tests;
 
-import java.util.List;
-
-import org.eclipse.mylyn.commons.sdk.util.CommonTestUtil;
-import org.eclipse.mylyn.commons.sdk.util.ManagedSuite;
-import org.eclipse.mylyn.commons.sdk.util.ManagedTestSuite;
-import org.eclipse.mylyn.commons.sdk.util.TestConfiguration;
 import org.eclipse.mylyn.jenkins.tests.client.JenkinsClientTest;
 import org.eclipse.mylyn.jenkins.tests.client.JenkinsUrlTest;
 import org.eclipse.mylyn.jenkins.tests.client.JenkinsValidationTest;
 import org.eclipse.mylyn.jenkins.tests.core.JenkinsConnectorTest;
 import org.eclipse.mylyn.jenkins.tests.core.JenkinsServerBehaviourTest;
 import org.eclipse.mylyn.jenkins.tests.integration.JenkinsIntegrationTest;
-import org.eclipse.mylyn.jenkins.tests.support.JenkinsFixture;
+import org.junit.platform.suite.api.SelectClasses;
+import org.junit.platform.suite.api.Suite;
+import org.junit.platform.suite.api.SuiteDisplayName;
 
-import junit.framework.Test;
-import junit.framework.TestSuite;
-
-/**
- * @author Steffen Pingel
- */
-@SuppressWarnings("nls")
+@Suite
+@SuiteDisplayName("Jenkins Test Suite")
+@SelectClasses({ SuiteSetup.class, JenkinsConnectorTest.class, JenkinsServerBehaviourTest.class, JenkinsUrlTest.class,
+	JenkinsValidationTest.class, JenkinsClientTest.class, JenkinsIntegrationTest.class })
 public class AllJenkinsTests {
-
-	public static Test suite() {
-		if (CommonTestUtil.fixProxyConfiguration()) {
-			CommonTestUtil.dumpSystemInfo(System.err);
-		}
-		TestConfiguration testConfiguration = ManagedSuite.getTestConfigurationOrCreateDefault();
-		testConfiguration.setLocalOnly(true); // No CI Server
-		TestSuite suite = new ManagedTestSuite(AllJenkinsTests.class.getName());
-		addTests(suite, testConfiguration);
-		return suite;
-	}
-
-	public static Test suite(TestConfiguration configuration) {
-		TestSuite suite = new TestSuite(AllJenkinsTests.class.getName());
-		addTests(suite, configuration);
-		return suite;
-	}
-
-	private static void addTests(TestSuite suite, TestConfiguration configuration) {
-		suite.addTestSuite(JenkinsConnectorTest.class);
-		suite.addTestSuite(JenkinsServerBehaviourTest.class);
-		suite.addTestSuite(JenkinsUrlTest.class);
-		if (!configuration.isLocalOnly()) {
-			// network tests
-			suite.addTestSuite(JenkinsValidationTest.class);
-			List<JenkinsFixture> fixtures = configuration.discover(JenkinsFixture.class, "jenkins");
-			for (JenkinsFixture fixture : fixtures) {
-				if (fixture.isExcluded()
-						|| fixture.isUseCertificateAuthentication() && CommonTestUtil.isCertificateAuthBroken()) {
-					continue;
-				}
-				fixture.createSuite(suite);
-				fixture.add(JenkinsClientTest.class);
-				if (!fixture.isUseCertificateAuthentication()) {
-					fixture.add(JenkinsIntegrationTest.class);
-				}
-				fixture.done();
-			}
-		}
-	}
 
 }

--- a/mylyn.builds/org.eclipse.mylyn.jenkins.tests/src/org/eclipse/mylyn/jenkins/tests/SuiteSetup.java
+++ b/mylyn.builds/org.eclipse.mylyn.jenkins.tests/src/org/eclipse/mylyn/jenkins/tests/SuiteSetup.java
@@ -1,0 +1,64 @@
+/*******************************************************************************
+ * Copyright (c) 2024 George Lindholm
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html.
+ *
+ * Contributors:
+ *      See git history
+ *******************************************************************************/
+
+package org.eclipse.mylyn.jenkins.tests;
+
+import org.eclipse.mylyn.commons.sdk.util.CommonTestUtil;
+import org.eclipse.mylyn.commons.sdk.util.ManagedSuite;
+import org.eclipse.mylyn.commons.sdk.util.TestConfiguration;
+import org.eclipse.mylyn.jenkins.tests.support.JenkinsFixture;
+import org.junit.jupiter.api.Test;
+
+public class SuiteSetup {
+	private static boolean notLocalOnly = false;
+
+	private static boolean useCertificateAuthentication = false;
+
+	private static boolean fixtureActive = false;
+
+	static {
+		if (CommonTestUtil.fixProxyConfiguration()) {
+			CommonTestUtil.dumpSystemInfo(System.err);
+		}
+		TestConfiguration configuration = ManagedSuite.getTestConfigurationOrCreateDefault();
+
+		if (!configuration.isLocalOnly()) {
+			// network tests
+			notLocalOnly = true;
+			for (JenkinsFixture fixture : configuration.discover(JenkinsFixture.class, "jenkins")) { //$NON-NLS-1$
+				if (fixture.isExcluded()
+						|| fixture.isUseCertificateAuthentication() && CommonTestUtil.isCertificateAuthBroken()) {
+					continue;
+				}
+				fixtureActive = true;
+				useCertificateAuthentication = !fixture.isUseCertificateAuthentication();
+			}
+		}
+	}
+
+	@Test
+	public void dummyTest() {
+		// This is a dummy test to ensure the setup method is run
+	}
+
+	public static boolean isNotLocalOnly() {
+		return notLocalOnly;
+	}
+
+	public static boolean isUseCertificateAuthentication() {
+		return useCertificateAuthentication;
+	}
+
+	public static boolean isFixtureActive() {
+		return fixtureActive;
+	}
+
+}

--- a/mylyn.builds/org.eclipse.mylyn.jenkins.tests/src/org/eclipse/mylyn/jenkins/tests/client/JenkinsUrlTest.java
+++ b/mylyn.builds/org.eclipse.mylyn.jenkins.tests/src/org/eclipse/mylyn/jenkins/tests/client/JenkinsUrlTest.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
  * Copyright (c) 2014 Tasktop Technologies and others.
- * 
+ *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
  * https://www.eclipse.org/legal/epl-2.0
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  *     Tasktop Technologies - initial API and implementation
@@ -13,30 +13,28 @@
 
 package org.eclipse.mylyn.jenkins.tests.client;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 import java.io.UnsupportedEncodingException;
 import java.util.Collections;
 
 import org.eclipse.mylyn.internal.jenkins.core.client.JenkinsUrl;
-
-import junit.framework.TestCase;
+import org.junit.jupiter.api.Test;
 
 @SuppressWarnings("nls")
-public class JenkinsUrlTest extends TestCase {
+public class JenkinsUrlTest {
 
+	@Test
 	public void testQuotes() throws Exception {
-		assertEquals(getExpectedUrl("%27example%27"), createHudsonUrl("example"));
-		assertEquals(getExpectedUrl("%22exampleWithSingle%27Quote%22"), createHudsonUrl("exampleWithSingle'Quote"));
-		assertEquals(getExpectedUrl("%27exampleWithDouble%22Quote%27"), createHudsonUrl("exampleWithDouble\"Quote"));
-		try {
-			createHudsonUrl("exampleWithSingle'AndDouble\"Quote");
-			fail("Expected IllegalArgumentException");
-		} catch (IllegalArgumentException e) {// expected
-		}
-
+		assertEquals(getExpectedUrl("%27example%27"), createJacksonUrl("example"));
+		assertEquals(getExpectedUrl("%22exampleWithSingle%27Quote%22"), createJacksonUrl("exampleWithSingle'Quote"));
+		assertEquals(getExpectedUrl("%27exampleWithDouble%22Quote%27"), createJacksonUrl("exampleWithDouble\"Quote"));
+		assertThrows(IllegalArgumentException.class, () -> createJacksonUrl("exampleWithSingle'AndDouble\"Quote"));
 	}
 
-	private String createHudsonUrl(String buildName) throws UnsupportedEncodingException {
-		return JenkinsUrl.create("http://hudson.com") //$NON-NLS-1$
+	private String createJacksonUrl(String buildName) throws UnsupportedEncodingException {
+		return JenkinsUrl.create("https://jackson.test.mylyn") //$NON-NLS-1$
 				.depth(1)
 				.include("/hudson/job")
 				.match("name", Collections.singletonList(buildName)) //$NON-NLS-1$
@@ -45,7 +43,7 @@ public class JenkinsUrlTest extends TestCase {
 	}
 
 	private static String getExpectedUrl(String quotedName) {
-		return "http://hudson.com/api/xml?wrapper=hudson&depth=1&xpath=/hudson/job%5Bname%3D" + quotedName
+		return "https://jackson.test.mylyn/api/xml?wrapper=hudson&depth=1&xpath=/hudson/job%5Bname%3D" + quotedName
 				+ "%5D&exclude=/hudson/job/build";
 	}
 }

--- a/mylyn.builds/org.eclipse.mylyn.jenkins.tests/src/org/eclipse/mylyn/jenkins/tests/client/JenkinsUrlUtilTest.java
+++ b/mylyn.builds/org.eclipse.mylyn.jenkins.tests/src/org/eclipse/mylyn/jenkins/tests/client/JenkinsUrlUtilTest.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
  * Copyright (c) 2015, 2016 Christian Gaege and others.
- * 
+ *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
  * https://www.eclipse.org/legal/epl-2.0
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  *     Christian Gaege - initial API and implementation
@@ -12,6 +12,11 @@
  *******************************************************************************/
 
 package org.eclipse.mylyn.jenkins.tests.client;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -26,15 +31,14 @@ import org.eclipse.mylyn.internal.jenkins.core.client.JenkinsUrlUtil;
 import org.eclipse.mylyn.internal.jenkins.core.client.RestfulJenkinsClient;
 import org.eclipse.mylyn.jenkins.tests.support.JenkinsFixture;
 import org.eclipse.mylyn.jenkins.tests.support.JenkinsHarness;
-import org.junit.Assert;
-
-import junit.framework.TestCase;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Christian Gaege
  */
 @SuppressWarnings("nls")
-public class JenkinsUrlUtilTest extends TestCase {
+public class JenkinsUrlUtilTest {
 
 	private JenkinsUrlUtil jenkinsUrlUtil;
 
@@ -42,8 +46,8 @@ public class JenkinsUrlUtilTest extends TestCase {
 
 	private RepositoryLocation repositoryLocation;
 
-	@Override
-	protected void setUp() throws Exception {
+	@BeforeEach
+	public void setUp() throws Exception {
 		harness = JenkinsFixture.current().createHarness();
 		RestfulJenkinsClient client = harness.connect(PrivilegeLevel.ANONYMOUS);
 		repositoryLocation = client.getLocation();
@@ -51,20 +55,23 @@ public class JenkinsUrlUtilTest extends TestCase {
 		jenkinsUrlUtil = new JenkinsUrlUtil(repositoryLocation);
 	}
 
+	@Test
 	public void testBaseUrl() {
 
-		Assert.assertEquals(repositoryLocation.getUrl(), jenkinsUrlUtil.baseUrl());
+		assertEquals(repositoryLocation.getUrl(), jenkinsUrlUtil.baseUrl());
 	}
 
+	@Test
 	public void testAssembleJobUrl() throws JenkinsException {
 
 		String jobName = harness.getPlanNestedTwo();
 		String folderUrl = repositoryLocation.getUrl();
 		String expectedJobUrl = folderUrl + "job/" + jobName + "/";
 
-		Assert.assertEquals(expectedJobUrl, jenkinsUrlUtil.assembleJobUrl(jobName, folderUrl));
+		assertEquals(expectedJobUrl, jenkinsUrlUtil.assembleJobUrl(jobName, folderUrl));
 	}
 
+	@Test
 	public void testAssembleJobUrlWithWhitespace() throws JenkinsException, URISyntaxException {
 
 		String jobName = harness.getPlanWhitespace();
@@ -72,18 +79,20 @@ public class JenkinsUrlUtilTest extends TestCase {
 		String encodedJobName = new URI(null, jobName, null).toASCIIString();
 		String expectedJobUrl = folderUrl + "job/" + encodedJobName + "/";
 
-		Assert.assertEquals(expectedJobUrl, jenkinsUrlUtil.assembleJobUrl(jobName, folderUrl));
+		assertEquals(expectedJobUrl, jenkinsUrlUtil.assembleJobUrl(jobName, folderUrl));
 	}
 
+	@Test
 	public void testGroupJobNamesByFolderUrlWithoutJobUrls() throws JenkinsException {
 
 		Map<String, List<String>> jobNamesByFolderUrl = jenkinsUrlUtil
 				.groupJobNamesByFolderUrl(new ArrayList<>());
 
-		Assert.assertNotNull(jobNamesByFolderUrl);
-		Assert.assertTrue(jobNamesByFolderUrl.isEmpty());
+		assertNotNull(jobNamesByFolderUrl);
+		assertTrue(jobNamesByFolderUrl.isEmpty());
 	}
 
+	@Test
 	public void testGroupJobNameByFolderUrlWithJobUrlIds() throws JenkinsException {
 
 		String baseUrl = repositoryLocation.getUrl();
@@ -98,26 +107,27 @@ public class JenkinsUrlUtilTest extends TestCase {
 
 		Map<String, List<String>> jobNamesByFolderUrl = jenkinsUrlUtil.groupJobNamesByFolderUrl(jobIds);
 
-		Assert.assertNotNull(jobNamesByFolderUrl);
-		Assert.assertEquals(3, jobNamesByFolderUrl.size());
+		assertNotNull(jobNamesByFolderUrl);
+		assertEquals(3, jobNamesByFolderUrl.size());
 
-		Assert.assertTrue(jobNamesByFolderUrl.containsKey(baseUrl));
+		assertTrue(jobNamesByFolderUrl.containsKey(baseUrl));
 		List<String> baseUrlJobs = jobNamesByFolderUrl.get(baseUrl);
-		Assert.assertNotNull(baseUrlJobs);
-		Assert.assertTrue(baseUrlJobs.contains("test-succeeding"));
-		Assert.assertTrue(baseUrlJobs.contains("test-white space"));
+		assertNotNull(baseUrlJobs);
+		assertTrue(baseUrlJobs.contains("test-succeeding"));
+		assertTrue(baseUrlJobs.contains("test-white space"));
 
-		Assert.assertTrue(jobNamesByFolderUrl.containsKey(baseUrl));
+		assertTrue(jobNamesByFolderUrl.containsKey(baseUrl));
 		List<String> folderUrlJobs = jobNamesByFolderUrl.get(folderUrl);
-		Assert.assertNotNull(folderUrlJobs);
-		Assert.assertTrue(folderUrlJobs.contains("test-nested-one"));
+		assertNotNull(folderUrlJobs);
+		assertTrue(folderUrlJobs.contains("test-nested-one"));
 
-		Assert.assertTrue(jobNamesByFolderUrl.containsKey(baseUrl));
+		assertTrue(jobNamesByFolderUrl.containsKey(baseUrl));
 		List<String> subFolderUrlJobs = jobNamesByFolderUrl.get(subFolderUrl);
-		Assert.assertNotNull(subFolderUrlJobs);
-		Assert.assertTrue(subFolderUrlJobs.contains("test-nested-two"));
+		assertNotNull(subFolderUrlJobs);
+		assertTrue(subFolderUrlJobs.contains("test-nested-two"));
 	}
 
+	@Test
 	public void testGroupJobNameByFolderUrlWithJobNameIds() throws JenkinsException {
 
 		String baseUrl = repositoryLocation.getUrl();
@@ -128,14 +138,15 @@ public class JenkinsUrlUtilTest extends TestCase {
 
 		Map<String, List<String>> jobNamesByFolderUrl = jenkinsUrlUtil.groupJobNamesByFolderUrl(jobIds);
 
-		Assert.assertNotNull(jobNamesByFolderUrl);
-		Assert.assertEquals(1, jobNamesByFolderUrl.size());
+		assertNotNull(jobNamesByFolderUrl);
+		assertEquals(1, jobNamesByFolderUrl.size());
 		List<String> baseUrlJobs = jobNamesByFolderUrl.get(baseUrl);
-		Assert.assertNotNull(baseUrlJobs);
-		Assert.assertTrue(baseUrlJobs.contains(harness.getPlanGit()));
-		Assert.assertTrue(baseUrlJobs.contains(harness.getPlanWhitespace()));
+		assertNotNull(baseUrlJobs);
+		assertTrue(baseUrlJobs.contains(harness.getPlanGit()));
+		assertTrue(baseUrlJobs.contains(harness.getPlanWhitespace()));
 	}
 
+	@Test
 	public void testGroupJobNameByFolderUrlWithJobNameIdsAndJobUrlIds() throws JenkinsException {
 
 		String baseUrl = repositoryLocation.getUrl();
@@ -149,20 +160,21 @@ public class JenkinsUrlUtilTest extends TestCase {
 
 		Map<String, List<String>> jobNamesByFolderUrl = jenkinsUrlUtil.groupJobNamesByFolderUrl(jobIds);
 
-		Assert.assertNotNull(jobNamesByFolderUrl);
-		Assert.assertEquals(2, jobNamesByFolderUrl.size());
+		assertNotNull(jobNamesByFolderUrl);
+		assertEquals(2, jobNamesByFolderUrl.size());
 
 		List<String> baseUrlJobs = jobNamesByFolderUrl.get(baseUrl);
-		Assert.assertNotNull(baseUrlJobs);
-		Assert.assertTrue(baseUrlJobs.contains(harness.getPlanGit()));
-		Assert.assertTrue(baseUrlJobs.contains(harness.getPlanWhitespace()));
-		Assert.assertTrue(baseUrlJobs.contains("test-succeeding"));
+		assertNotNull(baseUrlJobs);
+		assertTrue(baseUrlJobs.contains(harness.getPlanGit()));
+		assertTrue(baseUrlJobs.contains(harness.getPlanWhitespace()));
+		assertTrue(baseUrlJobs.contains("test-succeeding"));
 
 		List<String> folderUrlJobs = jobNamesByFolderUrl.get(folderUrl);
-		Assert.assertNotNull(folderUrlJobs);
-		Assert.assertTrue(folderUrlJobs.contains("test-nested-one"));
+		assertNotNull(folderUrlJobs);
+		assertTrue(folderUrlJobs.contains("test-nested-one"));
 	}
 
+	@Test
 	public void testGetJobUrlFromJobIdWithJobName() throws JenkinsException {
 
 		String jobId = harness.getPlanGit();
@@ -170,18 +182,20 @@ public class JenkinsUrlUtilTest extends TestCase {
 
 		String jobUrl = jenkinsUrlUtil.getJobUrlFromJobId(jobId);
 
-		Assert.assertEquals(expectedJobUrl, jobUrl);
+		assertEquals(expectedJobUrl, jobUrl);
 	}
 
+	@Test
 	public void testGetJobUrlFromJobIdWithJobUrl() throws JenkinsException {
 
 		String jobId = repositoryLocation.getUrl() + "job/" + harness.getPlanSucceeding() + "/";
 
 		String jobUrl = jenkinsUrlUtil.getJobUrlFromJobId(jobId);
 
-		Assert.assertEquals(jobId, jobUrl);
+		assertEquals(jobId, jobUrl);
 	}
 
+	@Test
 	public void testGetJobUrlFromJobIdWithNestedJobUrl() throws JenkinsException {
 
 		String jobId = repositoryLocation.getUrl() + "job/" + harness.getPlanFolder() + "/job/"
@@ -189,63 +203,70 @@ public class JenkinsUrlUtilTest extends TestCase {
 
 		String jobUrl = jenkinsUrlUtil.getJobUrlFromJobId(jobId);
 
-		Assert.assertEquals(jobId, jobUrl);
+		assertEquals(jobId, jobUrl);
 	}
 
+	@Test
 	public void testIsNestedJobWithNestedJob() {
 
 		String nestedJobId = repositoryLocation.getUrl() + "job/" + harness.getPlanFolder() + "/job/"
 				+ harness.getPlanNestedOne() + "/";
 
-		Assert.assertTrue(jenkinsUrlUtil.isNestedJob(nestedJobId));
+		assertTrue(jenkinsUrlUtil.isNestedJob(nestedJobId));
 	}
 
+	@Test
 	public void testIsNestedJobWithTopLevelJob() {
 
 		String topLevelJobId = repositoryLocation.getUrl() + "job/" + harness.getPlanSucceeding() + "/";
 
-		Assert.assertFalse(jenkinsUrlUtil.isNestedJob(topLevelJobId));
+		assertFalse(jenkinsUrlUtil.isNestedJob(topLevelJobId));
 	}
 
+	@Test
 	public void testGetDisplayNameWithTopLevelJob() throws JenkinsException {
 
 		String nestedJobUrl = repositoryLocation.getUrl() + "job/" + harness.getPlanSucceeding() + "/";
 		String expectedDisplayName = harness.getPlanSucceeding();
 
-		Assert.assertEquals(expectedDisplayName, jenkinsUrlUtil.getDisplayName(nestedJobUrl));
+		assertEquals(expectedDisplayName, jenkinsUrlUtil.getDisplayName(nestedJobUrl));
 	}
 
+	@Test
 	public void testGetDisplayNameWithNestedJob() throws JenkinsException {
 
 		String nestedJobUrl = repositoryLocation.getUrl() + "job/" + harness.getPlanFolder() + "/job/"
 				+ harness.getPlanNestedOne() + "/";
 		String expectedDisplayName = harness.getPlanFolder() + "/" + harness.getPlanNestedOne();
 
-		Assert.assertEquals(expectedDisplayName, jenkinsUrlUtil.getDisplayName(nestedJobUrl));
+		assertEquals(expectedDisplayName, jenkinsUrlUtil.getDisplayName(nestedJobUrl));
 	}
 
+	@Test
 	public void testGetDisplayNameWithJobNamedJob() throws JenkinsException {
 
 		String nestedJobUrl = repositoryLocation.getUrl() + "job/job/";
 		String expectedDisplayName = "job";
 
-		Assert.assertEquals(expectedDisplayName, jenkinsUrlUtil.getDisplayName(nestedJobUrl));
+		assertEquals(expectedDisplayName, jenkinsUrlUtil.getDisplayName(nestedJobUrl));
 	}
 
+	@Test
 	public void testGetDisplayNameWithFolderAndJobNamedJob() throws JenkinsException {
 
 		String nestedJobUrl = repositoryLocation.getUrl() + "job/job/job/job/";
 		String expectedDisplayName = "job/job";
 
-		Assert.assertEquals(expectedDisplayName, jenkinsUrlUtil.getDisplayName(nestedJobUrl));
+		assertEquals(expectedDisplayName, jenkinsUrlUtil.getDisplayName(nestedJobUrl));
 	}
 
+	@Test
 	public void testGetDisplayNameWithWhitespace() throws URISyntaxException, JenkinsException {
 
 		String jobUrl = new URI(null, repositoryLocation.getUrl() + "job/" + harness.getPlanWhitespace() + "/", null)
 				.toASCIIString();
 		String expectedDisplayName = harness.getPlanWhitespace();
 
-		Assert.assertEquals(expectedDisplayName, jenkinsUrlUtil.getDisplayName(jobUrl));
+		assertEquals(expectedDisplayName, jenkinsUrlUtil.getDisplayName(jobUrl));
 	}
 }

--- a/mylyn.builds/org.eclipse.mylyn.jenkins.tests/src/org/eclipse/mylyn/jenkins/tests/client/JenkinsValidationTest.java
+++ b/mylyn.builds/org.eclipse.mylyn.jenkins.tests/src/org/eclipse/mylyn/jenkins/tests/client/JenkinsValidationTest.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
  * Copyright (c) 2012 Tasktop Technologies and others.
- * 
+ *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
  * https://www.eclipse.org/legal/epl-2.0
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  *     Tasktop Technologies - initial API and implementation
@@ -13,42 +13,39 @@
 
 package org.eclipse.mylyn.jenkins.tests.client;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 import org.eclipse.mylyn.commons.core.operations.OperationUtil;
 import org.eclipse.mylyn.commons.repositories.core.RepositoryLocation;
 import org.eclipse.mylyn.internal.jenkins.core.client.JenkinsException;
 import org.eclipse.mylyn.internal.jenkins.core.client.RestfulJenkinsClient;
 import org.eclipse.mylyn.jenkins.tests.support.JenkinsFixture;
-
-import junit.framework.TestCase;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIf;
 
 /**
  * @author Steffen Pingel
  */
 @SuppressWarnings("nls")
-public class JenkinsValidationTest extends TestCase {
+@EnabledIf("org.eclipse.mylyn.jenkins.tests.SuiteSetup#isNotLocalOnly")
+public class JenkinsValidationTest {
 
+	@Test
 	public void testValidateNonExistantUrl() throws Exception {
 		// invalid url
 		RepositoryLocation location = new RepositoryLocation();
 		location.setUrl("http://non.existant/repository");
 		RestfulJenkinsClient client = JenkinsFixture.connect(location);
-		try {
-			client.validate(OperationUtil.convert(null));
-			fail("Expected JenkinsException");
-		} catch (JenkinsException e) {
-		}
+		assertThrows(JenkinsException.class, () -> client.validate(OperationUtil.convert(null)));
 	}
 
+	@Test
 	public void testValidateNonHudsonUrl() throws Exception {
 		// non Hudson url
 		RepositoryLocation location = new RepositoryLocation();
 		location.setUrl("http://eclipse.org/mylyn");
 		RestfulJenkinsClient client = JenkinsFixture.connect(location);
-		try {
-			client.validate(OperationUtil.convert(null));
-			fail("Expected JenkinsException");
-		} catch (JenkinsException e) {
-		}
+		assertThrows(JenkinsException.class, () -> client.validate(OperationUtil.convert(null)));
 	}
 
 }

--- a/mylyn.builds/org.eclipse.mylyn.jenkins.tests/src/org/eclipse/mylyn/jenkins/tests/core/JenkinsConnectorTest.java
+++ b/mylyn.builds/org.eclipse.mylyn.jenkins.tests/src/org/eclipse/mylyn/jenkins/tests/core/JenkinsConnectorTest.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
  * Copyright (c) 2012, 2013 Tasktop Technologies.
- * 
+ *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
  * https://www.eclipse.org/legal/epl-2.0
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  *     Tasktop Technologies - initial API and implementation
@@ -13,27 +13,32 @@
 
 package org.eclipse.mylyn.jenkins.tests.core;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import org.eclipse.mylyn.builds.core.IBuild;
 import org.eclipse.mylyn.builds.core.IBuildElement;
 import org.eclipse.mylyn.builds.core.IBuildServer;
 import org.eclipse.mylyn.builds.internal.core.BuildFactory;
 import org.eclipse.mylyn.internal.jenkins.core.JenkinsConnector;
-
-import junit.framework.TestCase;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Steffen Pingel
  */
 @SuppressWarnings("nls")
-public class JenkinsConnectorTest extends TestCase {
+public class JenkinsConnectorTest {
 
+	@Test
 	public void testBuildElementFromUrlJobUrl() throws Exception {
 		IBuildServer server = BuildFactory.eINSTANCE.createBuildServer();
 		server.setUrl("http://server/");
 		JenkinsConnector connector = new JenkinsConnector();
 		IBuildElement element = connector.getBuildElementFromUrl(server, "http://server/job/my-plan/3/");
 		assertNotNull(element);
-		assertTrue("Expected IBuild, got " + element.getClass(), element instanceof IBuild);
+		assertTrue(element instanceof IBuild, "Expected IBuild, got " + element.getClass());
 		IBuild build = (IBuild) element;
 		assertEquals("3", build.getId());
 		assertEquals("my-plan", build.getPlan().getId());
@@ -41,13 +46,14 @@ public class JenkinsConnectorTest extends TestCase {
 		assertEquals("http://server/job/my-plan/", build.getPlan().getUrl());
 	}
 
+	@Test
 	public void testBuildElementFromUrlViewsUrl() throws Exception {
 		IBuildServer server = BuildFactory.eINSTANCE.createBuildServer();
 		server.setUrl("http://server/");
 		JenkinsConnector connector = new JenkinsConnector();
 		IBuildElement element = connector.getBuildElementFromUrl(server, "http://server/me/my-view/All/job/my-plan/3/");
 		assertNotNull(element);
-		assertTrue("Expected IBuild, got " + element.getClass(), element instanceof IBuild);
+		assertTrue(element instanceof IBuild, "Expected IBuild, got " + element.getClass());
 		IBuild build = (IBuild) element;
 		assertEquals("3", build.getId());
 		assertEquals("my-plan", build.getPlan().getId());
@@ -55,6 +61,7 @@ public class JenkinsConnectorTest extends TestCase {
 		assertEquals("http://server/me/my-view/All/job/my-plan/", build.getPlan().getUrl());
 	}
 
+	@Test
 	public void testBuildElementFromUrlUserUrl() throws Exception {
 		IBuildServer server = BuildFactory.eINSTANCE.createBuildServer();
 		server.setUrl("http://server/");
@@ -63,6 +70,7 @@ public class JenkinsConnectorTest extends TestCase {
 		assertNull(element);
 	}
 
+	@Test
 	public void testBuildElementFromUrlNotMatching() throws Exception {
 		IBuildServer server = BuildFactory.eINSTANCE.createBuildServer();
 		server.setUrl("http://server/");

--- a/mylyn.builds/org.eclipse.mylyn.jenkins.tests/src/org/eclipse/mylyn/jenkins/tests/core/JenkinsServerBehaviourTest.java
+++ b/mylyn.builds/org.eclipse.mylyn.jenkins.tests/src/org/eclipse/mylyn/jenkins/tests/core/JenkinsServerBehaviourTest.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
  * Copyright (c) 2010, 2016 Markus Knittig and others.
- * 
+ *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
  * https://www.eclipse.org/legal/epl-2.0
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  *     Markus Knittig - initial API and implementation
@@ -12,6 +12,9 @@
  *******************************************************************************/
 
 package org.eclipse.mylyn.jenkins.tests.core;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.util.HashSet;
 import java.util.Set;
@@ -24,16 +27,15 @@ import org.eclipse.mylyn.internal.hudson.model.HudsonModelHealthReport;
 import org.eclipse.mylyn.internal.hudson.model.HudsonModelJob;
 import org.eclipse.mylyn.internal.jenkins.core.JenkinsServerBehaviour;
 import org.eclipse.mylyn.internal.jenkins.core.client.JenkinsConfigurationCache;
-import org.junit.Assert;
-
-import junit.framework.TestCase;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Markus Knittig
  */
 @SuppressWarnings("nls")
-public class JenkinsServerBehaviourTest extends TestCase {
+public class JenkinsServerBehaviourTest {
 
+	@Test
 	public void testParseJobHealthNoReport() throws Exception {
 		RepositoryLocation repositoryLocation = new RepositoryLocation();
 		String baseUrl = "http://test.org/jenkins/";
@@ -47,6 +49,7 @@ public class JenkinsServerBehaviourTest extends TestCase {
 		assertEquals(-1, behaviour.parseJob(job).getHealth());
 	}
 
+	@Test
 	public void testParseJobHealth() throws Exception {
 		RepositoryLocation repositoryLocation = new RepositoryLocation();
 		String baseUrl = "http://test.org/jenkins/";
@@ -62,6 +65,7 @@ public class JenkinsServerBehaviourTest extends TestCase {
 		assertEquals(80, behaviour.parseJob(job).getHealth());
 	}
 
+	@Test
 	public void testParseJobNoColor() throws Exception {
 		RepositoryLocation repositoryLocation = new RepositoryLocation();
 		String baseUrl = "http://test.org/jenkins/";
@@ -77,6 +81,7 @@ public class JenkinsServerBehaviourTest extends TestCase {
 		assertNull(buildPlan.getStatus());
 	}
 
+	@Test
 	public void testParseJobRunningColor() throws Exception {
 		RepositoryLocation repositoryLocation = new RepositoryLocation();
 		String baseUrl = "http://test.org/jenkins/";
@@ -94,6 +99,7 @@ public class JenkinsServerBehaviourTest extends TestCase {
 		}
 	}
 
+	@Test
 	public void testParseJobStoppedColor() throws Exception {
 		RepositoryLocation repositoryLocation = new RepositoryLocation();
 		String baseUrl = "http://test.org/jenkins/";
@@ -111,6 +117,7 @@ public class JenkinsServerBehaviourTest extends TestCase {
 		}
 	}
 
+	@Test
 	public void testParseJobNestedJob() throws Exception {
 		RepositoryLocation repositoryLocation = new RepositoryLocation();
 		String baseUrl = "http://test.org/jenkins/";
@@ -123,9 +130,10 @@ public class JenkinsServerBehaviourTest extends TestCase {
 		nestedJob.setName("test-nested-one");
 		nestedJob.setUrl(nestedJobUrl);
 		IBuildPlan buildPlan = behaviour.parseJob(nestedJob);
-		Assert.assertEquals(nestedJobUrl, buildPlan.getId());
+		assertEquals(nestedJobUrl, buildPlan.getId());
 	}
 
+	@Test
 	public void testParseJobTopLevelJob() throws Exception {
 		RepositoryLocation repositoryLocation = new RepositoryLocation();
 		String baseUrl = "http://test.org/jenkins/";
@@ -138,7 +146,7 @@ public class JenkinsServerBehaviourTest extends TestCase {
 		topLevelJob.setName(jobName);
 		topLevelJob.setUrl(baseUrl + "job/test-succeeding/");
 		IBuildPlan buildPlan = behaviour.parseJob(topLevelJob);
-		Assert.assertEquals(jobName, buildPlan.getId());
+		assertEquals(jobName, buildPlan.getId());
 	}
 
 	private Set<HudsonModelBallColor> getRunningColors() {

--- a/mylyn.builds/org.eclipse.mylyn.jenkins.tests/src/org/eclipse/mylyn/jenkins/tests/integration/JenkinsIntegrationTest.java
+++ b/mylyn.builds/org.eclipse.mylyn.jenkins.tests/src/org/eclipse/mylyn/jenkins/tests/integration/JenkinsIntegrationTest.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
  * Copyright (c) 2012 Tasktop Technologies and others.
- * 
+ *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
  * https://www.eclipse.org/legal/epl-2.0
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  *     Tasktop Technologies - initial API and implementation
@@ -12,6 +12,8 @@
  *******************************************************************************/
 
 package org.eclipse.mylyn.jenkins.tests.integration;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.Collections;
 import java.util.List;
@@ -28,34 +30,38 @@ import org.eclipse.mylyn.commons.repositories.core.RepositoryLocation;
 import org.eclipse.mylyn.jenkins.core.JenkinsCore;
 import org.eclipse.mylyn.jenkins.tests.support.JenkinsFixture;
 import org.eclipse.mylyn.jenkins.tests.support.JenkinsHarness;
-
-import junit.framework.TestCase;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIf;
 
 /**
  * @author Steffen Pingel
  */
 @SuppressWarnings("nls")
-public class JenkinsIntegrationTest extends TestCase {
+@EnabledIf("org.eclipse.mylyn.jenkins.tests.SuiteSetup#isUseCertificateAuthentication")
+public class JenkinsIntegrationTest {
 
 	private JenkinsHarness harness;
 
-	@Override
-	protected void setUp() throws Exception {
+	@BeforeEach
+	public void setUp() throws Exception {
 		harness = JenkinsFixture.current().createHarness();
 	}
 
-	@Override
-	protected void tearDown() throws Exception {
+	@AfterEach
+	public void tearDown() throws Exception {
 		harness.dispose();
 	}
 
+	@Test
 	public void testPlanParameters() throws Exception {
 		RepositoryLocation location = harness.getFixture().location();
 		BuildServerBehaviour behaviour = JenkinsCore.createConnector(null).getBehaviour(location);
 		BuildPlanRequest request = new BuildPlanRequest(Collections.singletonList(harness.getPlanParameterized()));
 
 		List<IBuildPlan> plans = behaviour.getPlans(request, null);
-		assertEquals("Expected one plan, got: " + plans, 1, plans.size());
+		assertEquals(1, plans.size(), "Expected one plan, got: " + plans.size());
 
 		IBuildPlan plan = plans.get(0);
 		assertEquals(harness.getPlanParameterized(), plan.getName());

--- a/mylyn.builds/org.eclipse.mylyn.jenkins.tests/src/org/eclipse/mylyn/jenkins/tests/support/JenkinsFixture.java
+++ b/mylyn.builds/org.eclipse.mylyn.jenkins.tests/src/org/eclipse/mylyn/jenkins/tests/support/JenkinsFixture.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
  * Copyright (c) 2010, 2015 Markus Knittig and others.
- * 
+ *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
  * https://www.eclipse.org/legal/epl-2.0
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  *     Markus Knittig - initial API and implementation
@@ -15,9 +15,6 @@
 
 package org.eclipse.mylyn.jenkins.tests.support;
 
-import org.eclipse.core.runtime.IStatus;
-import org.eclipse.core.runtime.Status;
-import org.eclipse.mylyn.commons.core.StatusHandler;
 import org.eclipse.mylyn.commons.repositories.core.RepositoryLocation;
 import org.eclipse.mylyn.commons.sdk.util.FixtureConfiguration;
 import org.eclipse.mylyn.commons.sdk.util.RepositoryTestFixture;
@@ -37,12 +34,6 @@ public class JenkinsFixture extends RepositoryTestFixture {
 	public static final JenkinsFixture DEFAULT = discoverDefault();
 
 	private static JenkinsFixture discoverDefault() {
-		try {
-			return TestConfiguration.getDefault().discoverDefault(JenkinsFixture.class, "hudson");
-		} catch (RuntimeException e) {
-			StatusHandler.log(new Status(IStatus.ERROR, JenkinsCorePlugin.ID_PLUGIN,
-					"No default hudson fixture found, will look for default jenkins fixture", e));
-		}
 		return TestConfiguration.getDefault().discoverDefault(JenkinsFixture.class, "jenkins");
 	}
 
@@ -109,8 +100,9 @@ public class JenkinsFixture extends RepositoryTestFixture {
 		return true;
 	}
 
-	public boolean isHudson() {
-		return Type.HUDSON == getType();
+	@Override
+	public String toString() {
+		return "JenkinsFixture [version=" + version + ", type=" + type + ", toString()=" + super.toString() + "]";
 	}
 
 }

--- a/mylyn.builds/org.eclipse.mylyn.jenkins.tests/src/org/eclipse/mylyn/jenkins/tests/support/JenkinsHarness.java
+++ b/mylyn.builds/org.eclipse.mylyn.jenkins.tests/src/org/eclipse/mylyn/jenkins/tests/support/JenkinsHarness.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
  * Copyright (c) 2011, 2016 Tasktop Technologies and others.
- * 
+ *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
  * https://www.eclipse.org/legal/epl-2.0
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  *     Tasktop Technologies - initial API and implementation
@@ -159,19 +159,11 @@ public class JenkinsHarness {
 	}
 
 	public HudsonModelBallColor getSuccessColor() {
-		if (getFixture().isHudson() && getFixture().getVersion().compareTo("3.0.1") >= 0) {
-			return HudsonModelBallColor.GREEN;
-		} else {
-			return HudsonModelBallColor.BLUE;
-		}
+		return HudsonModelBallColor.BLUE;
 	}
 
 	public HudsonModelBallColor getSuccessAnimeColor() {
-		if (getFixture().isHudson() && getFixture().getVersion().compareTo("3.0.1") >= 0) {
-			return HudsonModelBallColor.GREEN_ANIME;
-		} else {
-			return HudsonModelBallColor.BLUE_ANIME;
-		}
+		return HudsonModelBallColor.BLUE_ANIME;
 	}
 
 	public HudsonModelBallColor getAbortedColor() {

--- a/mylyn.builds/org.eclipse.mylyn.jenkins.tests/src/org/eclipse/mylyn/jenkins/tests/support/JenkinsTestUtil.java
+++ b/mylyn.builds/org.eclipse.mylyn.jenkins.tests/src/org/eclipse/mylyn/jenkins/tests/support/JenkinsTestUtil.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
  * Copyright (c) 2011, 2016 Tasktop Technologies and others.
- * 
+ *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
  * https://www.eclipse.org/legal/epl-2.0
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  *     Tasktop Technologies - initial API and implementation
@@ -13,15 +13,12 @@
 
 package org.eclipse.mylyn.jenkins.tests.support;
 
-import java.util.List;
 import java.util.concurrent.Callable;
 
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.mylyn.commons.core.StatusHandler;
-import org.eclipse.mylyn.internal.hudson.model.HudsonModelJob;
 import org.eclipse.mylyn.internal.jenkins.core.client.JenkinsException;
-import org.junit.Assert;
 
 /**
  * @author Steffen Pingel
@@ -32,33 +29,6 @@ public class JenkinsTestUtil {
 	private static final long POLL_TIMEOUT = 60 * 1000;
 
 	private static final long POLL_INTERVAL = 3 * 1000;
-
-	public static void assertContains(List<HudsonModelJob> jobs, String name) {
-		for (HudsonModelJob job : jobs) {
-			if (job.getName().equals(name)) {
-				return;
-			}
-		}
-		Assert.fail("Expected '" + name + "' in " + jobs);
-	}
-
-	public static void assertContainsNot(List<HudsonModelJob> jobs, String name) {
-		for (HudsonModelJob job : jobs) {
-			if (job.getName().equals(name)) {
-				Assert.fail("Not expected '" + name + "' in " + jobs);
-			}
-		}
-
-	}
-
-	public static void assertHealthReport(List<HudsonModelJob> jobs) {
-		for (HudsonModelJob job : jobs) {
-			if (!job.getHealthReport().isEmpty()) {
-				return;
-			}
-		}
-		Assert.fail("Expected attribute 'healthReport' in " + jobs);
-	}
 
 	public static <T> T poll(Callable<T> callable) throws Exception {
 		AssertionError lastException = null;

--- a/mylyn.commons/org.eclipse.mylyn.commons.sdk.util/src/org/eclipse/mylyn/commons/sdk/util/AbstractTestFixture.java
+++ b/mylyn.commons/org.eclipse.mylyn.commons.sdk.util/src/org/eclipse/mylyn/commons/sdk/util/AbstractTestFixture.java
@@ -1,14 +1,15 @@
 /*******************************************************************************
  * Copyright (c) 2013, 2024 Tasktop Technologies and others.
- * 
+ *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
  * https://www.eclipse.org/legal/epl-2.0
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  *     Tasktop Technologies - initial API and implementation
  *     ArSysOp - ongoing support
+ *     See git histpry
  *******************************************************************************/
 
 package org.eclipse.mylyn.commons.sdk.util;
@@ -190,6 +191,14 @@ public abstract class AbstractTestFixture {
 
 	public void setDefaultproperties(Map<String, String> defaultproperties) {
 		this.defaultproperties = defaultproperties;
+	}
+
+	@Override
+	public String toString() {
+		return "AbstractTestFixture [connectorKind=" + connectorKind + ", description=" + description
+				+ ", repositoryName=" + repositoryName + ", repositoryUrl=" + repositoryUrl
+				+ ", useCertificateAuthentication=" + useCertificateAuthentication + ", properties=" + properties
+				+ ", defaultproperties=" + defaultproperties + "]";
 	}
 
 }

--- a/mylyn.tasks/connectors/bugzilla/org.eclipse.mylyn.bugzilla.tests/src/org/eclipse/mylyn/bugzilla/tests/AllBugzillaTests.java
+++ b/mylyn.tasks/connectors/bugzilla/org.eclipse.mylyn.bugzilla.tests/src/org/eclipse/mylyn/bugzilla/tests/AllBugzillaTests.java
@@ -47,7 +47,6 @@ public class AllBugzillaTests {
 
 		TestSuite suite = new ManagedTestSuite(AllBugzillaTests.class.getName());
 		TestConfiguration testConfiguration = ManagedSuite.getTestConfigurationOrCreateDefault();
-		testConfiguration.setLocalOnly(true); // No CI Server
 		addTests(suite, testConfiguration);
 		return suite;
 	}

--- a/mylyn.tasks/org.eclipse.mylyn.tasks.core/src/org/eclipse/mylyn/internal/tasks/core/TaskList.java
+++ b/mylyn.tasks/org.eclipse.mylyn.tasks.core/src/org/eclipse/mylyn/internal/tasks/core/TaskList.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
  * Copyright (c) 2004, 2011 Tasktop Technologies and others.
- * 
+ *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
  * https://www.eclipse.org/legal/epl-2.0
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -81,7 +81,7 @@ public class TaskList implements ITaskList, ITransferList {
 			lock();
 			if (categories.containsKey(category.getHandleIdentifier())) {
 				throw new IllegalArgumentException("Handle " + category.getHandleIdentifier() //$NON-NLS-1$
-						+ " already exists in task list"); //$NON-NLS-1$
+				+ " already exists in task list"); //$NON-NLS-1$
 			}
 			categories.put(category.getHandleIdentifier(), category);
 			delta.add(new TaskContainerDelta(category, TaskContainerDelta.Kind.ADDED));
@@ -119,7 +119,7 @@ public class TaskList implements ITaskList, ITransferList {
 			lock();
 			if (queries.containsKey(query.getHandleIdentifier())) {
 				throw new IllegalArgumentException("Handle " + query.getHandleIdentifier() //$NON-NLS-1$
-						+ " already exists in task list"); //$NON-NLS-1$
+				+ " already exists in task list"); //$NON-NLS-1$
 			}
 			queries.put(query.getHandleIdentifier(), query);
 			delta.add(new TaskContainerDelta(query, TaskContainerDelta.Kind.ADDED));
@@ -442,6 +442,9 @@ public class TaskList implements ITaskList, ITransferList {
 			return defaultCategory;
 		} else {
 			UnmatchedTaskContainer unmatched = unmatchedMap.get(repositoryUrl);
+			if (unmatched == null && !repositoryUrl.endsWith("/")) {
+				unmatched = unmatchedMap.get(repositoryUrl + "/");
+			}
 			if (unmatched == null) {
 				StatusHandler.log(new Status(IStatus.ERROR, ITasksCoreConstants.ID_PLUGIN,
 						"Failed to find unmatched container for repository \"" + repositoryUrl + "\"")); //$NON-NLS-1$ //$NON-NLS-2$
@@ -479,7 +482,7 @@ public class TaskList implements ITaskList, ITransferList {
 
 		if (result == null) {
 			throw new IllegalArgumentException("Element " + taskListElement.getHandleIdentifier() //$NON-NLS-1$
-					+ " does not exist in the task list."); //$NON-NLS-1$
+			+ " does not exist in the task list."); //$NON-NLS-1$
 		} else {
 			return result;
 		}

--- a/org.eclipse.mylyn.tests/src/org/eclipse/mylyn/tests/AllHeartbeatTests.java
+++ b/org.eclipse.mylyn.tests/src/org/eclipse/mylyn/tests/AllHeartbeatTests.java
@@ -1,13 +1,14 @@
 /*******************************************************************************
  * Copyright (c) 2010 Tasktop Technologies and others.
- * 
+ *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
  * https://www.eclipse.org/legal/epl-2.0
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  *     Tasktop Technologies - initial API and implementation
+ *     See git histpry
  *******************************************************************************/
 
 package org.eclipse.mylyn.tests;
@@ -25,7 +26,6 @@ public class AllHeartbeatTests {
 
 	public static Test suite() {
 		TestConfiguration configuration = new TestConfiguration();
-		configuration.setLocalOnly(true);
 
 		TestSuite suite = new ManagedTestSuite(AllHeartbeatTests.class.getName());
 		AllNonConnectorTests.addTests(suite, configuration);

--- a/org.eclipse.mylyn.tests/src/org/eclipse/mylyn/tests/AllLocalTests.java
+++ b/org.eclipse.mylyn.tests/src/org/eclipse/mylyn/tests/AllLocalTests.java
@@ -8,6 +8,7 @@
  * SPDX-License-Identifier: EPL-2.0
  *
  *     Tasktop Technologies - initial API and implementation
+ *     See git histpry
  *******************************************************************************/
 
 package org.eclipse.mylyn.tests;
@@ -28,7 +29,6 @@ public class AllLocalTests {
 		TestConfiguration configuration = ManagedSuite.getTestConfiguration();
 		if (configuration == null) {
 			configuration = new TestConfiguration();
-			configuration.setLocalOnly(true);
 			ManagedSuite.setTestConfiguration(configuration);
 		}
 


### PR DESCRIPTION
Proof of Concept replacing JUnit 4 with JUnit 5

Convert Jenkins unit tests

Conditionally re-enable the CI runs if a CI server can be reached. CI server setup using the multipass scrips created by @BeckerFrank 

Task-Url: https://github.com/eclipse-mylyn/org.eclipse.mylyn/issues/51