### PR TITLE
Restore wikitext.context.ui/wikitext.tasks.ui modules to wikitext #626

### DIFF
--- a/mylyn.docs/wikitext/ui/pom.xml
+++ b/mylyn.docs/wikitext/ui/pom.xml
@@ -2,13 +2,13 @@
 <!--
  *******************************************************************************
  * Copyright (c) 2024 Contributors to the Eclipse Foundation
- * 
+ *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * https://www.eclipse.org/legal/epl-2.0/.
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  *   See git history
  *******************************************************************************
@@ -60,11 +60,13 @@
         <module>org.eclipse.mylyn.wikitext.asciidoc.ui.tests</module>
         <module>org.eclipse.mylyn.wikitext.commonmark.ui</module>
         <module>org.eclipse.mylyn.wikitext.confluence.ui</module>
+        <module>org.eclipse.mylyn.wikitext.context.ui</module>
         <module>org.eclipse.mylyn.wikitext.osgi</module>
         <module>org.eclipse.mylyn.wikitext.osgi.tests</module>
         <module>org.eclipse.mylyn.wikitext.creole.ui</module>
         <module>org.eclipse.mylyn.wikitext.markdown.ui</module>
         <module>org.eclipse.mylyn.wikitext.mediawiki.ui</module>
+        <module>org.eclipse.mylyn.wikitext.tasks.ui</module>
         <module>org.eclipse.mylyn.wikitext.textile.ui</module>
         <module>org.eclipse.mylyn.wikitext.tracwiki.ui</module>
         <module>org.eclipse.mylyn.wikitext.twiki.ui</module>


### PR DESCRIPTION

Task-Url: https://github.com/eclipse-mylyn/org.eclipse.mylyn/issues/issues/626