### PR TITLE
Bump tycho to 4.0.9 #495

### DIFF
--- a/mylyn.docs/pom.xml
+++ b/mylyn.docs/pom.xml
@@ -2,13 +2,13 @@
 <!--
  *******************************************************************************
  * Copyright (c) 2024 Contributors to the Eclipse Foundation
- * 
+ *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * https://www.eclipse.org/legal/epl-2.0/.
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  *   See git history
  *******************************************************************************
@@ -34,7 +34,6 @@
     <properties>
         <releaseVersion>4.5.0</releaseVersion>
         <qualifier>-SNAPSHOT</qualifier>
-        <tycho-version>4.0.8</tycho-version>
         <tycho.scmUrl>scm:git:https://github.com/eclipse-mylyn/org.eclipse.mylyn.docs</tycho.scmUrl>
         <nexus.autoReleaseAfterClose>false</nexus.autoReleaseAfterClose>
     </properties>
@@ -247,7 +246,7 @@
             </plugin>
 -->
         </plugins>
-    </build>    
+    </build>
     <profiles>
         <profile>
             <id>ossrh</id>
@@ -273,7 +272,7 @@
                             </execution>
                         </executions>
                     </plugin>
-<!--                    
+<!--
                     <plugin>
                         <groupId>org.eclipse.tycho</groupId>
                         <artifactId>tycho-gpg-plugin</artifactId>
@@ -294,7 +293,7 @@
                             </execution>
                         </executions>
                     </plugin>
--->                    
+-->
                 </plugins>
             </build>
         </profile>

--- a/mylyn.releng/org.eclipse.mylyn.parent/pom.xml
+++ b/mylyn.releng/org.eclipse.mylyn.parent/pom.xml
@@ -26,7 +26,7 @@
     <maven>3.0</maven>
   </prerequisites>
   <properties>
-    <tycho-version>4.0.8</tycho-version>
+    <tycho-version>4.0.9</tycho-version>
     <tycho.scmUrl>scm:git:https://github.com/eclipse-mylyn/org.eclipse.mylyn.git</tycho.scmUrl>
     <tycho.testArgLine></tycho.testArgLine>
     <analysis.skip>true</analysis.skip>


### PR DESCRIPTION
tycho 4.0.9 (and JGit 6.9.0) fixes the missing class complaint at the end of the maven run

Task-Url: https://github.com/eclipse-mylyn/org.eclipse.mylyn/issues/issues/626