### PR TITLE
Include org.apache.lucene.facet in the update site

### DIFF
--- a/org.eclipse.mylyn-site/category.xml
+++ b/org.eclipse.mylyn-site/category.xml
@@ -201,6 +201,7 @@
    <bundle id="org.apache.httpcomponents.httpcore"/>
    <bundle id="org.apache.lucene.analysis-common"/>
    <bundle id="org.apache.lucene.core"/>
+   <bundle id="org.apache.lucene.facet"/>
    <bundle id="org.apache.lucene.queries"/>
    <bundle id="org.apache.lucene.queryparser"/>
    <bundle id="org.apache.lucene.sandbox"/>

--- a/org.eclipse.mylyn-target/org.eclipse.mylyn.target.target
+++ b/org.eclipse.mylyn-target/org.eclipse.mylyn.target.target
@@ -20,7 +20,7 @@
 			<unit id="org.eclipse.license.feature.group" version="0.0.0"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<repository location="https://download.eclipse.org/eclipse/updates/4.34-I-builds/I20241120-1800/"/>
+			<repository location="https://download.eclipse.org/eclipse/updates/4.34/R-4.34-202411201800/"/>
 			<unit id="org.eclipse.equinox.sdk.feature.group" version="0.0.0"/>
 			<unit id="org.eclipse.equinox.p2.sdk.feature.group" version="0.0.0"/>
 			<unit id="org.eclipse.sdk.feature.group" version="0.0.0"/>
@@ -80,6 +80,7 @@
 			<unit id="org.apache.commons.text" version="0.0.0"/>
 			<unit id="org.apache.lucene.analysis-common" version="0.0.0"/>
 			<unit id="org.apache.lucene.core" version="0.0.0"/>
+			<unit id="org.apache.lucene.facet" version="0.0.0"/>
 			<unit id="org.apache.lucene.queries" version="0.0.0"/>
 			<unit id="org.apache.lucene.queryparser" version="0.0.0"/>
 			<unit id="org.apache.lucene.sandbox" version="0.0.0"/>


### PR DESCRIPTION
- The 9.12 version of org.apache.lucene.sandbox has a new dependency on that bundle.
- Update the target platform to use the 4.34 release repository.