### PR TITLE
Develocity configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ target
 build.log
 .local-repo
 .flattened-pom.xml
+.mvn/.develocity/develocity-workspace-id

--- a/.mvn/develocity.xml
+++ b/.mvn/develocity.xml
@@ -8,7 +8,6 @@
   <projectId>org.eclipse.mylyn</projectId>
   <buildScan>
     <obfuscation>
-      <username>#{'eclipse-' + env['EF_SHORT_NAME'] + '-bot'}</username>
       <ipAddresses>0.0.0.0</ipAddresses>
     </obfuscation>
     <publishing>
@@ -16,7 +15,7 @@
         <![CDATA[authenticated]]>
       </onlyIf>
     </publishing>
-    <backgroundBuildScanUpload>#{isFalse(env['CI'])}</backgroundBuildScanUpload>
+    <backgroundBuildScanUpload>#{isFalse(env['JENKINS_URL'])}</backgroundBuildScanUpload>
   </buildScan>
   <buildCache>
     <local>
@@ -24,7 +23,7 @@
     </local>
     <remote>
       <enabled>false</enabled>
-      <storeEnabled>#{isTrue(env['CI'])}</storeEnabled>
+      <storeEnabled>#{isTrue(env['JENKINS_URL'])}</storeEnabled>
     </remote>
   </buildCache>
 </develocity>

--- a/.mvn/develocity.xml
+++ b/.mvn/develocity.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
+<develocity
+  xmlns="https://www.gradle.com/develocity-maven" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="https://www.gradle.com/develocity-maven https://www.gradle.com/schema/develocity-maven.xsd">
+  <server>
+    <url>https://develocity-staging.eclipse.org</url>
+  </server>
+  <projectId>org.eclipse.mylyn</projectId>
+  <buildScan>
+    <obfuscation>
+      <username>#{'eclipse-' + env['EF_SHORT_NAME'] + '-bot'}</username>
+      <ipAddresses>0.0.0.0</ipAddresses>
+    </obfuscation>
+    <publishing>
+      <onlyIf>
+        <![CDATA[authenticated]]>
+      </onlyIf>
+    </publishing>
+    <backgroundBuildScanUpload>#{isFalse(env['CI'])}</backgroundBuildScanUpload>
+  </buildScan>
+  <buildCache>
+    <local>
+      <enabled>false</enabled>
+    </local>
+    <remote>
+      <enabled>false</enabled>
+      <storeEnabled>#{isTrue(env['CI'])}</storeEnabled>
+    </remote>
+  </buildCache>
+</develocity>

--- a/.mvn/develocity.xml
+++ b/.mvn/develocity.xml
@@ -1,4 +1,18 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
+<!--
+ *******************************************************************************
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   See git history
+ *******************************************************************************
+-->
 <develocity
   xmlns="https://www.gradle.com/develocity-maven" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="https://www.gradle.com/develocity-maven https://www.gradle.com/schema/develocity-maven.xsd">

--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -17,4 +17,14 @@
 		<artifactId>tycho-build</artifactId>
 		<version>4.0.8</version>
 	</extension>
+	<extension>
+		<groupId>com.gradle</groupId>
+		<artifactId>develocity-maven-extension</artifactId>
+		<version>1.23</version>
+	</extension>
+	<extension>
+		<groupId>com.gradle</groupId>
+		<artifactId>common-custom-user-data-maven-extension</artifactId>
+		<version>2.0.1</version>
+	</extension>
 </extensions>

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -89,7 +89,6 @@ MAVEN_PROFILES=${env.MAVEN_PROFILES}
                                 -B \
                                 $MAVEN_PROFILES \
                                 -Dmaven.repo.local=$WORKSPACE/.m2/repository \
-                                -Ddevelocity.storage.directory=$WORKSPACE/.m2/.develocity \
                                 -Dmaven.test.failure.ignore=true \
                                 -Dmaven.test.error.ignore=true \
                                 -Ddash.fail=false \

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,7 +12,7 @@
  *******************************************************************************/
 def secrets = [
   [path: 'cbi/org.eclipse.mylyn/develocity.eclipse.org', secretValues: [
-    [envVar: 'DEVELOCITY_ACCESS_KEY', vaultKey: 'develocity-token']
+    [envVar: 'DEVELOCITY_ACCESS_KEY', vaultKey: 'api-token']
     ]
   ]
 ]
@@ -89,6 +89,7 @@ MAVEN_PROFILES=${env.MAVEN_PROFILES}
                                 -B \
                                 $MAVEN_PROFILES \
                                 -Dmaven.repo.local=$WORKSPACE/.m2/repository \
+                                -Ddevelocity.storage.directory=$WORKSPACE/.m2/.develocity \
                                 -Dmaven.test.failure.ignore=true \
                                 -Dmaven.test.error.ignore=true \
                                 -Ddash.fail=false \


### PR DESCRIPTION
This PR will enable you to publish Build Scans to [develocity-staging.eclipse.org](https://develocity-staging.eclipse.org) as requested [here](https://gitlab.eclipse.org/eclipsefdn/helpdesk/-/issues/5409).

### Description
This PR publishes a build scan for every CI build and for every local build from an authenticated Eclipse committer. The build will not fail if publishing fails. Local and remote caching was left disabled on this PR by design so that the build is not affected by this change.

The build scans of the Eclipse Mylyn project are published to the Develocity instance at [develocity-staging.eclipse.org](https://develocity-staging.eclipse.org), hosted by the Eclipse Foundation and run in partnership between the Eclipse and Gradle. This Develocity instance has all features and extensions enabled and is freely available for use by the Eclipse Mylyn project and all other Eclipse projects.

On this Develocity instance, Eclipse Mylyn will have access not only to all of the published build scans but also to other aggregate data features such as:

- Dashboards to view all historical build scans, along with performance trends over time
- Build failure analytics for enhanced investigation and diagnosis of build failures
- Test failure analytics to better understand trends and causes around slow, failing, and flaky tests

This will also enable you to (optionally) use build time optimization features, such as (remote) build caching and Predictive Test Selection. 

More information can be read in the [Eclipse announcement](https://www.eclipse.org/lists/cross-project-issues-dev/msg20000.html). This is the first part of Develocity integration issue no. #664. The second part, if you opt for it, would be to enable caching for the project.

Please let me know if there are any questions about the value of Develocity or the changes in this pull request and I’d be happy to address them.

Locally, you can authenticate by running `mvn develocity:provision-access-key`. More info available [here](https://docs.gradle.com/develocity/maven-extension/current/#automated_access_key_provisioning)