### PR TITLE
Fixed wrong project-id referenced in the Jenkinsfile. #664

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,7 +11,7 @@
  *   See git history
  *******************************************************************************/
 def secrets = [
-  [path: 'cbi/org.eclipse.mylyn/develocity.eclipse.org', secretValues: [
+  [path: 'cbi/tools.mylyn/develocity.eclipse.org', secretValues: [
     [envVar: 'DEVELOCITY_ACCESS_KEY', vaultKey: 'api-token']
     ]
   ]


### PR DESCRIPTION
Fixed wrong project-id referenced in the Jenkinsfile. The project-id needs to be the id from [project.eclipse.org](http://project.eclipse.org/): https://projects.eclipse.org/projects/tools.mylyn, instead of http://ci.eclipse.org/. I will also update the [documentation](https://gitlab.eclipse.org/eclipsefdn/it/releng/develocity/develocity-documentation#ci-integration).

Related to issue #664.