### PR TITLE
Bump Develocity extension version

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -20,7 +20,7 @@
 	<extension>
 		<groupId>com.gradle</groupId>
 		<artifactId>develocity-maven-extension</artifactId>
-		<version>1.23</version>
+		<version>1.23.2</version>
 	</extension>
 	<extension>
 		<groupId>com.gradle</groupId>


### PR DESCRIPTION
Update the Develocity extension version to 1.23.2, which brings support for Tycho test result discovery. This allows you to use build scans to view test failures and the exact reason for those, instead of getting the test report / searching through the console log, which can be especially useful on CI.