### PR TITLE
Adapt functionality for using SVGs in org.eclipse.mylyn.tasks.ui

### DIFF
--- a/mylyn.tasks/org.eclipse.mylyn.tasks.ui/src/org/eclipse/mylyn/internal/tasks/ui/actions/CompareAttachmentsAction.java
+++ b/mylyn.tasks/org.eclipse.mylyn.tasks.ui/src/org/eclipse/mylyn/internal/tasks/ui/actions/CompareAttachmentsAction.java
@@ -108,7 +108,7 @@ public class CompareAttachmentsAction extends BaseSelectionListenerAction implem
 		}
 	}
 
-	private static final String[] IMAGE_EXTENSIONS = { ".jpg", ".gif", ".png", ".tiff", ".tif", ".bmp" }; //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$ //$NON-NLS-5$ //$NON-NLS-6$
+	private static final String[] IMAGE_EXTENSIONS = { ".jpg", ".gif", ".png", ".tiff", ".tif", ".bmp", ".svg" }; //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$ //$NON-NLS-5$ //$NON-NLS-6$ //$NON-NLS-7$
 
 	private Image getImage(ITaskAttachment attachment) {
 		if (AttachmentUtil.isContext(attachment)) {
@@ -169,7 +169,7 @@ public class CompareAttachmentsAction extends BaseSelectionListenerAction implem
 
 		@Override
 		public String getType() {
-			// ImageMergeViewerCreator - gif,jpg,jpeg,png,bmp,ico,tif,tiff
+			// ImageMergeViewerCreator - gif,jpg,jpeg,png,bmp,ico,tif,tiff,svg
 			// BinaryCompareViewerCreator - class,exe,dll,binary,zip,jar
 			// TextMergeViewerCreator - txt
 			// PropertiesFileMergeViewerCreator - properties,properties2

--- a/mylyn.tasks/org.eclipse.mylyn.tasks.ui/src/org/eclipse/mylyn/internal/tasks/ui/editors/TaskEditorOutlineNodeLabelProvider.java
+++ b/mylyn.tasks/org.eclipse.mylyn.tasks.ui/src/org/eclipse/mylyn/internal/tasks/ui/editors/TaskEditorOutlineNodeLabelProvider.java
@@ -32,7 +32,7 @@ import org.eclipse.ui.internal.WorkbenchImages;
  */
 public class TaskEditorOutlineNodeLabelProvider extends LabelProvider {
 
-	private static final String[] IMAGE_EXTENSIONS = { "jpg", "gif", "png", "tiff", "tif", "bmp" }; //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$ //$NON-NLS-5$ //$NON-NLS-6$	@Override
+	private static final String[] IMAGE_EXTENSIONS = { "jpg", "gif", "png", "tiff", "tif", "bmp", "svg" }; //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$ //$NON-NLS-5$ //$NON-NLS-6$ //$NON-NLS-7$	@Override
 
 	@Override
 	public Image getImage(Object element) {

--- a/mylyn.tasks/org.eclipse.mylyn.tasks.ui/src/org/eclipse/mylyn/internal/tasks/ui/wizards/AttachmentPreviewPage.java
+++ b/mylyn.tasks/org.eclipse.mylyn.tasks.ui/src/org/eclipse/mylyn/internal/tasks/ui/wizards/AttachmentPreviewPage.java
@@ -99,6 +99,7 @@ public class AttachmentPreviewPage extends WizardPage {
 		imageTypes.add("image/gif"); //$NON-NLS-1$
 		imageTypes.add("image/png"); //$NON-NLS-1$
 		imageTypes.add("image/tiff"); //$NON-NLS-1$
+		imageTypes.add("image/svg"); //$NON-NLS-1$
 	}
 
 	private void adjustScrollbars(Rectangle imgSize) {


### PR DESCRIPTION
This PR adapts functionality for using SVGs in the bundle `org.eclipse.mylyn.tasks.ui` and should be merged after [this](https://github.com/eclipse-mylyn/org.eclipse.mylyn/pull/707).
As I don't have knowledge about potential side effects regarding this change I assumed it would be better to seperate these changes in this PR.

Please inform me if you see potential problems, so I can adjust the PR. :)
