### PR TITLE
Revert "Develocity update with tycho caching"

### DIFF
--- a/.mvn/develocity.xml
+++ b/.mvn/develocity.xml
@@ -33,10 +33,10 @@
   </buildScan>
   <buildCache>
     <local>
-      <enabled>true</enabled>
+      <enabled>false</enabled>
     </local>
     <remote>
-      <enabled>true</enabled>
+      <enabled>false</enabled>
       <storeEnabled>#{isTrue(env['JENKINS_URL'])}</storeEnabled>
     </remote>
   </buildCache>

--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -20,7 +20,7 @@
 	<extension>
 		<groupId>com.gradle</groupId>
 		<artifactId>develocity-maven-extension</artifactId>
-		<version>2.0</version>
+		<version>1.23.2</version>
 	</extension>
 	<extension>
 		<groupId>com.gradle</groupId>

--- a/mylyn.releng/org.eclipse.mylyn.parent/pom.xml
+++ b/mylyn.releng/org.eclipse.mylyn.parent/pom.xml
@@ -360,45 +360,6 @@
             <rerunFailingTestsCount>1</rerunFailingTestsCount>
           </configuration>
         </plugin>
-        <plugin>
-          <groupId>com.gradle</groupId>
-          <artifactId>develocity-maven-extension</artifactId>
-          <configuration>
-            <develocity>
-              <plugins>
-                <plugin>
-                  <groupId>org.eclipse.tycho</groupId>
-                  <artifactId>tycho-surefire-plugin</artifactId>
-                  <inputs>
-                    <fileSets>
-                      <fileSet>
-                        <name>config.ini</name>
-                        <paths>
-                          <path>${test.keyring.password}</path>
-                        </paths>
-                        <normalization>RELATIVE_PATH</normalization>
-                      </fileSet>
-                      <fileSet>
-                        <name>.eclipse.keyring</name>
-                        <paths>
-                          <path>${project.build.directory}/.eclipse.keyring</path>
-                        </paths>
-                        <normalization>RELATIVE_PATH</normalization>
-                      </fileSet>
-                      <fileSet>
-                        <name>testdata</name>
-                        <paths>
-                          <path>testdata</path>
-                        </paths>
-                        <normalization>RELATIVE_PATH</normalization>
-                      </fileSet>
-                    </fileSets>
-                  </inputs>
-                </plugin>
-              </plugins>
-            </develocity>
-          </configuration>
-        </plugin>
       </plugins>
     </pluginManagement>
   </build>

--- a/org.eclipse.mylyn.tests/pom.xml
+++ b/org.eclipse.mylyn.tests/pom.xml
@@ -110,42 +110,5 @@
         </configuration>
       </plugin>
     </plugins>
-
-    <pluginManagement>
-      <plugins>
-        <plugin>
-          <groupId>com.gradle</groupId>
-          <artifactId>develocity-maven-extension</artifactId>
-          <configuration>
-            <develocity>
-              <plugins>
-                <plugin>
-                  <groupId>org.eclipse.tycho</groupId>
-                  <artifactId>tycho-surefire-plugin</artifactId>
-                  <inputs>
-                    <fileSets combine.children="append">
-                      <fileSet>
-                        <name>test-fixture</name>
-                        <paths>
-                          <path>${basedir}/test-fixture.xsl</path>
-                        </paths>
-                        <normalization>RELATIVE_PATH</normalization>
-                      </fileSet>
-                      <fileSet>
-                        <name>test-suite</name>
-                        <paths>
-                          <path>${basedir}/test-suite.xsl</path>
-                        </paths>
-                        <normalization>RELATIVE_PATH</normalization>
-                      </fileSet>
-                    </fileSets>
-                  </inputs>
-                </plugin>
-              </plugins>
-            </develocity>
-          </configuration>
-        </plugin>
-      </plugins>
-    </pluginManagement>
   </build>
 </project>


### PR DESCRIPTION
Reverts eclipse-mylyn/org.eclipse.mylyn#718

We have some misconfiguration or infra issue

```
PluginClassLoader for hashicorp-vault-plugin//com.datapipe.jenkins.vault.VaultAccessor.retrieveVaultSecrets(VaultAccessor.java:230)
	PluginClassLoader for hashicorp-vault-plugin//com.datapipe.jenkins.vault.VaultBindingStep$Execution.doStart(VaultBindingStep.java:115)
	PluginClassLoader for workflow-step-api//org.jenkinsci.plugins.workflow.steps.GeneralNonBlockingStepExecution.lambda$run$0(GeneralNonBlockingStepExecution.java:77)
	java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:5[3](https://ci.eclipse.org/mylyn/job/GitHub-mylyn-Orga/job/org.eclipse.mylyn/job/PR-723/1/pipeline-console/?start-byte=0&selected-node=72#log-3)9)
	java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
	java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
	java.base/java.lang.Thread.run(Thread.java:8[5](https://ci.eclipse.org/mylyn/job/GitHub-mylyn-Orga/job/org.eclipse.mylyn/job/PR-723/1/pipeline-console/?start-byte=0&selected-node=72#log-5)3)
```