### PR TITLE
Re-enable Develocity

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -20,11 +20,11 @@
 	<extension>
 		<groupId>com.gradle</groupId>
 		<artifactId>develocity-maven-extension</artifactId>
-		<version>2.0</version>
+		<version>2.0.1</version>
 	</extension>
 	<extension>
 		<groupId>com.gradle</groupId>
 		<artifactId>common-custom-user-data-maven-extension</artifactId>
-		<version>2.0.1</version>
+		<version>2.0.3</version>
 	</extension>
 </extensions>

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -93,8 +93,6 @@ MAVEN_PROFILES=${env.MAVEN_PROFILES}
                                 -B \
                                 $MAVEN_PROFILES \
                                 -Dmaven.repo.local=$WORKSPACE/.m2/repository \
-                                -Dmaven.test.failure.ignore=true \
-                                -Dmaven.test.error.ignore=true \
                                 -Ddash.fail=false \
                                 -Dorg.eclipse.justj.p2.manager.build.url=$JOB_URL \
                                 -Dbuild.type=$BUILD_TYPE \

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,15 +10,13 @@
  * Contributors:
  *   See git history
  *******************************************************************************/
-/* develocity disabled to produce 4.7.0 M3
-
 def secrets = [
   [path: 'cbi/tools.mylyn/develocity.eclipse.org', secretValues: [
     [envVar: 'DEVELOCITY_ACCESS_KEY', vaultKey: 'api-token']
     ]
   ]
 ]
-*/
+
 
 pipeline {
 	options {
@@ -83,9 +81,7 @@ MAVEN_PROFILES=${env.MAVEN_PROFILES}
 			steps {
 				sshagent (['projects-storage.eclipse.org-bot-ssh']) {
 					wrap([$class: 'Xvnc', useXauthority: true]) {
-                        /* develocity disabled to produce 4.7.0 M3
                         withVault([vaultSecrets: secrets]) {
-						*/
                             sh '''
                                 mvn \
                                 clean \
@@ -98,9 +94,7 @@ MAVEN_PROFILES=${env.MAVEN_PROFILES}
                                 -Dbuild.type=$BUILD_TYPE \
                                 -Dgit.commit=$GIT_COMMIT
                             '''
-                        /* develocity disabled to produce 4.7.0 M3
                         }
-                        */
 					}
 				}
 			}

--- a/mylyn.releng/org.eclipse.mylyn.parent/pom.xml
+++ b/mylyn.releng/org.eclipse.mylyn.parent/pom.xml
@@ -360,7 +360,6 @@
             <rerunFailingTestsCount>1</rerunFailingTestsCount>
           </configuration>
         </plugin>
-<!-- develocity disabled to prщduce 4.7.0 M3
         <plugin>
           <groupId>com.gradle</groupId>
           <artifactId>develocity-maven-extension</artifactId>
@@ -400,8 +399,6 @@
             </develocity>
           </configuration>
         </plugin>
-	
--->
       </plugins>
     </pluginManagement>
   </build>

--- a/org.eclipse.mylyn.tests/pom.xml
+++ b/org.eclipse.mylyn.tests/pom.xml
@@ -113,7 +113,6 @@
 
     <pluginManagement>
       <plugins>
-<!-- develocity disabled to prщduce 4.7.0 M3
         <plugin>
           <groupId>com.gradle</groupId>
           <artifactId>develocity-maven-extension</artifactId>
@@ -146,7 +145,6 @@
             </develocity>
           </configuration>
         </plugin>
--->
       </plugins>
     </pluginManagement>
   </build>


### PR DESCRIPTION
This PR will re-enable Develocity and enable caching for Tycho tests, as added in PR https://github.com/eclipse-mylyn/org.eclipse.mylyn/pull/718. 

I hope this is a good time to do this. As discussed already, the reason for you disabling it in the first place was problems with the Eclipse infrastructure, related to Jenkins vaults, which is how secrets are managed for Develocity for Eclipse projects.