### PR TITLE
Gitlab Connector: remove user and password authorization #672

### DIFF
--- a/mylyn.tasks/connectors/gitlab/org.eclipse.mylyn.gitlab.core.test/src/org/eclipse/mylyn/gitlab/core/test/GitlabTestFixture.java
+++ b/mylyn.tasks/connectors/gitlab/org.eclipse.mylyn.gitlab.core.test/src/org/eclipse/mylyn/gitlab/core/test/GitlabTestFixture.java
@@ -27,6 +27,7 @@ import org.eclipse.mylyn.commons.sdk.util.TestConfiguration;
 import org.eclipse.mylyn.gitlab.core.GitlabCoreActivator;
 import org.eclipse.mylyn.internal.gitlab.core.GitlabRepositoryConnector;
 import org.eclipse.mylyn.internal.gitlab.core.GitlabRestClient;
+import org.eclipse.mylyn.internal.tasks.core.IRepositoryConstants;
 import org.eclipse.mylyn.tasks.core.TaskRepository;
 import org.eclipse.mylyn.tests.util.TestFixture;
 
@@ -41,8 +42,7 @@ public class GitlabTestFixture extends TestFixture {
 		private static final long serialVersionUID = 1751817962812899025L;
 
 		{
-			put(GitlabCoreActivator.USE_PERSONAL_ACCESS_TOKEN, "true");
-			put(GitlabCoreActivator.PERSONAL_ACCESS_TOKEN, "glpat-Test1nPwd12345");
+			put(IRepositoryConstants.PROPERTY_USE_TOKEN, "true");
 			put(GitlabCoreActivator.GROUPS, "eclipse-mylyn");
 		}
 	};

--- a/mylyn.tasks/connectors/gitlab/org.eclipse.mylyn.gitlab.core.test/src/org/eclipse/mylyn/gitlab/core/test/RestfulGitlabClientTest.java
+++ b/mylyn.tasks/connectors/gitlab/org.eclipse.mylyn.gitlab.core.test/src/org/eclipse/mylyn/gitlab/core/test/RestfulGitlabClientTest.java
@@ -32,7 +32,6 @@ import org.eclipse.mylyn.commons.sdk.util.CommonTestUtil;
 import org.eclipse.mylyn.gitlab.core.GitlabConfiguration;
 import org.eclipse.mylyn.internal.commons.core.operations.NullOperationMonitor;
 import org.eclipse.mylyn.internal.gitlab.core.GitlabRestClient;
-import org.junit.Ignore;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
@@ -47,7 +46,6 @@ import com.google.gson.JsonNull;
 import com.google.gson.JsonObject;
 
 @SuppressWarnings({ "nls", "restriction" })
-@Ignore //FIXME: re-enable with https://github.com/eclipse-mylyn/org.eclipse.mylyn/issues/716
 public final class RestfulGitlabClientTest {
 
 	@BeforeAll
@@ -74,11 +72,6 @@ public final class RestfulGitlabClientTest {
 	@GitLabTestService
 	public void setUp() throws Exception {
 		GitlabTestFixture.current().clearOverwriteProperties();
-// when you want to execute the tests with user and password instead of the accestoken.
-// change the password stored in
-// /org.eclipse.mylyn.gitlab.core.test/testdata/credentials.properties
-// and uncomment the next line
-//		GitlabTestFixture.current().addOverwriteProperty(GitlabCoreActivator.USE_PERSONAL_ACCESS_TOKEN, "false");
 	}
 
 	@AfterEach

--- a/mylyn.tasks/connectors/gitlab/org.eclipse.mylyn.gitlab.core.test/src/org/eclipse/mylyn/internal/gitlab/core/GitlabRestClientTest.java
+++ b/mylyn.tasks/connectors/gitlab/org.eclipse.mylyn.gitlab.core.test/src/org/eclipse/mylyn/internal/gitlab/core/GitlabRestClientTest.java
@@ -11,22 +11,17 @@
 
 package org.eclipse.mylyn.internal.gitlab.core;
 
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import org.apache.http.client.methods.HttpRequestBase;
-import org.eclipse.mylyn.commons.core.operations.IOperationMonitor;
 import org.eclipse.mylyn.commons.repositories.core.RepositoryLocation;
 import org.eclipse.mylyn.commons.repositories.http.core.CommonHttpClient;
 import org.eclipse.mylyn.gitlab.core.GitlabCoreActivator;
+import org.eclipse.mylyn.internal.commons.core.operations.NullOperationMonitor;
 import org.eclipse.mylyn.tasks.core.TaskRepository;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 
 import com.google.gson.Gson;
+import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 
 public class GitlabRestClientTest {
@@ -35,14 +30,9 @@ public class GitlabRestClientTest {
 	@Test
 	public void ignoreMilestonesForProjectsWithIssuesDisabled() throws Exception {
 		RepositoryLocation location = new RepositoryLocation("http://localhost");
-		CommonHttpClient httpClient = Mockito.mock(CommonHttpClient.class);
-		when(httpClient.getLocation()).thenReturn(location);
-
+		CommonHttpClient httpClient = new CommonHttpClient(location);
 		GitlabRepositoryConnector connector = new GitlabRepositoryConnector();
-		String repoUrl = "http://localhost";
-		TaskRepository repository = new TaskRepository(GitlabCoreActivator.CONNECTOR_KIND, repoUrl);
-		repository.setProperty(GitlabCoreActivator.USE_PERSONAL_ACCESS_TOKEN, "true");
-		repository.setProperty(GitlabCoreActivator.PERSONAL_ACCESS_TOKEN, "test-token");
+		TaskRepository repository = new TaskRepository(GitlabCoreActivator.CONNECTOR_KIND, "http://localhost");
 		GitlabRestClient client = new GitlabRestClient(location, httpClient, connector, repository);
 
 		JsonObject project = new Gson().fromJson("""
@@ -51,7 +41,8 @@ public class GitlabRestClientTest {
 				"issues_enabled": false
 				}
 				""", JsonObject.class);
-		client.getProjectMilestones(project, mock(IOperationMonitor.class, Mockito.RETURNS_SELF));
-		verify(httpClient, times(0)).execute(any(HttpRequestBase.class), any(IOperationMonitor.class));
+		JsonArray emptyArray = new JsonArray();
+		JsonArray milestones = client.getProjectMilestones(project, new NullOperationMonitor());
+		assertEquals(emptyArray, milestones);
 	}
 }

--- a/mylyn.tasks/connectors/gitlab/org.eclipse.mylyn.gitlab.core.test/testdata/credentials.properties
+++ b/mylyn.tasks/connectors/gitlab/org.eclipse.mylyn.gitlab.core.test/testdata/credentials.properties
@@ -1,3 +1,2 @@
 user: mylynTest
-pass: Tst1nPwd
-token: glpat-Test1nPwd12345
+pass: glpat-Test1nPwd12345

--- a/mylyn.tasks/connectors/gitlab/org.eclipse.mylyn.gitlab.core/src/org/eclipse/mylyn/gitlab/core/GitlabCoreActivator.java
+++ b/mylyn.tasks/connectors/gitlab/org.eclipse.mylyn.gitlab.core/src/org/eclipse/mylyn/gitlab/core/GitlabCoreActivator.java
@@ -41,10 +41,6 @@ public final class GitlabCoreActivator extends Plugin {
 
 	public static final String SHOW_ACTIVITY_ICONS = "gitlab.show.activity.icons"; //$NON-NLS-1$
 
-	public static final String USE_PERSONAL_ACCESS_TOKEN = "gitlab.use.personal.access.token"; //$NON-NLS-1$
-
-	public static final String PERSONAL_ACCESS_TOKEN = "gitlab.personal.access.token"; //$NON-NLS-1$
-
 	public static final String API_VERSION = "/api/v4"; //$NON-NLS-1$
 
 	public static final String ATTRIBUTE_TYPE_ACTIVITY = "activity"; //$NON-NLS-1$

--- a/mylyn.tasks/connectors/gitlab/org.eclipse.mylyn.gitlab.ui/src/org/eclipse/mylyn/internal/gitlab/ui/GitlabRepositorySettingsPage.java
+++ b/mylyn.tasks/connectors/gitlab/org.eclipse.mylyn.gitlab.ui/src/org/eclipse/mylyn/internal/gitlab/ui/GitlabRepositorySettingsPage.java
@@ -75,6 +75,7 @@ public class GitlabRepositorySettingsPage extends AbstractRepositorySettingsPage
 		setNeedsEncoding(false);
 		setNeedsTimeZone(false);
 		setNeedsProxy(false);
+		setUseTokenForAuthentication(true);
 	}
 
 	@Override
@@ -84,6 +85,7 @@ public class GitlabRepositorySettingsPage extends AbstractRepositorySettingsPage
 
 	@Override
 	protected void createAdditionalControls(Composite parent) {
+		setUseTokenSelection(true);
 		FormToolkit toolkit = new FormToolkit(TasksUiPlugin.getDefault().getFormColors(parent.getDisplay()));
 		Composite aditionalContainer = new Composite(parent, SWT.NONE);
 		GridLayoutFactory.fillDefaults().margins(0, 0).numColumns(3).applyTo(aditionalContainer);
@@ -257,6 +259,7 @@ public class GitlabRepositorySettingsPage extends AbstractRepositorySettingsPage
 			showActivityIconsButton.setSelection(value == null ? true : Boolean.parseBoolean(value));
 		}
 
+		/*
 		gd = new GridData(GridData.FILL_BOTH);
 		gd.horizontalSpan = 3;
 		gd.verticalSpan = 1;
@@ -284,7 +287,7 @@ public class GitlabRepositorySettingsPage extends AbstractRepositorySettingsPage
 
 		String accessTokenValue = getRepository() != null
 				? getRepository().getProperty(GitlabCoreActivator.PERSONAL_ACCESS_TOKEN)
-				: null;
+						: null;
 		if (accessTokenValue == null) {
 			accessTokenValue = ""; //$NON-NLS-1$
 		}
@@ -295,6 +298,7 @@ public class GitlabRepositorySettingsPage extends AbstractRepositorySettingsPage
 		gd.grabExcessHorizontalSpace = true;
 		personalAccessTokenText.setLayoutData(gd);
 
+		 */
 		updateUIEnablement();
 	}
 
@@ -317,9 +321,11 @@ public class GitlabRepositorySettingsPage extends AbstractRepositorySettingsPage
 		repository.setProperty(GitlabCoreActivator.AVANTAR, Boolean.toString(avatarSupportButton.getSelection()));
 		repository.setProperty(GitlabCoreActivator.SHOW_ACTIVITY_ICONS,
 				Boolean.toString(showActivityIconsButton.getSelection()));
+		/*
 		repository.setProperty(GitlabCoreActivator.USE_PERSONAL_ACCESS_TOKEN,
 				Boolean.toString(usePersonalAccessTokenButton.getSelection()));
 		repository.setProperty(GitlabCoreActivator.PERSONAL_ACCESS_TOKEN, personalAccessTokenText.getText());
+		 */
 		super.applyTo(repository);
 	}
 

--- a/mylyn.tasks/org.eclipse.mylyn.tasks.ui.tests/src/org/eclipse/mylyn/tasks/ui/editors/AbstractTaskEditorPageTest.java
+++ b/mylyn.tasks/org.eclipse.mylyn.tasks.ui.tests/src/org/eclipse/mylyn/tasks/ui/editors/AbstractTaskEditorPageTest.java
@@ -65,7 +65,6 @@ public class AbstractTaskEditorPageTest {
 
 	private TaskAttribute attribute;
 
-	@SuppressWarnings("restriction")
 	@Before
 	public void setUp() {
 		repository = TaskTestUtil.createMockRepository();

--- a/mylyn.tasks/org.eclipse.mylyn.tasks.ui.tests/src/org/eclipse/mylyn/tasks/ui/editors/AttributeEditorToolkitTest.java
+++ b/mylyn.tasks/org.eclipse.mylyn.tasks.ui.tests/src/org/eclipse/mylyn/tasks/ui/editors/AttributeEditorToolkitTest.java
@@ -78,7 +78,6 @@ public class AttributeEditorToolkitTest {
 
 	private final TaskDataModel taskDataModel = mock(TaskDataModel.class);
 
-	@SuppressWarnings("restriction")
 	@Before
 	public void setUp() {
 		CommonTextSupport textSupport = mock(CommonTextSupport.class);

--- a/mylyn.tasks/org.eclipse.mylyn.tasks.ui/src/org/eclipse/mylyn/tasks/ui/wizards/AbstractRepositorySettingsPage.java
+++ b/mylyn.tasks/org.eclipse.mylyn.tasks.ui/src/org/eclipse/mylyn/tasks/ui/wizards/AbstractRepositorySettingsPage.java
@@ -285,6 +285,28 @@ implements ITaskRepositoryPage, IAdaptable {
 
 	private Button useToken;
 
+	private SelectionAdapter useTokenListener;
+
+	/**
+	 * @since 4.8
+	 */
+	public void setUseTokenSelection(boolean selection) {
+		if (useToken != null) {
+			useToken.setSelection(selection);
+			// setSelection does not fire a selection event
+			useTokenListener.widgetSelected(null);
+		}
+	}
+
+	/**
+	 * @since 4.8
+	 */
+	public void setUseTokenButtonEnabled(boolean enabled) {
+		if (useToken != null) {
+			useToken.setEnabled(enabled);
+		}
+	}
+
 	/**
 	 * @since 3.10
 	 */
@@ -676,7 +698,7 @@ implements ITaskRepositoryPage, IAdaptable {
 			GridDataFactory.defaultsFor(useToken).span(3, 1).applyTo(useToken);
 			String savePasswordText = savePasswordButton.getText();
 			boolean[] allowAnon = { isAnonymousAccess() };
-			SelectionAdapter listener = new SelectionAdapter() {
+			useTokenListener = new SelectionAdapter() {
 
 				@Override
 				public void widgetSelected(SelectionEvent e) {
@@ -718,12 +740,12 @@ implements ITaskRepositoryPage, IAdaptable {
 					}
 				}
 			};
-			useToken.addSelectionListener(listener);
+			useToken.addSelectionListener(useTokenListener);
 			TaskRepository taskRepository = getRepository();
 			if (taskRepository != null) {
 				useToken.setSelection(useTokenChecked(taskRepository));
 				// setSelection does not fire a selection event
-				listener.widgetSelected(null);
+				useTokenListener.widgetSelected(null);
 			}
 
 		}


### PR DESCRIPTION
Gitlab authorization over oauth no longer accepts user and password.
So we must change the repository settings to always use the token and remove unused code.