### PR TITLE
716 reactivate ci server tests

### DIFF
--- a/mylyn.builds/org.eclipse.mylyn.jenkins.tests/src/org/eclipse/mylyn/jenkins/tests/AllJenkinsTests.java
+++ b/mylyn.builds/org.eclipse.mylyn.jenkins.tests/src/org/eclipse/mylyn/jenkins/tests/AllJenkinsTests.java
@@ -11,13 +11,19 @@
 
 package org.eclipse.mylyn.jenkins.tests;
 
+import java.util.List;
+
 import org.eclipse.mylyn.commons.sdk.util.CommonTestUtil;
 import org.eclipse.mylyn.commons.sdk.util.ManagedSuite;
 import org.eclipse.mylyn.commons.sdk.util.ManagedTestSuite;
 import org.eclipse.mylyn.commons.sdk.util.TestConfiguration;
+import org.eclipse.mylyn.jenkins.tests.client.JenkinsClientTest;
 import org.eclipse.mylyn.jenkins.tests.client.JenkinsUrlTest;
+import org.eclipse.mylyn.jenkins.tests.client.JenkinsValidationTest;
 import org.eclipse.mylyn.jenkins.tests.core.JenkinsConnectorTest;
 import org.eclipse.mylyn.jenkins.tests.core.JenkinsServerBehaviourTest;
+import org.eclipse.mylyn.jenkins.tests.integration.JenkinsIntegrationTest;
+import org.eclipse.mylyn.jenkins.tests.support.JenkinsFixture;
 
 import junit.framework.Test;
 import junit.framework.TestSuite;
@@ -49,8 +55,7 @@ public class AllJenkinsTests {
 		suite.addTestSuite(JenkinsConnectorTest.class);
 		suite.addTestSuite(JenkinsServerBehaviourTest.class);
 		suite.addTestSuite(JenkinsUrlTest.class);
-		//FIXME: [#772] Nothing for Jenkins available at https://mylyn.frank-becker.de/mylyn_idx/service
-/*
+
 		if (!configuration.isLocalOnly()) {
 			// network tests
 			suite.addTestSuite(JenkinsValidationTest.class);
@@ -68,7 +73,6 @@ public class AllJenkinsTests {
 				fixture.done();
 			}
 		}
- */
 	}
 
 }

--- a/mylyn.builds/org.eclipse.mylyn.jenkins.tests/src/org/eclipse/mylyn/jenkins/tests/client/JenkinsClientTest.java
+++ b/mylyn.builds/org.eclipse.mylyn.jenkins.tests/src/org/eclipse/mylyn/jenkins/tests/client/JenkinsClientTest.java
@@ -31,7 +31,6 @@ import org.eclipse.mylyn.internal.jenkins.core.client.RestfulJenkinsClient.Build
 import org.eclipse.mylyn.jenkins.tests.support.JenkinsFixture;
 import org.eclipse.mylyn.jenkins.tests.support.JenkinsHarness;
 import org.eclipse.mylyn.jenkins.tests.support.JenkinsTestUtil;
-import org.junit.Ignore;
 
 import junit.framework.TestCase;
 
@@ -42,7 +41,6 @@ import junit.framework.TestCase;
  * @author Steffen Pingel
  */
 @SuppressWarnings("nls")
-@Ignore //FIXME: re-enable with https://github.com/eclipse-mylyn/org.eclipse.mylyn/issues/716
 public class JenkinsClientTest extends TestCase {
 
 	private JenkinsHarness harness;

--- a/mylyn.builds/org.eclipse.mylyn.jenkins.tests/src/org/eclipse/mylyn/jenkins/tests/client/JenkinsUrlUtilTest.java
+++ b/mylyn.builds/org.eclipse.mylyn.jenkins.tests/src/org/eclipse/mylyn/jenkins/tests/client/JenkinsUrlUtilTest.java
@@ -27,7 +27,6 @@ import org.eclipse.mylyn.internal.jenkins.core.client.RestfulJenkinsClient;
 import org.eclipse.mylyn.jenkins.tests.support.JenkinsFixture;
 import org.eclipse.mylyn.jenkins.tests.support.JenkinsHarness;
 import org.junit.Assert;
-import org.junit.Ignore;
 
 import junit.framework.TestCase;
 
@@ -35,8 +34,6 @@ import junit.framework.TestCase;
  * @author Christian Gaege
  */
 @SuppressWarnings("nls")
-//FIXME: [#772] Nothing for Jenkins available at https://mylyn.frank-becker.de/mylyn_idx/service
-@Ignore
 public class JenkinsUrlUtilTest extends TestCase {
 
 	private JenkinsUrlUtil jenkinsUrlUtil;

--- a/mylyn.builds/org.eclipse.mylyn.jenkins.tests/src/org/eclipse/mylyn/jenkins/tests/client/JenkinsValidationTest.java
+++ b/mylyn.builds/org.eclipse.mylyn.jenkins.tests/src/org/eclipse/mylyn/jenkins/tests/client/JenkinsValidationTest.java
@@ -18,7 +18,6 @@ import org.eclipse.mylyn.commons.repositories.core.RepositoryLocation;
 import org.eclipse.mylyn.internal.jenkins.core.client.JenkinsException;
 import org.eclipse.mylyn.internal.jenkins.core.client.RestfulJenkinsClient;
 import org.eclipse.mylyn.jenkins.tests.support.JenkinsFixture;
-import org.junit.Ignore;
 
 import junit.framework.TestCase;
 
@@ -26,8 +25,6 @@ import junit.framework.TestCase;
  * @author Steffen Pingel
  */
 @SuppressWarnings("nls")
-//FIXME: [#772] Nothing for Jenkins available at https://mylyn.frank-becker.de/mylyn_idx/service
-@Ignore
 public class JenkinsValidationTest extends TestCase {
 
 	public void testValidateNonExistantUrl() throws Exception {

--- a/mylyn.builds/org.eclipse.mylyn.jenkins.tests/src/org/eclipse/mylyn/jenkins/tests/integration/JenkinsIntegrationTest.java
+++ b/mylyn.builds/org.eclipse.mylyn.jenkins.tests/src/org/eclipse/mylyn/jenkins/tests/integration/JenkinsIntegrationTest.java
@@ -28,7 +28,6 @@ import org.eclipse.mylyn.commons.repositories.core.RepositoryLocation;
 import org.eclipse.mylyn.jenkins.core.JenkinsCore;
 import org.eclipse.mylyn.jenkins.tests.support.JenkinsFixture;
 import org.eclipse.mylyn.jenkins.tests.support.JenkinsHarness;
-import org.junit.Ignore;
 
 import junit.framework.TestCase;
 
@@ -36,8 +35,6 @@ import junit.framework.TestCase;
  * @author Steffen Pingel
  */
 @SuppressWarnings("nls")
-//FIXME: [#772] Nothing for Jenkins available at https://mylyn.frank-becker.de/mylyn_idx/service
-@Ignore
 public class JenkinsIntegrationTest extends TestCase {
 
 	private JenkinsHarness harness;

--- a/mylyn.tasks/connectors/bugzilla-rest/org.eclipse.mylyn.bugzilla.rest.core.tests/config/local-All-BugzillaRestCoreTests.launch
+++ b/mylyn.tasks/connectors/bugzilla-rest/org.eclipse.mylyn.bugzilla.rest.core.tests/config/local-All-BugzillaRestCoreTests.launch
@@ -32,7 +32,7 @@
     <stringAttribute key="org.eclipse.jdt.launching.PROGRAM_ARGUMENTS" value="-os ${target.os} -ws ${target.ws} -arch ${target.arch} -nl ${target.nl} -consoleLog -consolelog"/>
     <stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="org.eclipse.mylyn.bugzilla.rest.core.tests"/>
     <stringAttribute key="org.eclipse.jdt.launching.SOURCE_PATH_PROVIDER" value="org.eclipse.pde.ui.workbenchClasspathProvider"/>
-    <stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="-Xms40m -Xmx256m&#10;-Dorg.eclipse.mylyn.ci.server.tests=true&#10;-Dorg.eclipse.mylyn.tests.all=true"/>
+    <stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="-Xms40m -Xmx256m&#10;-Dorg.eclipse.mylyn.tests.all=true"/>
     <stringAttribute key="pde.version" value="3.3"/>
     <stringAttribute key="product" value="org.eclipse.platform.ide"/>
     <booleanAttribute key="run_in_ui_thread" value="true"/>

--- a/mylyn.tasks/connectors/bugzilla-rest/org.eclipse.mylyn.bugzilla.rest.core.tests/config/local-All-BugzillaTests.launch
+++ b/mylyn.tasks/connectors/bugzilla-rest/org.eclipse.mylyn.bugzilla.rest.core.tests/config/local-All-BugzillaTests.launch
@@ -1,43 +1,46 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <launchConfiguration type="org.eclipse.pde.ui.JunitLaunchConfig">
-<booleanAttribute key="append.args" value="true"/>
-<booleanAttribute key="askclear" value="false"/>
-<booleanAttribute key="automaticAdd" value="true"/>
-<booleanAttribute key="automaticValidate" value="false"/>
-<stringAttribute key="bootstrap" value=""/>
-<stringAttribute key="checked" value="[NONE]"/>
-<booleanAttribute key="clearConfig" value="true"/>
-<booleanAttribute key="clearws" value="true"/>
-<booleanAttribute key="clearwslog" value="false"/>
-<stringAttribute key="configLocation" value="${workspace_loc}/.metadata/.plugins/org.eclipse.pde.core/pde-junit"/>
-<booleanAttribute key="default" value="true"/>
-<booleanAttribute key="includeOptional" value="true"/>
-<stringAttribute key="location" value="${workspace_loc}/../junit-workspace"/>
-<listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_PATHS">
-<listEntry value="/org.eclipse.mylyn.bugzilla.tests/src/org/eclipse/mylyn/bugzilla/tests/AllBugzillaTests.java"/>
-</listAttribute>
-<listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_TYPES">
-<listEntry value="1"/>
-</listAttribute>
-<stringAttribute key="org.eclipse.jdt.junit.CONTAINER" value=""/>
-<booleanAttribute key="org.eclipse.jdt.junit.KEEPRUNNING_ATTR" value="false"/>
-<stringAttribute key="org.eclipse.jdt.junit.TESTNAME" value=""/>
-<stringAttribute key="org.eclipse.jdt.junit.TEST_KIND" value="org.eclipse.jdt.junit.loader.junit4"/>
-<booleanAttribute key="org.eclipse.jdt.launching.ATTR_USE_START_ON_FIRST_THREAD" value="true"/>
-<stringAttribute key="org.eclipse.jdt.launching.JRE_CONTAINER" value="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.launching.macosx.MacOSXType/Java SE 17 [17.0.5]"/>
-<stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="org.eclipse.mylyn.bugzilla.tests.AllBugzillaTests"/>
-<stringAttribute key="org.eclipse.jdt.launching.PROGRAM_ARGUMENTS" value="-os ${target.os} -ws ${target.ws} -arch ${target.arch} -nl ${target.nl} -consoleLog -consolelog"/>
-<stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="org.eclipse.mylyn.bugzilla.tests"/>
-<stringAttribute key="org.eclipse.jdt.launching.SOURCE_PATH_PROVIDER" value="org.eclipse.pde.ui.workbenchClasspathProvider"/>
-<stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="-Xms40m -Xmx256m -XX:MaxPermSize=128m&#10;-Dorg.eclipse.mylyn.tests.all=true"/>
-<stringAttribute key="pde.version" value="3.3"/>
-<stringAttribute key="product" value="org.eclipse.platform.ide"/>
-<booleanAttribute key="run_in_ui_thread" value="true"/>
-<booleanAttribute key="show_selected_only" value="false"/>
-<stringAttribute key="templateConfig" value="${target_home}/configuration/config.ini"/>
-<booleanAttribute key="tracing" value="false"/>
-<booleanAttribute key="useCustomFeatures" value="false"/>
-<booleanAttribute key="useDefaultConfig" value="true"/>
-<booleanAttribute key="useDefaultConfigArea" value="false"/>
-<booleanAttribute key="useProduct" value="true"/>
+    <booleanAttribute key="append.args" value="true"/>
+    <booleanAttribute key="askclear" value="false"/>
+    <booleanAttribute key="automaticAdd" value="true"/>
+    <booleanAttribute key="automaticValidate" value="false"/>
+    <stringAttribute key="bootstrap" value=""/>
+    <stringAttribute key="checked" value="[NONE]"/>
+    <booleanAttribute key="clearConfig" value="true"/>
+    <booleanAttribute key="clearws" value="true"/>
+    <booleanAttribute key="clearwslog" value="false"/>
+    <stringAttribute key="configLocation" value="${workspace_loc}/.metadata/.plugins/org.eclipse.pde.core/pde-junit"/>
+    <booleanAttribute key="default" value="true"/>
+    <booleanAttribute key="includeOptional" value="true"/>
+    <stringAttribute key="location" value="${workspace_loc}/../junit-workspace"/>
+    <booleanAttribute key="org.eclipse.debug.core.ATTR_FORCE_SYSTEM_CONSOLE_ENCODING" value="false"/>
+    <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_PATHS">
+        <listEntry value="/org.eclipse.mylyn.bugzilla.tests/src/org/eclipse/mylyn/bugzilla/tests/AllBugzillaTests.java"/>
+    </listAttribute>
+    <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_TYPES">
+        <listEntry value="1"/>
+    </listAttribute>
+    <stringAttribute key="org.eclipse.jdt.junit.CONTAINER" value=""/>
+    <booleanAttribute key="org.eclipse.jdt.junit.KEEPRUNNING_ATTR" value="false"/>
+    <stringAttribute key="org.eclipse.jdt.junit.TESTNAME" value=""/>
+    <stringAttribute key="org.eclipse.jdt.junit.TEST_KIND" value="org.eclipse.jdt.junit.loader.junit4"/>
+    <booleanAttribute key="org.eclipse.jdt.launching.ATTR_ATTR_USE_ARGFILE" value="false"/>
+    <booleanAttribute key="org.eclipse.jdt.launching.ATTR_SHOW_CODEDETAILS_IN_EXCEPTION_MESSAGES" value="true"/>
+    <booleanAttribute key="org.eclipse.jdt.launching.ATTR_USE_START_ON_FIRST_THREAD" value="true"/>
+    <stringAttribute key="org.eclipse.jdt.launching.JRE_CONTAINER" value="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-21"/>
+    <stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="org.eclipse.mylyn.bugzilla.tests.AllBugzillaTests"/>
+    <stringAttribute key="org.eclipse.jdt.launching.PROGRAM_ARGUMENTS" value="-os ${target.os} -ws ${target.ws} -arch ${target.arch} -nl ${target.nl} -consoleLog -consolelog"/>
+    <stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="org.eclipse.mylyn.bugzilla.tests"/>
+    <stringAttribute key="org.eclipse.jdt.launching.SOURCE_PATH_PROVIDER" value="org.eclipse.pde.ui.workbenchClasspathProvider"/>
+    <stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="-Xms40m -Xmx256m&#10;-Dorg.eclipse.mylyn.tests.all=true"/>
+    <stringAttribute key="pde.version" value="3.3"/>
+    <stringAttribute key="product" value="org.eclipse.platform.ide"/>
+    <booleanAttribute key="run_in_ui_thread" value="true"/>
+    <booleanAttribute key="show_selected_only" value="false"/>
+    <stringAttribute key="templateConfig" value="${target_home}/configuration/config.ini"/>
+    <booleanAttribute key="tracing" value="false"/>
+    <booleanAttribute key="useCustomFeatures" value="false"/>
+    <booleanAttribute key="useDefaultConfig" value="true"/>
+    <booleanAttribute key="useDefaultConfigArea" value="false"/>
+    <booleanAttribute key="useProduct" value="true"/>
 </launchConfiguration>

--- a/mylyn.tasks/connectors/bugzilla-rest/org.eclipse.mylyn.bugzilla.rest.core.tests/config/local-Single-BugzillaRestCoreTests.launch
+++ b/mylyn.tasks/connectors/bugzilla-rest/org.eclipse.mylyn.bugzilla.rest.core.tests/config/local-Single-BugzillaRestCoreTests.launch
@@ -1,43 +1,46 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <launchConfiguration type="org.eclipse.pde.ui.JunitLaunchConfig">
-<booleanAttribute key="append.args" value="true"/>
-<booleanAttribute key="askclear" value="false"/>
-<booleanAttribute key="automaticAdd" value="true"/>
-<booleanAttribute key="automaticValidate" value="false"/>
-<stringAttribute key="bootstrap" value=""/>
-<stringAttribute key="checked" value="[NONE]"/>
-<booleanAttribute key="clearConfig" value="true"/>
-<booleanAttribute key="clearws" value="true"/>
-<booleanAttribute key="clearwslog" value="false"/>
-<stringAttribute key="configLocation" value="${workspace_loc}/.metadata/.plugins/org.eclipse.pde.core/pde-junit"/>
-<booleanAttribute key="default" value="true"/>
-<booleanAttribute key="includeOptional" value="true"/>
-<stringAttribute key="location" value="${workspace_loc}/../junit-workspace"/>
-<listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_PATHS">
-<listEntry value="/org.eclipse.mylyn.bugzilla.rest.core.tests/src/org/eclipse/mylyn/internal/bugzilla/rest/core/tests/BugzillaRestClientTest.java"/>
-</listAttribute>
-<listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_TYPES">
-<listEntry value="1"/>
-</listAttribute>
-<stringAttribute key="org.eclipse.jdt.junit.CONTAINER" value=""/>
-<booleanAttribute key="org.eclipse.jdt.junit.KEEPRUNNING_ATTR" value="false"/>
-<stringAttribute key="org.eclipse.jdt.junit.TESTNAME" value=""/>
-<stringAttribute key="org.eclipse.jdt.junit.TEST_KIND" value="org.eclipse.jdt.junit.loader.junit4"/>
-<booleanAttribute key="org.eclipse.jdt.launching.ATTR_USE_START_ON_FIRST_THREAD" value="true"/>
-<stringAttribute key="org.eclipse.jdt.launching.JRE_CONTAINER" value="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.launching.macosx.MacOSXType/Java SE 17 [17.0.5]"/>
-<stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="org.eclipse.mylyn.internal.bugzilla.rest.core.tests.BugzillaRestClientTest"/>
-<stringAttribute key="org.eclipse.jdt.launching.PROGRAM_ARGUMENTS" value="-os ${target.os} -ws ${target.ws} -arch ${target.arch} -nl ${target.nl} -consoleLog -consolelog"/>
-<stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="org.eclipse.mylyn.bugzilla.rest.core.tests"/>
-<stringAttribute key="org.eclipse.jdt.launching.SOURCE_PATH_PROVIDER" value="org.eclipse.pde.ui.workbenchClasspathProvider"/>
-<stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="-Xms40m -Xmx256m -XX:MaxPermSize=128m&#10;-Dorg.eclipse.mylyn.tests.all=false&#10;-Dmylyn.tests.configuration.url=http://localhost:2080/bugzilla-rest-master"/>
-<stringAttribute key="pde.version" value="3.3"/>
-<stringAttribute key="product" value="org.eclipse.platform.ide"/>
-<booleanAttribute key="run_in_ui_thread" value="true"/>
-<booleanAttribute key="show_selected_only" value="false"/>
-<stringAttribute key="templateConfig" value="${target_home}/configuration/config.ini"/>
-<booleanAttribute key="tracing" value="false"/>
-<booleanAttribute key="useCustomFeatures" value="false"/>
-<booleanAttribute key="useDefaultConfig" value="true"/>
-<booleanAttribute key="useDefaultConfigArea" value="false"/>
-<booleanAttribute key="useProduct" value="true"/>
+    <booleanAttribute key="append.args" value="true"/>
+    <booleanAttribute key="askclear" value="false"/>
+    <booleanAttribute key="automaticAdd" value="true"/>
+    <booleanAttribute key="automaticValidate" value="false"/>
+    <stringAttribute key="bootstrap" value=""/>
+    <stringAttribute key="checked" value="[NONE]"/>
+    <booleanAttribute key="clearConfig" value="true"/>
+    <booleanAttribute key="clearws" value="true"/>
+    <booleanAttribute key="clearwslog" value="false"/>
+    <stringAttribute key="configLocation" value="${workspace_loc}/.metadata/.plugins/org.eclipse.pde.core/pde-junit"/>
+    <booleanAttribute key="default" value="true"/>
+    <booleanAttribute key="includeOptional" value="true"/>
+    <stringAttribute key="location" value="${workspace_loc}/../junit-workspace"/>
+    <booleanAttribute key="org.eclipse.debug.core.ATTR_FORCE_SYSTEM_CONSOLE_ENCODING" value="false"/>
+    <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_PATHS">
+        <listEntry value="/org.eclipse.mylyn.bugzilla.rest.core.tests/src/org/eclipse/mylyn/bugzilla/rest/core/tests/AllBugzillaRestCoreTests.java"/>
+    </listAttribute>
+    <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_TYPES">
+        <listEntry value="1"/>
+    </listAttribute>
+    <stringAttribute key="org.eclipse.jdt.junit.CONTAINER" value=""/>
+    <booleanAttribute key="org.eclipse.jdt.junit.KEEPRUNNING_ATTR" value="false"/>
+    <stringAttribute key="org.eclipse.jdt.junit.TESTNAME" value=""/>
+    <stringAttribute key="org.eclipse.jdt.junit.TEST_KIND" value="org.eclipse.jdt.junit.loader.junit4"/>
+    <booleanAttribute key="org.eclipse.jdt.launching.ATTR_ATTR_USE_ARGFILE" value="false"/>
+    <booleanAttribute key="org.eclipse.jdt.launching.ATTR_SHOW_CODEDETAILS_IN_EXCEPTION_MESSAGES" value="true"/>
+    <booleanAttribute key="org.eclipse.jdt.launching.ATTR_USE_START_ON_FIRST_THREAD" value="true"/>
+    <stringAttribute key="org.eclipse.jdt.launching.JRE_CONTAINER" value="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.launching.macosx.MacOSXType/OpenJDK 21.0.3 [21.0.3]"/>
+    <stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="org.eclipse.mylyn.bugzilla.rest.core.tests.AllBugzillaRestCoreTests"/>
+    <stringAttribute key="org.eclipse.jdt.launching.PROGRAM_ARGUMENTS" value="-os ${target.os} -ws ${target.ws} -arch ${target.arch} -nl ${target.nl} -consoleLog -consolelog"/>
+    <stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="org.eclipse.mylyn.bugzilla.rest.core.tests"/>
+    <stringAttribute key="org.eclipse.jdt.launching.SOURCE_PATH_PROVIDER" value="org.eclipse.pde.ui.workbenchClasspathProvider"/>
+    <stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="-Xms40m -Xmx256m&#10;-Dorg.eclipse.mylyn.tests.all=false"/>
+    <stringAttribute key="pde.version" value="3.3"/>
+    <stringAttribute key="product" value="org.eclipse.platform.ide"/>
+    <booleanAttribute key="run_in_ui_thread" value="true"/>
+    <booleanAttribute key="show_selected_only" value="false"/>
+    <stringAttribute key="templateConfig" value="${target_home}/configuration/config.ini"/>
+    <booleanAttribute key="tracing" value="false"/>
+    <booleanAttribute key="useCustomFeatures" value="false"/>
+    <booleanAttribute key="useDefaultConfig" value="true"/>
+    <booleanAttribute key="useDefaultConfigArea" value="false"/>
+    <booleanAttribute key="useProduct" value="true"/>
 </launchConfiguration>

--- a/mylyn.tasks/connectors/bugzilla-rest/org.eclipse.mylyn.bugzilla.rest.core.tests/src/org/eclipse/mylyn/bugzilla/rest/core/tests/BugzillaRestClientTest.java
+++ b/mylyn.tasks/connectors/bugzilla-rest/org.eclipse.mylyn.bugzilla.rest.core.tests/src/org/eclipse/mylyn/bugzilla/rest/core/tests/BugzillaRestClientTest.java
@@ -84,7 +84,6 @@ import org.eclipse.mylyn.tasks.core.data.TaskData;
 import org.eclipse.mylyn.tasks.core.data.TaskDataCollector;
 import org.eclipse.mylyn.tasks.core.data.TaskMapper;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -100,7 +99,6 @@ import com.google.gson.Gson;
 // Note: When there is no fixture with this property no tests get executed
 //@RunOnlyWhenProperty(property = "default", value = "1")
 
-@Ignore //FIXME: re-enable with https://github.com/eclipse-mylyn/org.eclipse.mylyn/issues/716
 public class BugzillaRestClientTest implements IFixtureJUnitClass {
 	private final BugzillaRestTestFixture actualFixture;
 

--- a/mylyn.tasks/connectors/bugzilla-rest/org.eclipse.mylyn.bugzilla.rest.core.tests/src/org/eclipse/mylyn/bugzilla/rest/core/tests/BugzillaRestConfigurationTest.java
+++ b/mylyn.tasks/connectors/bugzilla-rest/org.eclipse.mylyn.bugzilla.rest.core.tests/src/org/eclipse/mylyn/bugzilla/rest/core/tests/BugzillaRestConfigurationTest.java
@@ -36,7 +36,6 @@ import org.eclipse.mylyn.internal.tasks.core.TaskRepositoryManager;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -47,7 +46,7 @@ import com.google.gson.Gson;
 @RunWith(Junit4TestFixtureRunner.class)
 @FixtureDefinition(fixtureClass = BugzillaRestTestFixture.class, fixtureType = "bugzillaREST")
 //@RunOnlyWhenProperty(property = "default", value = "1")
-@Ignore //FIXME: re-enable with https://github.com/eclipse-mylyn/org.eclipse.mylyn/issues/716
+
 public class BugzillaRestConfigurationTest implements IFixtureJUnitClass {
 	private final BugzillaRestTestFixture actualFixture;
 

--- a/mylyn.tasks/connectors/bugzilla-rest/org.eclipse.mylyn.bugzilla.rest.core.tests/src/org/eclipse/mylyn/bugzilla/rest/core/tests/BugzillaRestConnectorTest.java
+++ b/mylyn.tasks/connectors/bugzilla-rest/org.eclipse.mylyn.bugzilla.rest.core.tests/src/org/eclipse/mylyn/bugzilla/rest/core/tests/BugzillaRestConnectorTest.java
@@ -47,7 +47,6 @@ import org.eclipse.mylyn.tasks.core.TaskRepository;
 import org.eclipse.mylyn.tasks.core.data.TaskAttributeMapper;
 import org.eclipse.mylyn.tasks.core.data.TaskData;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -57,7 +56,6 @@ import com.github.benmanes.caffeine.cache.Caffeine;
 @RunWith(Junit4TestFixtureRunner.class)
 @FixtureDefinition(fixtureClass = BugzillaRestTestFixture.class, fixtureType = "bugzillaREST")
 @SuppressWarnings({ "nls", "restriction" })
-@Ignore //FIXME: re-enable with https://github.com/eclipse-mylyn/org.eclipse.mylyn/issues/716
 public class BugzillaRestConnectorTest implements IFixtureJUnitClass {
 	private final BugzillaRestTestFixture actualFixture;
 	@Rule

--- a/mylyn.tasks/connectors/bugzilla-rest/org.eclipse.mylyn.bugzilla.rest.core.tests/src/org/eclipse/mylyn/bugzilla/rest/test/support/BugzillaRestTestFixture.java
+++ b/mylyn.tasks/connectors/bugzilla-rest/org.eclipse.mylyn.bugzilla.rest.core.tests/src/org/eclipse/mylyn/bugzilla/rest/test/support/BugzillaRestTestFixture.java
@@ -115,4 +115,9 @@ public class BugzillaRestTestFixture extends RepositoryTestFixture {
 		return new BugzillaRestHarness(this);
 	}
 
+	@Override
+	public String toString() {
+		// ignore
+		return getRepositoryUrl();
+	}
 }

--- a/mylyn.tasks/connectors/bugzilla/org.eclipse.mylyn.bugzilla.tests/src/org/eclipse/mylyn/bugzilla/tests/BugzillaAttachmentHandlerTest.java
+++ b/mylyn.tasks/connectors/bugzilla/org.eclipse.mylyn.bugzilla.tests/src/org/eclipse/mylyn/bugzilla/tests/BugzillaAttachmentHandlerTest.java
@@ -50,14 +50,12 @@ import org.eclipse.mylyn.tasks.core.data.TaskAttachmentMapper;
 import org.eclipse.mylyn.tasks.core.data.TaskAttribute;
 import org.eclipse.mylyn.tasks.core.data.TaskData;
 import org.eclipse.mylyn.tasks.ui.TasksUi;
-import org.junit.Ignore;
 
 /**
  * @author Robert Elves
  * @author Frank Becker
  */
 @SuppressWarnings("nls")
-@Ignore //FIXME: re-enable with https://github.com/eclipse-mylyn/org.eclipse.mylyn/issues/716
 public class BugzillaAttachmentHandlerTest extends AbstractBugzillaTest {
 
 	@SuppressWarnings("null")

--- a/mylyn.tasks/connectors/bugzilla/org.eclipse.mylyn.bugzilla.tests/src/org/eclipse/mylyn/bugzilla/tests/BugzillaRepositoryConnectorTest.java
+++ b/mylyn.tasks/connectors/bugzilla/org.eclipse.mylyn.bugzilla.tests/src/org/eclipse/mylyn/bugzilla/tests/BugzillaRepositoryConnectorTest.java
@@ -69,14 +69,12 @@ import org.eclipse.mylyn.tasks.core.data.TaskDataModel;
 import org.eclipse.mylyn.tasks.core.data.TaskOperation;
 import org.eclipse.mylyn.tasks.ui.TasksUi;
 import org.eclipse.mylyn.tasks.ui.TasksUiUtil;
-import org.junit.Ignore;
 
 /**
  * @author Rob Elves
  * @author Frank Becker
  */
 @SuppressWarnings("nls")
-@Ignore //FIXME: re-enable with https://github.com/eclipse-mylyn/org.eclipse.mylyn/issues/716
 public class BugzillaRepositoryConnectorTest extends AbstractBugzillaTest {
 
 	public void testSingleRetrievalFailure() throws CoreException {

--- a/mylyn.tasks/connectors/bugzilla/org.eclipse.mylyn.bugzilla.tests/src/org/eclipse/mylyn/bugzilla/tests/BugzillaSearchTest.java
+++ b/mylyn.tasks/connectors/bugzilla/org.eclipse.mylyn.bugzilla.tests/src/org/eclipse/mylyn/bugzilla/tests/BugzillaSearchTest.java
@@ -27,7 +27,6 @@ import org.eclipse.mylyn.tasks.core.TaskRepository;
 import org.eclipse.mylyn.tasks.core.data.TaskData;
 import org.eclipse.mylyn.tasks.core.data.TaskDataCollector;
 import org.eclipse.mylyn.tasks.ui.TasksUi;
-import org.junit.Ignore;
 
 import junit.framework.TestCase;
 
@@ -35,7 +34,6 @@ import junit.framework.TestCase;
  * @author Rob Elves
  */
 @SuppressWarnings("nls")
-@Ignore //FIXME: re-enable with https://github.com/eclipse-mylyn/org.eclipse.mylyn/issues/716
 public class BugzillaSearchTest extends TestCase {
 
 	private static final String QUERY_NAME = "Query Page Name";

--- a/mylyn.tasks/connectors/bugzilla/org.eclipse.mylyn.bugzilla.tests/src/org/eclipse/mylyn/bugzilla/tests/BugzillaTaskDataHandlerTest.java
+++ b/mylyn.tasks/connectors/bugzilla/org.eclipse.mylyn.bugzilla.tests/src/org/eclipse/mylyn/bugzilla/tests/BugzillaTaskDataHandlerTest.java
@@ -27,7 +27,6 @@ import org.eclipse.mylyn.tasks.core.data.AbstractTaskDataHandler;
 import org.eclipse.mylyn.tasks.core.data.TaskAttribute;
 import org.eclipse.mylyn.tasks.core.data.TaskAttributeMapper;
 import org.eclipse.mylyn.tasks.core.data.TaskData;
-import org.junit.Ignore;
 
 import junit.framework.TestCase;
 
@@ -36,7 +35,6 @@ import junit.framework.TestCase;
  * @author Rob Elves
  */
 @SuppressWarnings("nls")
-@Ignore //FIXME: re-enable with https://github.com/eclipse-mylyn/org.eclipse.mylyn/issues/716
 public class BugzillaTaskDataHandlerTest extends TestCase {
 
 	private TaskRepository repository;

--- a/mylyn.tasks/connectors/bugzilla/org.eclipse.mylyn.bugzilla.tests/src/org/eclipse/mylyn/bugzilla/tests/EncodingTest.java
+++ b/mylyn.tasks/connectors/bugzilla/org.eclipse.mylyn.bugzilla.tests/src/org/eclipse/mylyn/bugzilla/tests/EncodingTest.java
@@ -33,13 +33,11 @@ import org.eclipse.mylyn.tasks.core.data.TaskAttribute;
 import org.eclipse.mylyn.tasks.core.data.TaskData;
 import org.eclipse.mylyn.tasks.core.data.TaskDataModel;
 import org.eclipse.mylyn.tasks.ui.TasksUi;
-import org.junit.Ignore;
 
 /**
  * @author Mik Kersten
  */
 @SuppressWarnings("nls")
-@Ignore //FIXME: re-enable with https://github.com/eclipse-mylyn/org.eclipse.mylyn/issues/716
 public class EncodingTest extends AbstractBugzillaTest {
 
 	public void testEncodingSetting() {

--- a/mylyn.tasks/connectors/bugzilla/org.eclipse.mylyn.bugzilla.tests/src/org/eclipse/mylyn/bugzilla/tests/RepositoryReportFactoryTest.java
+++ b/mylyn.tasks/connectors/bugzilla/org.eclipse.mylyn.bugzilla.tests/src/org/eclipse/mylyn/bugzilla/tests/RepositoryReportFactoryTest.java
@@ -30,7 +30,6 @@ import org.eclipse.mylyn.tasks.core.TaskRepository;
 import org.eclipse.mylyn.tasks.core.data.TaskAttribute;
 import org.eclipse.mylyn.tasks.core.data.TaskData;
 import org.eclipse.mylyn.tasks.core.data.TaskMapper;
-import org.junit.Ignore;
 
 import junit.framework.TestCase;
 
@@ -39,7 +38,6 @@ import junit.framework.TestCase;
  * @author Mik Kersten
  */
 @SuppressWarnings("nls")
-@Ignore //FIXME: re-enable with https://github.com/eclipse-mylyn/org.eclipse.mylyn/issues/716
 public class RepositoryReportFactoryTest extends TestCase {
 
 	TaskRepository repository;

--- a/mylyn.tasks/connectors/bugzilla/org.eclipse.mylyn.bugzilla.tests/src/org/eclipse/mylyn/bugzilla/tests/core/BugzillaClientTest.java
+++ b/mylyn.tasks/connectors/bugzilla/org.eclipse.mylyn.bugzilla.tests/src/org/eclipse/mylyn/bugzilla/tests/core/BugzillaClientTest.java
@@ -44,7 +44,6 @@ import org.eclipse.mylyn.tasks.core.data.TaskAttributeMapper;
 import org.eclipse.mylyn.tasks.core.data.TaskData;
 import org.eclipse.mylyn.tasks.core.data.TaskDataCollector;
 import org.eclipse.mylyn.tests.util.UrlBuilder;
-import org.junit.Ignore;
 
 /**
  * @author Robert Elves
@@ -53,7 +52,6 @@ import org.junit.Ignore;
  * @author David Green
  */
 @SuppressWarnings("nls")
-@Ignore //FIXME: re-enable with https://github.com/eclipse-mylyn/org.eclipse.mylyn/issues/716
 public class BugzillaClientTest extends AbstractBugzillaTest {
 
 	public void testRDFProductConfig() throws Exception {

--- a/mylyn.tasks/connectors/bugzilla/org.eclipse.mylyn.bugzilla.tests/src/org/eclipse/mylyn/bugzilla/tests/core/BugzillaCustomFieldsTest.java
+++ b/mylyn.tasks/connectors/bugzilla/org.eclipse.mylyn.bugzilla.tests/src/org/eclipse/mylyn/bugzilla/tests/core/BugzillaCustomFieldsTest.java
@@ -48,7 +48,6 @@ import org.eclipse.mylyn.tasks.core.data.TaskAttributeMapper;
 import org.eclipse.mylyn.tasks.core.data.TaskData;
 import org.eclipse.mylyn.tasks.core.data.TaskDataCollector;
 import org.eclipse.mylyn.tasks.core.data.TaskMapper;
-import org.junit.Ignore;
 
 import junit.framework.TestCase;
 
@@ -59,7 +58,6 @@ import junit.framework.TestCase;
  * @author Robert Elves
  */
 @SuppressWarnings("nls")
-@Ignore //FIXME: re-enable with https://github.com/eclipse-mylyn/org.eclipse.mylyn/issues/716
 public class BugzillaCustomFieldsTest extends TestCase {
 
 	private TaskData fruitTaskData;

--- a/mylyn.tasks/connectors/bugzilla/org.eclipse.mylyn.bugzilla.tests/src/org/eclipse/mylyn/bugzilla/tests/core/BugzillaFlagsTest.java
+++ b/mylyn.tasks/connectors/bugzilla/org.eclipse.mylyn.bugzilla.tests/src/org/eclipse/mylyn/bugzilla/tests/core/BugzillaFlagsTest.java
@@ -25,7 +25,6 @@ import org.eclipse.mylyn.internal.bugzilla.core.BugzillaAttribute;
 import org.eclipse.mylyn.internal.bugzilla.core.BugzillaClient;
 import org.eclipse.mylyn.tasks.core.data.TaskAttribute;
 import org.eclipse.mylyn.tasks.core.data.TaskData;
-import org.junit.Ignore;
 
 import junit.framework.TestCase;
 
@@ -36,7 +35,6 @@ import junit.framework.TestCase;
  * @author Robert Elves
  */
 @SuppressWarnings("nls")
-@Ignore //FIXME: re-enable with https://github.com/eclipse-mylyn/org.eclipse.mylyn/issues/716
 public class BugzillaFlagsTest extends TestCase {
 
 	private BugzillaClient client;

--- a/mylyn.tasks/connectors/bugzilla/org.eclipse.mylyn.bugzilla.tests/src/org/eclipse/mylyn/bugzilla/tests/core/BugzillaRepositoryConnectorStandaloneTest.java
+++ b/mylyn.tasks/connectors/bugzilla/org.eclipse.mylyn.bugzilla.tests/src/org/eclipse/mylyn/bugzilla/tests/core/BugzillaRepositoryConnectorStandaloneTest.java
@@ -45,7 +45,6 @@ import org.eclipse.mylyn.tasks.core.data.TaskAttribute;
 import org.eclipse.mylyn.tasks.core.data.TaskAttributeMapper;
 import org.eclipse.mylyn.tasks.core.data.TaskData;
 import org.eclipse.mylyn.tasks.core.data.TaskDataCollector;
-import org.junit.Ignore;
 
 import junit.framework.TestCase;
 
@@ -57,7 +56,6 @@ import junit.framework.TestCase;
  * @author Frank Becker
  */
 @SuppressWarnings("nls")
-@Ignore //FIXME: re-enable with https://github.com/eclipse-mylyn/org.eclipse.mylyn/issues/716
 public class BugzillaRepositoryConnectorStandaloneTest extends TestCase {
 
 	private TaskRepository repository;

--- a/mylyn.tasks/connectors/bugzilla/org.eclipse.mylyn.bugzilla.tests/src/org/eclipse/mylyn/bugzilla/tests/core/BugzillaTaskCompletionTest.java
+++ b/mylyn.tasks/connectors/bugzilla/org.eclipse.mylyn.bugzilla.tests/src/org/eclipse/mylyn/bugzilla/tests/core/BugzillaTaskCompletionTest.java
@@ -27,7 +27,6 @@ import org.eclipse.mylyn.tasks.core.TaskRepository;
 import org.eclipse.mylyn.tasks.core.data.TaskAttribute;
 import org.eclipse.mylyn.tasks.core.data.TaskAttributeMapper;
 import org.eclipse.mylyn.tasks.core.data.TaskData;
-import org.junit.Ignore;
 
 import junit.framework.TestCase;
 
@@ -35,7 +34,6 @@ import junit.framework.TestCase;
  * @author Rob Elves
  */
 @SuppressWarnings("nls")
-@Ignore //FIXME: re-enable with https://github.com/eclipse-mylyn/org.eclipse.mylyn/issues/716
 public class BugzillaTaskCompletionTest extends TestCase {
 
 	private TaskRepository repository;

--- a/mylyn.tasks/connectors/bugzilla/org.eclipse.mylyn.bugzilla.tests/src/org/eclipse/mylyn/bugzilla/tests/core/BugzillaXmlRpcClientTest.java
+++ b/mylyn.tasks/connectors/bugzilla/org.eclipse.mylyn.bugzilla.tests/src/org/eclipse/mylyn/bugzilla/tests/core/BugzillaXmlRpcClientTest.java
@@ -50,7 +50,6 @@ import org.eclipse.mylyn.tasks.core.data.TaskData;
 import org.eclipse.mylyn.tasks.core.data.TaskDataCollector;
 import org.eclipse.mylyn.tasks.core.data.TaskDataModel;
 import org.eclipse.mylyn.tasks.core.sync.SubmitJob;
-import org.junit.Ignore;
 
 /**
  * Tests should be run against Bugzilla 3.6 or greater
@@ -58,7 +57,6 @@ import org.junit.Ignore;
  * @author Frank Becker
  */
 @SuppressWarnings("nls")
-@Ignore //FIXME: re-enable with https://github.com/eclipse-mylyn/org.eclipse.mylyn/issues/716
 public class BugzillaXmlRpcClientTest extends AbstractBugzillaTest {
 
 	private static final String BUGZILLA_LE_4_0 = "<4.0";

--- a/mylyn.tasks/connectors/bugzilla/org.eclipse.mylyn.bugzilla.tests/src/org/eclipse/mylyn/bugzilla/tests/ui/BugzillaRepositorySettingsPageTest.java
+++ b/mylyn.tasks/connectors/bugzilla/org.eclipse.mylyn.bugzilla.tests/src/org/eclipse/mylyn/bugzilla/tests/ui/BugzillaRepositorySettingsPageTest.java
@@ -37,7 +37,6 @@ import org.eclipse.mylyn.tasks.core.TaskRepository;
 import org.eclipse.mylyn.tasks.ui.TasksUi;
 import org.eclipse.mylyn.tests.util.TasksUiTestUtil;
 import org.eclipse.ui.PlatformUI;
-import org.junit.Ignore;
 
 import junit.framework.TestCase;
 
@@ -45,7 +44,6 @@ import junit.framework.TestCase;
  * @author Rob Elves
  */
 @SuppressWarnings("nls")
-@Ignore //FIXME: re-enable with https://github.com/eclipse-mylyn/org.eclipse.mylyn/issues/716
 public class BugzillaRepositorySettingsPageTest extends TestCase {
 
 	private TaskRepositoryManager manager;

--- a/mylyn.tasks/connectors/bugzilla/org.eclipse.mylyn.bugzilla.tests/src/org/eclipse/mylyn/bugzilla/tests/ui/BugzillaSearchPageTest.java
+++ b/mylyn.tasks/connectors/bugzilla/org.eclipse.mylyn.bugzilla.tests/src/org/eclipse/mylyn/bugzilla/tests/ui/BugzillaSearchPageTest.java
@@ -18,7 +18,6 @@ import org.eclipse.mylyn.bugzilla.tests.support.BugzillaFixture;
 import org.eclipse.mylyn.commons.workbench.WorkbenchUtil;
 import org.eclipse.mylyn.internal.bugzilla.ui.search.BugzillaSearchPage;
 import org.eclipse.mylyn.tasks.core.TaskRepository;
-import org.junit.Ignore;
 
 import junit.framework.TestCase;
 
@@ -28,7 +27,6 @@ import junit.framework.TestCase;
  * @author Jeff Pound
  * @author Steffen Pingel
  */
-@Ignore //FIXME: re-enable with https://github.com/eclipse-mylyn/org.eclipse.mylyn/issues/716
 public class BugzillaSearchPageTest extends TestCase {
 
 	private TaskRepository repository;

--- a/mylyn.tasks/connectors/bugzilla/org.eclipse.mylyn.bugzilla.tests/src/org/eclipse/mylyn/bugzilla/tests/ui/BugzillaTaskEditorTest.java
+++ b/mylyn.tasks/connectors/bugzilla/org.eclipse.mylyn.bugzilla.tests/src/org/eclipse/mylyn/bugzilla/tests/ui/BugzillaTaskEditorTest.java
@@ -26,7 +26,6 @@ import org.eclipse.mylyn.tasks.ui.editors.TaskEditor;
 import org.eclipse.mylyn.tests.util.TestFixture;
 import org.eclipse.ui.IWorkbenchPage;
 import org.eclipse.ui.PlatformUI;
-import org.junit.Ignore;
 
 import junit.framework.TestCase;
 
@@ -35,7 +34,6 @@ import junit.framework.TestCase;
  * @author Steffen Pingel
  */
 @SuppressWarnings("nls")
-@Ignore //FIXME: re-enable with https://github.com/eclipse-mylyn/org.eclipse.mylyn/issues/716
 public class BugzillaTaskEditorTest extends TestCase {
 
 	private TaskRepository repository;

--- a/org.eclipse.mylyn.releng/launcher/local-All-BugzillaRestClientTest.launch
+++ b/org.eclipse.mylyn.releng/launcher/local-All-BugzillaRestClientTest.launch
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<launchConfiguration type="org.eclipse.pde.ui.JunitLaunchConfig">
+    <booleanAttribute key="append.args" value="true"/>
+    <booleanAttribute key="askclear" value="false"/>
+    <booleanAttribute key="automaticAdd" value="true"/>
+    <booleanAttribute key="automaticValidate" value="false"/>
+    <stringAttribute key="bootstrap" value=""/>
+    <stringAttribute key="checked" value="[NONE]"/>
+    <booleanAttribute key="clearConfig" value="true"/>
+    <booleanAttribute key="clearws" value="true"/>
+    <booleanAttribute key="clearwslog" value="false"/>
+    <stringAttribute key="configLocation" value="${workspace_loc}/.metadata/.plugins/org.eclipse.pde.core/pde-junit"/>
+    <booleanAttribute key="default" value="true"/>
+    <booleanAttribute key="includeOptional" value="true"/>
+    <stringAttribute key="location" value="${workspace_loc}/../junit-workspace"/>
+    <booleanAttribute key="org.eclipse.debug.core.ATTR_FORCE_SYSTEM_CONSOLE_ENCODING" value="false"/>
+    <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_PATHS">
+        <listEntry value="/org.eclipse.mylyn.bugzilla.rest.core.tests/src/org/eclipse/mylyn/bugzilla/rest/core/tests/AllBugzillaRestCoreTests.java"/>
+    </listAttribute>
+    <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_TYPES">
+        <listEntry value="1"/>
+    </listAttribute>
+    <stringAttribute key="org.eclipse.jdt.junit.CONTAINER" value=""/>
+    <booleanAttribute key="org.eclipse.jdt.junit.KEEPRUNNING_ATTR" value="false"/>
+    <stringAttribute key="org.eclipse.jdt.junit.TESTNAME" value=""/>
+    <stringAttribute key="org.eclipse.jdt.junit.TEST_KIND" value="org.eclipse.jdt.junit.loader.junit4"/>
+    <booleanAttribute key="org.eclipse.jdt.launching.ATTR_ATTR_USE_ARGFILE" value="false"/>
+    <booleanAttribute key="org.eclipse.jdt.launching.ATTR_SHOW_CODEDETAILS_IN_EXCEPTION_MESSAGES" value="true"/>
+    <booleanAttribute key="org.eclipse.jdt.launching.ATTR_USE_START_ON_FIRST_THREAD" value="true"/>
+    <stringAttribute key="org.eclipse.jdt.launching.JRE_CONTAINER" value="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-21"/>
+    <stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="org.eclipse.mylyn.bugzilla.rest.core.tests.AllBugzillaRestCoreTests"/>
+    <stringAttribute key="org.eclipse.jdt.launching.PROGRAM_ARGUMENTS" value="-os ${target.os} -ws ${target.ws} -arch ${target.arch} -nl ${target.nl} -consoleLog"/>
+    <stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="org.eclipse.mylyn.bugzilla.rest.core.tests"/>
+    <stringAttribute key="org.eclipse.jdt.launching.SOURCE_PATH_PROVIDER" value="org.eclipse.pde.ui.workbenchClasspathProvider"/>
+    <stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="-Dorg.eclipse.swt.graphics.Resource.reportNonDisposed=true&#10;-Dorg.eclipse.mylyn.ci.server.tests=true&#10;-Dorg.eclipse.mylyn.tests.all=true&#10;-Dmylyn.tests.configuration.url1=https://mylyn.local/bugzilla-5_2-rest/"/>
+    <stringAttribute key="pde.version" value="3.3"/>
+    <stringAttribute key="product" value="org.eclipse.sdk.ide"/>
+    <booleanAttribute key="run_in_ui_thread" value="true"/>
+    <booleanAttribute key="show_selected_only" value="false"/>
+    <booleanAttribute key="tracing" value="false"/>
+    <booleanAttribute key="useCustomFeatures" value="false"/>
+    <booleanAttribute key="useDefaultConfig" value="true"/>
+    <booleanAttribute key="useDefaultConfigArea" value="false"/>
+    <booleanAttribute key="useProduct" value="true"/>
+</launchConfiguration>

--- a/org.eclipse.mylyn.releng/launcher/local-All-GitlabRestClientTest.launch
+++ b/org.eclipse.mylyn.releng/launcher/local-All-GitlabRestClientTest.launch
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<launchConfiguration type="org.eclipse.pde.ui.JunitLaunchConfig">
+    <booleanAttribute key="append.args" value="true"/>
+    <booleanAttribute key="askclear" value="false"/>
+    <booleanAttribute key="automaticAdd" value="true"/>
+    <booleanAttribute key="automaticValidate" value="false"/>
+    <stringAttribute key="bootstrap" value=""/>
+    <stringAttribute key="checked" value="[NONE]"/>
+    <booleanAttribute key="clearConfig" value="true"/>
+    <booleanAttribute key="clearws" value="true"/>
+    <booleanAttribute key="clearwslog" value="false"/>
+    <stringAttribute key="configLocation" value="${workspace_loc}/.metadata/.plugins/org.eclipse.pde.core/pde-junit"/>
+    <booleanAttribute key="default" value="true"/>
+    <booleanAttribute key="includeOptional" value="true"/>
+    <stringAttribute key="location" value="${workspace_loc}/../junit-workspace"/>
+    <booleanAttribute key="org.eclipse.debug.core.ATTR_FORCE_SYSTEM_CONSOLE_ENCODING" value="false"/>
+    <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_PATHS">
+        <listEntry value="/org.eclipse.mylyn.gitlab.core.test/src/org/eclipse/mylyn/gitlab/core/test/RestfulGitlabClientTest.java"/>
+    </listAttribute>
+    <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_TYPES">
+        <listEntry value="1"/>
+    </listAttribute>
+    <stringAttribute key="org.eclipse.jdt.junit.CONTAINER" value=""/>
+    <booleanAttribute key="org.eclipse.jdt.junit.KEEPRUNNING_ATTR" value="false"/>
+    <stringAttribute key="org.eclipse.jdt.junit.TESTNAME" value=""/>
+    <stringAttribute key="org.eclipse.jdt.junit.TEST_KIND" value="org.eclipse.jdt.junit.loader.junit5"/>
+    <booleanAttribute key="org.eclipse.jdt.launching.ATTR_ATTR_USE_ARGFILE" value="false"/>
+    <booleanAttribute key="org.eclipse.jdt.launching.ATTR_SHOW_CODEDETAILS_IN_EXCEPTION_MESSAGES" value="true"/>
+    <booleanAttribute key="org.eclipse.jdt.launching.ATTR_USE_START_ON_FIRST_THREAD" value="true"/>
+    <stringAttribute key="org.eclipse.jdt.launching.JRE_CONTAINER" value="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-21"/>
+    <stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="org.eclipse.mylyn.gitlab.core.test.RestfulGitlabClientTest"/>
+    <stringAttribute key="org.eclipse.jdt.launching.PROGRAM_ARGUMENTS" value="-os ${target.os} -ws ${target.ws} -arch ${target.arch} -nl ${target.nl} -consoleLog"/>
+    <stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="org.eclipse.mylyn.gitlab.core.test"/>
+    <stringAttribute key="org.eclipse.jdt.launching.SOURCE_PATH_PROVIDER" value="org.eclipse.pde.ui.workbenchClasspathProvider"/>
+    <stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="-Dorg.eclipse.swt.graphics.Resource.reportNonDisposed=true&#10;-Dorg.eclipse.mylyn.tests.all=true"/>
+    <stringAttribute key="pde.version" value="3.3"/>
+    <stringAttribute key="product" value="org.eclipse.sdk.ide"/>
+    <booleanAttribute key="run_in_ui_thread" value="true"/>
+    <booleanAttribute key="show_selected_only" value="false"/>
+    <booleanAttribute key="tracing" value="false"/>
+    <booleanAttribute key="useCustomFeatures" value="false"/>
+    <booleanAttribute key="useDefaultConfig" value="true"/>
+    <booleanAttribute key="useDefaultConfigArea" value="false"/>
+    <booleanAttribute key="useProduct" value="true"/>
+</launchConfiguration>

--- a/org.eclipse.mylyn.releng/launcher/local-All-JenkinsTests.launch
+++ b/org.eclipse.mylyn.releng/launcher/local-All-JenkinsTests.launch
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<launchConfiguration type="org.eclipse.pde.ui.JunitLaunchConfig">
+    <booleanAttribute key="append.args" value="true"/>
+    <booleanAttribute key="askclear" value="false"/>
+    <booleanAttribute key="automaticAdd" value="true"/>
+    <booleanAttribute key="automaticValidate" value="false"/>
+    <stringAttribute key="bootstrap" value=""/>
+    <stringAttribute key="checked" value="[NONE]"/>
+    <booleanAttribute key="clearConfig" value="true"/>
+    <booleanAttribute key="clearws" value="true"/>
+    <booleanAttribute key="clearwslog" value="false"/>
+    <stringAttribute key="configLocation" value="${workspace_loc}/.metadata/.plugins/org.eclipse.pde.core/pde-junit"/>
+    <booleanAttribute key="default" value="true"/>
+    <booleanAttribute key="includeOptional" value="true"/>
+    <stringAttribute key="location" value="${workspace_loc}/../junit-workspace"/>
+    <booleanAttribute key="org.eclipse.debug.core.ATTR_FORCE_SYSTEM_CONSOLE_ENCODING" value="false"/>
+    <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_PATHS">
+        <listEntry value="/org.eclipse.mylyn.jenkins.tests/src/org/eclipse/mylyn/jenkins/tests/AllJenkinsTests.java"/>
+    </listAttribute>
+    <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_TYPES">
+        <listEntry value="1"/>
+    </listAttribute>
+    <stringAttribute key="org.eclipse.jdt.junit.CONTAINER" value=""/>
+    <booleanAttribute key="org.eclipse.jdt.junit.KEEPRUNNING_ATTR" value="false"/>
+    <stringAttribute key="org.eclipse.jdt.junit.TESTNAME" value=""/>
+    <stringAttribute key="org.eclipse.jdt.junit.TEST_KIND" value="org.eclipse.jdt.junit.loader.junit4"/>
+    <booleanAttribute key="org.eclipse.jdt.launching.ATTR_ATTR_USE_ARGFILE" value="false"/>
+    <booleanAttribute key="org.eclipse.jdt.launching.ATTR_SHOW_CODEDETAILS_IN_EXCEPTION_MESSAGES" value="true"/>
+    <booleanAttribute key="org.eclipse.jdt.launching.ATTR_USE_START_ON_FIRST_THREAD" value="true"/>
+    <stringAttribute key="org.eclipse.jdt.launching.JRE_CONTAINER" value="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-21"/>
+    <stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="org.eclipse.mylyn.jenkins.tests.AllJenkinsTests"/>
+    <stringAttribute key="org.eclipse.jdt.launching.PROGRAM_ARGUMENTS" value="-os ${target.os} -ws ${target.ws} -arch ${target.arch} -nl ${target.nl} -consoleLog"/>
+    <stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="org.eclipse.mylyn.jenkins.tests"/>
+    <stringAttribute key="org.eclipse.jdt.launching.SOURCE_PATH_PROVIDER" value="org.eclipse.pde.ui.workbenchClasspathProvider"/>
+    <stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="-Dorg.eclipse.swt.graphics.Resource.reportNonDisposed=true&#10;-Dorg.eclipse.mylyn.tests.all=true"/>
+    <stringAttribute key="pde.version" value="3.3"/>
+    <stringAttribute key="product" value="org.eclipse.sdk.ide"/>
+    <booleanAttribute key="run_in_ui_thread" value="true"/>
+    <booleanAttribute key="show_selected_only" value="false"/>
+    <booleanAttribute key="tracing" value="false"/>
+    <booleanAttribute key="useCustomFeatures" value="false"/>
+    <booleanAttribute key="useDefaultConfig" value="true"/>
+    <booleanAttribute key="useDefaultConfigArea" value="false"/>
+    <booleanAttribute key="useProduct" value="true"/>
+</launchConfiguration>

--- a/org.eclipse.mylyn.releng/launcher/local-All-internal-GitlabRestClientTest.launch
+++ b/org.eclipse.mylyn.releng/launcher/local-All-internal-GitlabRestClientTest.launch
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<launchConfiguration type="org.eclipse.pde.ui.JunitLaunchConfig">
+    <booleanAttribute key="append.args" value="true"/>
+    <booleanAttribute key="askclear" value="false"/>
+    <booleanAttribute key="automaticAdd" value="true"/>
+    <booleanAttribute key="automaticValidate" value="false"/>
+    <stringAttribute key="bootstrap" value=""/>
+    <stringAttribute key="checked" value="[NONE]"/>
+    <booleanAttribute key="clearConfig" value="true"/>
+    <booleanAttribute key="clearws" value="true"/>
+    <booleanAttribute key="clearwslog" value="false"/>
+    <stringAttribute key="configLocation" value="${workspace_loc}/.metadata/.plugins/org.eclipse.pde.core/pde-junit"/>
+    <booleanAttribute key="default" value="true"/>
+    <booleanAttribute key="includeOptional" value="true"/>
+    <stringAttribute key="location" value="${workspace_loc}/../junit-workspace"/>
+    <booleanAttribute key="org.eclipse.debug.core.ATTR_FORCE_SYSTEM_CONSOLE_ENCODING" value="false"/>
+    <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_PATHS">
+        <listEntry value="/org.eclipse.mylyn.gitlab.core.test/src/org/eclipse/mylyn/internal/gitlab/core/GitlabRestClientTest.java"/>
+    </listAttribute>
+    <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_TYPES">
+        <listEntry value="1"/>
+    </listAttribute>
+    <stringAttribute key="org.eclipse.jdt.junit.CONTAINER" value=""/>
+    <booleanAttribute key="org.eclipse.jdt.junit.KEEPRUNNING_ATTR" value="false"/>
+    <stringAttribute key="org.eclipse.jdt.junit.TESTNAME" value=""/>
+    <stringAttribute key="org.eclipse.jdt.junit.TEST_KIND" value="org.eclipse.jdt.junit.loader.junit5"/>
+    <booleanAttribute key="org.eclipse.jdt.launching.ATTR_ATTR_USE_ARGFILE" value="false"/>
+    <booleanAttribute key="org.eclipse.jdt.launching.ATTR_SHOW_CODEDETAILS_IN_EXCEPTION_MESSAGES" value="true"/>
+    <booleanAttribute key="org.eclipse.jdt.launching.ATTR_USE_START_ON_FIRST_THREAD" value="true"/>
+    <stringAttribute key="org.eclipse.jdt.launching.JRE_CONTAINER" value="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-21"/>
+    <stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="org.eclipse.mylyn.internal.gitlab.core.GitlabRestClientTest"/>
+    <stringAttribute key="org.eclipse.jdt.launching.PROGRAM_ARGUMENTS" value="-os ${target.os} -ws ${target.ws} -arch ${target.arch} -nl ${target.nl} -consoleLog"/>
+    <stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="org.eclipse.mylyn.gitlab.core.test"/>
+    <stringAttribute key="org.eclipse.jdt.launching.SOURCE_PATH_PROVIDER" value="org.eclipse.pde.ui.workbenchClasspathProvider"/>
+    <stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="-Dorg.eclipse.swt.graphics.Resource.reportNonDisposed=true&#10;-Dorg.eclipse.mylyn.tests.all=true"/>
+    <stringAttribute key="pde.version" value="3.3"/>
+    <stringAttribute key="product" value="org.eclipse.sdk.ide"/>
+    <booleanAttribute key="run_in_ui_thread" value="true"/>
+    <booleanAttribute key="show_selected_only" value="false"/>
+    <booleanAttribute key="tracing" value="false"/>
+    <booleanAttribute key="useCustomFeatures" value="false"/>
+    <booleanAttribute key="useDefaultConfig" value="true"/>
+    <booleanAttribute key="useDefaultConfigArea" value="false"/>
+    <booleanAttribute key="useProduct" value="true"/>
+</launchConfiguration>


### PR DESCRIPTION
I real the CI Server Test after doing some small updates to the mylyn.frank-becker.de test server.
If you want to temporarily disable CI Server Tests change the system Property mylyn.test.server.ci from https://mylyn.frank-becker.de to some other value. See see org.eclipse.mylyn.commons.sdk.util.CommonTestUtil.runOnCIServerTestsOnly().