### PR TITLE
Use 4.38-I-builds because all 4.37-I-builds are deleted

### DIFF
--- a/org.eclipse.mylyn-target/org.eclipse.mylyn.target.target
+++ b/org.eclipse.mylyn-target/org.eclipse.mylyn.target.target
@@ -20,7 +20,7 @@
 			<unit id="org.eclipse.license.feature.group" version="0.0.0"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<repository location="https://download.eclipse.org/eclipse/updates/4.37-I-builds/I20250828-0630/"/>
+			<repository location="https://download.eclipse.org/eclipse/updates/4.38-I-builds/"/>
 			<unit id="org.eclipse.equinox.sdk.feature.group" version="0.0.0"/>
 			<unit id="org.eclipse.equinox.p2.sdk.feature.group" version="0.0.0"/>
 			<unit id="org.eclipse.sdk.feature.group" version="0.0.0"/>


### PR DESCRIPTION
https://github.com/eclipse-mylyn/org.eclipse.mylyn/issues/868