### PR TITLE
Use version ranges rather than versions in the target platform

### DIFF
--- a/org.eclipse.mylyn-target/org.eclipse.mylyn.target.target
+++ b/org.eclipse.mylyn-target/org.eclipse.mylyn.target.target
@@ -74,18 +74,18 @@
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 			<repository location="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/2025-12/"/>
-			<unit id="junit-jupiter-api" version="5.14.0"/>
-			<unit id="junit-jupiter-engine" version="5.14.0"/>
-			<unit id="junit-jupiter-migrationsupport" version="5.14.0"/>
-			<unit id="junit-jupiter-params" version="5.14.0"/>
-			<unit id="junit-platform-commons" version="1.14.0"/>
-			<unit id="junit-platform-engine" version="1.14.0"/>
-			<unit id="junit-platform-launcher" version="1.14.0"/>
-			<unit id="junit-platform-runner" version="1.14.0"/>
-			<unit id="junit-platform-suite-api" version="1.14.0"/>
-			<unit id="junit-platform-suite-engine" version="1.14.0"/>
-			<unit id="junit-platform-suite-commons" version="1.14.0"/>
-			<unit id="junit-vintage-engine" version="5.14.0"/>
+			<unit id="junit-jupiter-api" version="[5.14.0,6.0.0)"/>
+			<unit id="junit-jupiter-engine" version="[5.14.0,6.0.0)"/>
+			<unit id="junit-jupiter-migrationsupport" version="[5.14.0,6.0.0)"/>
+			<unit id="junit-jupiter-params" version="[5.14.0,6.0.0)"/>
+			<unit id="junit-platform-commons" version="[1.14.0,2.0.0)"/>
+			<unit id="junit-platform-engine" version="[1.14.0,2.0.0)"/>
+			<unit id="junit-platform-launcher" version="[1.14.0,2.0.0)"/>
+			<unit id="junit-platform-runner" version="[1.14.0,2.0.0)"/>
+			<unit id="junit-platform-suite-api" version="[1.14.0,2.0.0)"/>
+			<unit id="junit-platform-suite-engine" version="[1.14.0,2.0.0)"/>
+			<unit id="junit-platform-suite-commons" version="[1.14.0,2.0.0)"/>
+			<unit id="junit-vintage-engine" version="[5.14.0,6.0.0)"/>
 			<unit id="org.glassfish.hk2.osgi-resource-locator" version="0.0.0"/>
 			<unit id="org.apache.commons.lang3" version="0.0.0"/>
 			<unit id="org.apache.commons.logging" version="0.0.0"/>


### PR DESCRIPTION
- This ensure that when there are updates to dependencies, particularly the Orbit dependencies, that the target platform remains valid and the build continues to work.