### PR TITLE
Use org.apache.tika 3.x

### DIFF
--- a/mylyn.tasks/org.eclipse.mylyn.tasks.ui/META-INF/MANIFEST.MF
+++ b/mylyn.tasks/org.eclipse.mylyn.tasks.ui/META-INF/MANIFEST.MF
@@ -76,7 +76,7 @@ Import-Package: com.ibm.icu.text,
  org.apache.commons.lang3;version="3.13.0",
  org.apache.commons.lang3.reflect;version="3.13.0",
  org.apache.commons.logging;version="[1.0.4,2.0.0)",
- org.apache.tika.mime;version="[2.9.0,3.0.0)",
+ org.apache.tika.mime;version="[3.0.0,4.0.0)",
  org.osgi.service.event;version="[1.4.0,2.0.0)"
 Service-Component: OSGI-INF/org.eclipse.mylyn.internal.tasks.ui.TaskUiStartup.xml
 Require-Capability: eclipse.swt;filter:="(image.format=svg)"


### PR DESCRIPTION
- The 2.x version has a CVE and is removed from Orbit.