### PR TITLE
Quick hack for better colors with Dark Theme #44

### DIFF
--- a/mylyn.context/org.eclipse.mylyn.context.ui/src/org/eclipse/mylyn/context/ui/ContextUi.java
+++ b/mylyn.context/org.eclipse.mylyn.context.ui/src/org/eclipse/mylyn/context/ui/ContextUi.java
@@ -51,7 +51,7 @@ public final class ContextUi {
 		} else if (node.getInterest().isInteresting()) {
 			return null;
 		}
-		return ColorMap.GRAY_MEDIUM;
+		return ColorMap.GRAY_LIGHT;
 	}
 
 	public static boolean isEditorAutoCloseEnabled() {

--- a/mylyn.context/org.eclipse.mylyn.context.ui/src/org/eclipse/mylyn/internal/context/ui/ColorMap.java
+++ b/mylyn.context/org.eclipse.mylyn.context.ui/src/org/eclipse/mylyn/internal/context/ui/ColorMap.java
@@ -21,66 +21,19 @@ import org.eclipse.swt.widgets.Display;
 public class ColorMap {
 
 	// TODO: use themes?
-	public static final Color LANDMARK = new Color(Display.getDefault(), 36, 22, 50);
-
-	public static final Color BACKGROUND_COLOR = new Color(Display.getDefault(), 255, 255, 255);
-
-	public static final Color DEFAULT = null;//Display.getCurrent().getSystemColor(SWT.COLOR_WIDGET_BACKGROUND);//new Color(Display.getDefault(), 255, 255, 255);
-
-	public static final Color GRAY_DARK = new Color(Display.getDefault(), 70, 70, 70);
+	public static final Color LANDMARK = new Color(Display.getDefault(), 80, 140, 200);
 
 	public static final Color GRAY_MEDIUM = new Color(Display.getDefault(), 105, 105, 105);
 
 	public static final Color GRAY_LIGHT = new Color(Display.getDefault(), 145, 145, 145);
 
-	public static final Color GRAY_VERY_LIGHT = new Color(Display.getDefault(), 200, 200, 200);
-
-	public static final Color RELATIONSHIP = new Color(Display.getDefault(), 32, 104, 157);
-
-	// FIXME 3.9 rename to HIGHLIGHTER_RED_INTERSECTION
-	public static final Color HIGLIGHTER_RED_INTERSECTION = new Color(Display.getDefault(), 200, 0, 0);
-
-	public static final Color HIGHLIGHTER_ORANGE_GRADIENT = new Color(Display.getDefault(), 222, 137, 71);
-
-	public static final Color HIGLIGHTER_BLUE_GRADIENT = new Color(Display.getDefault(), 81, 158, 235);
-
-	public static final Color HIGHLIGHTER_YELLOW = new Color(Display.getDefault(), 255, 238, 99);
-
-	public static final Color PANTONE_PASTEL_YELLOW = new Color(Display.getDefault(), 244, 238, 175);
-
-	public static final Color PANTONE_PASTEL_ROSE = new Color(Display.getDefault(), 254, 179, 190);
-
-	public static final Color PANTONE_PASTEL_MAUVE = new Color(Display.getDefault(), 241, 183, 216);
-
-	public static final Color PANTONE_PASTEL_PURPLE = new Color(Display.getDefault(), 202, 169, 222);
-
-	public static final Color PANTONE_PASTEL_BLUE = new Color(Display.getDefault(), 120, 160, 250);
-
-	public static final Color PANTONE_PASTERL_GREEN = new Color(Display.getDefault(), 162, 231, 215);
-
-	public static final Color COLOR_WHITE = new Color(Display.getCurrent(), 255, 255, 255);
-
-	public static final Color COLOR_BLACK = new Color(Display.getCurrent(), 0, 0, 0);
+	public static final Color RELATIONSHIP = new Color(Display.getDefault(), 0, 254, 0);
 
 	public void dispose() {
 		LANDMARK.dispose();
-		BACKGROUND_COLOR.dispose();
-		GRAY_DARK.dispose();
-		GRAY_MEDIUM.dispose();
 		GRAY_LIGHT.dispose();
-		GRAY_VERY_LIGHT.dispose();
+		GRAY_MEDIUM.dispose();
 		RELATIONSHIP.dispose();
-		HIGLIGHTER_RED_INTERSECTION.dispose();
-		HIGHLIGHTER_ORANGE_GRADIENT.dispose();
-		HIGHLIGHTER_YELLOW.dispose();
-		PANTONE_PASTERL_GREEN.dispose();
-		PANTONE_PASTEL_BLUE.dispose();
-		PANTONE_PASTEL_MAUVE.dispose();
-		PANTONE_PASTEL_PURPLE.dispose();
-		PANTONE_PASTEL_ROSE.dispose();
-		PANTONE_PASTEL_YELLOW.dispose();
-		COLOR_WHITE.dispose();
-		COLOR_BLACK.dispose();
 
 		// below disposed by registry
 		// DEFAULT.dispose();


### PR DESCRIPTION
Tweak the colours used by Mylyn in the package explorer and search view to make them more readable when using the Eclipse Dark Theme.

I'm partially colour blind (red/green) so the values should be taken with a grain of salt, but to me it makes the text so much easier to read:

<table>
  <thead>
    <tr>
      <th colspan="3">Package Explorer</th>
    </tr>
    <tr>
      <th>Current</th>
      <th>New</th>
      <th>New</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td><img width="619" height="494" alt="Screenshot 2026-03-05 002253" src="https://github.com/user-attachments/assets/0fd2e60d-2c50-440a-a64c-cdfb80410af0" /></td>
      <td><img width="566" height="426" alt="Screenshot 2026-03-05 002048" src="https://github.com/user-attachments/assets/56a796d0-397d-4a48-aead-fd5d99f4ffc1" /></td>
      <td><img width="543" height="377" alt="Screenshot 2026-03-05 001955" src="https://github.com/user-attachments/assets/37f370d2-c92a-4ae9-a202-c512369623af" /> </td>
    </tr>
  </tbody>
</table>

<table>
  <thead>
    <tr>
      <th colspan="2">Search View</th>
    </tr>
    <tr>
      <th>Current</th>
      <th>New</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td><img width="459" height="237" alt="Screenshot 2026-03-05 002329" src="https://github.com/user-attachments/assets/a04be0df-cb1d-4adf-b8d4-bf51f8154e6b" /></td>
      <td><img width="530" height="248" alt="Screenshot 2026-03-05 002345" src="https://github.com/user-attachments/assets/e49a49de-0195-4dac-990b-c48f0624c9a8" /></td>
  </tbody>
</table>


Task-Url: https://github.com/eclipse-mylyn/org.eclipse.mylyn/issues/44