### PR TITLE
DatePicker UI #1039

### DIFF
--- a/mylyn.commons/org.eclipse.mylyn.commons.ui/src/org/eclipse/mylyn/commons/ui/FontUtils.java
+++ b/mylyn.commons/org.eclipse.mylyn.commons.ui/src/org/eclipse/mylyn/commons/ui/FontUtils.java
@@ -1,0 +1,59 @@
+/*******************************************************************************
+ * Copyright (c) 2026 George Lindholm
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html.
+ *
+ * Contributors:
+ *      See git history
+ *******************************************************************************/
+
+package org.eclipse.mylyn.commons.ui;
+
+import org.eclipse.swt.graphics.FontMetrics;
+import org.eclipse.swt.graphics.GC;
+import org.eclipse.swt.graphics.Point;
+import org.eclipse.swt.widgets.Control;
+
+/**
+ * Some utility methods for working with fonts.
+ * 
+ * @since 4.11
+ */
+public class FontUtils {
+	private static final Point POINT_ZERO = new Point(0, 0);
+
+	/**
+	 * Returns the font metrics for the font of the given control.
+	 *
+	 * @param control
+	 * @return
+	 */
+	public static FontMetrics getFontMetrics(final Control control) {
+		final GC gc = new GC(control);
+		try {
+			return gc.getFontMetrics();
+		} finally {
+			gc.dispose();
+		}
+	}
+
+	/**
+	 * Returns the pixel width and height of the given string when rendered in the font of the given control.
+	 * @param control
+	 * @param string
+	 * @return
+	 */
+	public static Point getStringPixels(final Control control, final String string) {
+		final GC gc = new GC(control);
+		try {
+			if (string == null || string.isEmpty()) {
+				return POINT_ZERO;
+			}
+			return gc.stringExtent(string);
+		} finally {
+			gc.dispose();
+		}
+	}
+}

--- a/mylyn.commons/org.eclipse.mylyn.commons.ui/src/org/eclipse/mylyn/internal/commons/ui/FontUtils.java
+++ b/mylyn.commons/org.eclipse.mylyn.commons.ui/src/org/eclipse/mylyn/internal/commons/ui/FontUtils.java
@@ -1,0 +1,59 @@
+/*******************************************************************************
+ * Copyright (c) 2026 George Lindholm
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html.
+ *
+ * Contributors:
+ *      See git history
+ *******************************************************************************/
+
+package org.eclipse.mylyn.internal.commons.ui;
+
+import org.eclipse.swt.graphics.FontMetrics;
+import org.eclipse.swt.graphics.GC;
+import org.eclipse.swt.graphics.Point;
+import org.eclipse.swt.widgets.Control;
+
+/**
+ * Some utility methods for working with fonts.
+ * 
+ * @since 4.11
+ */
+public class FontUtils {
+	private static final Point POINT_ZERO = new Point(0, 0);
+
+	/**
+	 * Returns the font metrics for the font of the given control.
+	 *
+	 * @param control
+	 * @return
+	 */
+	public static FontMetrics getFontMetrics(final Control control) {
+		final GC gc = new GC(control);
+		try {
+			return gc.getFontMetrics();
+		} finally {
+			gc.dispose();
+		}
+	}
+
+	/**
+	 * Returns the pixel width and height of the given string when rendered in the font of the given control.
+	 * @param control
+	 * @param string
+	 * @return
+	 */
+	public static Point getStringPixels(final Control control, final String string) {
+		final GC gc = new GC(control);
+		try {
+			if (string == null || string.isEmpty()) {
+				return POINT_ZERO;
+			}
+			return gc.stringExtent(string);
+		} finally {
+			gc.dispose();
+		}
+	}
+}

--- a/mylyn.commons/org.eclipse.mylyn.commons.workbench/src/org/eclipse/mylyn/commons/workbench/forms/DatePicker.java
+++ b/mylyn.commons/org.eclipse.mylyn.commons.workbench/src/org/eclipse/mylyn/commons/workbench/forms/DatePicker.java
@@ -8,6 +8,7 @@
  * SPDX-License-Identifier: EPL-2.0
  *
  *     Tasktop Technologies - initial API and implementation
+ *     See git history
  *******************************************************************************/
 
 package org.eclipse.mylyn.commons.workbench.forms;
@@ -22,6 +23,7 @@ import java.util.List;
 
 import org.eclipse.jface.window.Window;
 import org.eclipse.mylyn.commons.ui.CommonImages;
+import org.eclipse.mylyn.internal.commons.ui.FontUtils;
 import org.eclipse.mylyn.internal.commons.workbench.Messages;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.FocusAdapter;
@@ -104,10 +106,8 @@ public class DatePicker extends Composite {
 		setLayout(gridLayout);
 
 		dateText = new Text(this, style);
-		GridData dateTextGridData = new GridData(SWT.FILL, SWT.FILL, false, false);
-		dateTextGridData.heightHint = 5;
-		dateTextGridData.grabExcessHorizontalSpace = true;
-		dateTextGridData.verticalAlignment = SWT.FILL;
+		GridData dateTextGridData = new GridData(SWT.FILL, SWT.CENTER, true, false);
+		dateTextGridData.widthHint = FontUtils.getStringPixels(dateText, Messages.DatePicker_Sample_Due_Date).x + 5;
 
 		dateText.setLayoutData(dateTextGridData);
 		dateText.setText(initialText);
@@ -186,8 +186,8 @@ public class DatePicker extends Composite {
 				dialog.open();
 			}
 		});
+
 		updateClearControlVisibility();
-		pack();
 		setBackground(getDisplay().getSystemColor(SWT.COLOR_LIST_BACKGROUND));
 	}
 
@@ -316,5 +316,4 @@ public class DatePicker extends Composite {
 		clearControl.setEnabled(enabled);
 		super.setEnabled(enabled);
 	}
-
 }

--- a/mylyn.commons/org.eclipse.mylyn.commons.workbench/src/org/eclipse/mylyn/commons/workbench/forms/DatePicker.java
+++ b/mylyn.commons/org.eclipse.mylyn.commons.workbench/src/org/eclipse/mylyn/commons/workbench/forms/DatePicker.java
@@ -8,6 +8,7 @@
  * SPDX-License-Identifier: EPL-2.0
  *
  *     Tasktop Technologies - initial API and implementation
+ *     See git history
  *******************************************************************************/
 
 package org.eclipse.mylyn.commons.workbench.forms;
@@ -22,6 +23,7 @@ import java.util.List;
 
 import org.eclipse.jface.window.Window;
 import org.eclipse.mylyn.commons.ui.CommonImages;
+import org.eclipse.mylyn.commons.ui.FontUtils;
 import org.eclipse.mylyn.internal.commons.workbench.Messages;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.FocusAdapter;
@@ -104,10 +106,8 @@ public class DatePicker extends Composite {
 		setLayout(gridLayout);
 
 		dateText = new Text(this, style);
-		GridData dateTextGridData = new GridData(SWT.FILL, SWT.FILL, false, false);
-		dateTextGridData.heightHint = 5;
-		dateTextGridData.grabExcessHorizontalSpace = true;
-		dateTextGridData.verticalAlignment = SWT.FILL;
+		GridData dateTextGridData = new GridData(SWT.FILL, SWT.CENTER, true, false);
+		dateTextGridData.widthHint = FontUtils.getStringPixels(dateText, Messages.DatePicker_Sample_Due_Date).x + 5;
 
 		dateText.setLayoutData(dateTextGridData);
 		dateText.setText(initialText);
@@ -186,8 +186,8 @@ public class DatePicker extends Composite {
 				dialog.open();
 			}
 		});
+
 		updateClearControlVisibility();
-		pack();
 		setBackground(getDisplay().getSystemColor(SWT.COLOR_LIST_BACKGROUND));
 	}
 
@@ -316,5 +316,4 @@ public class DatePicker extends Composite {
 		clearControl.setEnabled(enabled);
 		super.setEnabled(enabled);
 	}
-
 }

--- a/mylyn.commons/org.eclipse.mylyn.commons.workbench/src/org/eclipse/mylyn/commons/workbench/forms/DatePickerPanel.java
+++ b/mylyn.commons/org.eclipse.mylyn.commons.workbench/src/org/eclipse/mylyn/commons/workbench/forms/DatePickerPanel.java
@@ -9,16 +9,20 @@
  *
  *     Bahadir Yagan - initial API and implementation
  *     Tasktop Technologies - improvements
+ *     See git history
  *******************************************************************************/
 
 package org.eclipse.mylyn.commons.workbench.forms;
 
-import java.text.DateFormat;
+import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.FormatStyle;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.List;
 
 import org.eclipse.jface.layout.GridDataFactory;
+import org.eclipse.jface.resource.JFaceResources;
 import org.eclipse.jface.viewers.ArrayContentProvider;
 import org.eclipse.jface.viewers.ISelection;
 import org.eclipse.jface.viewers.ISelectionChangedListener;
@@ -150,15 +154,22 @@ public class DatePickerPanel extends Composite implements KeyListener, ISelectio
 	 */
 	private void createTimeList(Composite composite) {
 
-		DateFormat dateFormat = DateFormat.getTimeInstance(DateFormat.SHORT);
-		Calendar tempCalendar = Calendar.getInstance();
-		tempCalendar.set(Calendar.MINUTE, 0);
-		tempCalendar.set(Calendar.SECOND, 0);
+		DateTimeFormatter timeFormatter = DateTimeFormatter.ofLocalizedTime(FormatStyle.SHORT);
 		String[] times = new String[24];
+		int maxLen = 0;
 		for (int x = 0; x < 24; x++) {
-			tempCalendar.set(Calendar.HOUR_OF_DAY, x);
-			String timeString = dateFormat.format(tempCalendar.getTime());
-			times[x] = timeString;
+			times[x] = LocalTime.of(x, 0).format(timeFormatter);
+			if (times[x].length() > maxLen) {
+				maxLen = times[x].length();
+			}
+		}
+
+		// Right-justify by padding shorter strings with leading spaces
+		for (int i = 0; i < times.length; i++) {
+			int padding = maxLen - times[i].length();
+			if (padding > 0) {
+				times[i] = " ".repeat(padding) + times[i]; //$NON-NLS-1$
+			}
 		}
 
 		ListViewer listViewer = new ListViewer(composite);
@@ -167,6 +178,9 @@ public class DatePickerPanel extends Composite implements KeyListener, ISelectio
 		listViewer.setInput(times);
 
 		timeList = listViewer.getList();
+
+		// Use a monospace font so that leading spaces produce consistent alignment
+		timeList.setFont(JFaceResources.getTextFont());
 
 		listViewer.addSelectionChangedListener(event -> {
 			date.set(Calendar.HOUR_OF_DAY, timeList.getSelectionIndex());

--- a/mylyn.commons/org.eclipse.mylyn.commons.workbench/src/org/eclipse/mylyn/internal/commons/workbench/Messages.java
+++ b/mylyn.commons/org.eclipse.mylyn.commons.workbench/src/org/eclipse/mylyn/internal/commons/workbench/Messages.java
@@ -8,6 +8,7 @@
  * SPDX-License-Identifier: EPL-2.0
  *
  *     Tasktop Technologies - initial API and implementation
+ *     See git history
  *******************************************************************************/
 
 package org.eclipse.mylyn.internal.commons.workbench;
@@ -44,6 +45,8 @@ public class Messages extends NLS {
 	public static String DateSelectionDialog_Date_Selection;
 
 	public static String DatePickerPanel_Today;
+
+	public static String DatePicker_Sample_Due_Date;
 
 	public static String TextControl_FindToolTip;
 

--- a/mylyn.commons/org.eclipse.mylyn.commons.workbench/src/org/eclipse/mylyn/internal/commons/workbench/Messages.java
+++ b/mylyn.commons/org.eclipse.mylyn.commons.workbench/src/org/eclipse/mylyn/internal/commons/workbench/Messages.java
@@ -8,6 +8,7 @@
  * SPDX-License-Identifier: EPL-2.0
  *
  *     Tasktop Technologies - initial API and implementation
+ *     See git history
  *******************************************************************************/
 
 package org.eclipse.mylyn.internal.commons.workbench;
@@ -41,9 +42,13 @@ public class Messages extends NLS {
 
 	public static String DatePicker_Clear;
 
+	public static String DatePicker_Sample_Due_Date;
+
 	public static String DateSelectionDialog_Date_Selection;
 
 	public static String DatePickerPanel_Today;
+
+	public static String DatePickerPanel_Sample_Date;
 
 	public static String TextControl_FindToolTip;
 

--- a/mylyn.commons/org.eclipse.mylyn.commons.workbench/src/org/eclipse/mylyn/internal/commons/workbench/messages.properties
+++ b/mylyn.commons/org.eclipse.mylyn.commons.workbench/src/org/eclipse/mylyn/internal/commons/workbench/messages.properties
@@ -9,6 +9,7 @@
 #
 # Contributors:
 #      Tasktop Technologies - initial API and implementation
+#      See git history
 ###############################################################################
 WorkbenchUtil_Browser_Initialization_Failed=Browser initialization failed.
 WorkbenchUtil_Invalid_URL_Error=Invalid URL specified: ''{0}''.
@@ -19,6 +20,7 @@ AbstractFilteredTree_Find=Find
 
 DatePicker_Choose_Date=Choose Date
 DatePicker_Clear=Clear
+DatePicker_Sample_Due_Date=May 30, 2026, 12:00 p.m.
 
 DateSelectionDialog_Date_Selection=Date Selection
 

--- a/mylyn.context/org.eclipse.mylyn.context.ui/src/org/eclipse/mylyn/internal/context/ui/views/QuickContextPopupDialog.java
+++ b/mylyn.context/org.eclipse.mylyn.context.ui/src/org/eclipse/mylyn/internal/context/ui/views/QuickContextPopupDialog.java
@@ -9,6 +9,7 @@
  *
  *     IBM Corporation - initial API and implementation
  *     Tasktop Technologies - adapted for Mylyn
+ *     See git history
  *******************************************************************************/
 
 package org.eclipse.mylyn.internal.context.ui.views;
@@ -24,6 +25,7 @@ import org.eclipse.jface.text.IInformationControlExtension2;
 import org.eclipse.jface.viewers.ILabelProvider;
 import org.eclipse.jface.viewers.IStructuredSelection;
 import org.eclipse.jface.viewers.StructuredSelection;
+import org.eclipse.mylyn.commons.ui.FontUtils;
 import org.eclipse.mylyn.context.ui.InterestFilter;
 import org.eclipse.mylyn.internal.context.ui.ContextUiPlugin;
 import org.eclipse.swt.SWT;
@@ -38,7 +40,6 @@ import org.eclipse.swt.events.SelectionEvent;
 import org.eclipse.swt.events.SelectionListener;
 import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.graphics.FontMetrics;
-import org.eclipse.swt.graphics.GC;
 import org.eclipse.swt.graphics.Point;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.widgets.Composite;
@@ -57,7 +58,7 @@ import org.eclipse.ui.navigator.CommonViewer;
  * @author Mik Kersten
  */
 public class QuickContextPopupDialog extends PopupDialog
-		implements IInformationControl, IInformationControlExtension, IInformationControlExtension2, DisposeListener {
+implements IInformationControl, IInformationControlExtension, IInformationControlExtension2, DisposeListener {
 
 	public static final String ID_VIEWER = "org.eclipse.mylyn.context.ui.navigator.context.quick"; //$NON-NLS-1$
 
@@ -341,10 +342,7 @@ public class QuickContextPopupDialog extends PopupDialog
 		// Create the widget
 		fFilterText = new Text(parent, SWT.NONE);
 		// Set the font
-		GC gc = new GC(parent);
-		gc.setFont(parent.getFont());
-		FontMetrics fontMetrics = gc.getFontMetrics();
-		gc.dispose();
+		FontMetrics fontMetrics = FontUtils.getFontMetrics(parent);
 		// Create the layout
 		GridData data = new GridData(GridData.FILL_HORIZONTAL);
 		data.heightHint = Dialog.convertHeightInCharsToPixels(fontMetrics, 1);
@@ -371,11 +369,8 @@ public class QuickContextPopupDialog extends PopupDialog
 				if (e.keyCode == 0x0D) {
 					// Return key was pressed
 					gotoSelectedElement();
-				} else if (e.keyCode == SWT.ARROW_DOWN) {
+				} else if (e.keyCode == SWT.ARROW_DOWN || e.keyCode == SWT.ARROW_UP) {
 					// Down key was pressed
-					commonViewer.getTree().setFocus();
-				} else if (e.keyCode == SWT.ARROW_UP) {
-					// Up key was pressed
 					commonViewer.getTree().setFocus();
 				} else if (e.character == 0x1B) {
 					// Escape key was pressed

--- a/mylyn.context/org.eclipse.mylyn.context.ui/src/org/eclipse/mylyn/internal/context/ui/views/QuickContextPopupDialog.java
+++ b/mylyn.context/org.eclipse.mylyn.context.ui/src/org/eclipse/mylyn/internal/context/ui/views/QuickContextPopupDialog.java
@@ -9,6 +9,7 @@
  *
  *     IBM Corporation - initial API and implementation
  *     Tasktop Technologies - adapted for Mylyn
+ *     See git history
  *******************************************************************************/
 
 package org.eclipse.mylyn.internal.context.ui.views;
@@ -25,6 +26,7 @@ import org.eclipse.jface.viewers.ILabelProvider;
 import org.eclipse.jface.viewers.IStructuredSelection;
 import org.eclipse.jface.viewers.StructuredSelection;
 import org.eclipse.mylyn.context.ui.InterestFilter;
+import org.eclipse.mylyn.internal.commons.ui.FontUtils;
 import org.eclipse.mylyn.internal.context.ui.ContextUiPlugin;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.DisposeEvent;
@@ -38,7 +40,6 @@ import org.eclipse.swt.events.SelectionEvent;
 import org.eclipse.swt.events.SelectionListener;
 import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.graphics.FontMetrics;
-import org.eclipse.swt.graphics.GC;
 import org.eclipse.swt.graphics.Point;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.widgets.Composite;
@@ -57,7 +58,7 @@ import org.eclipse.ui.navigator.CommonViewer;
  * @author Mik Kersten
  */
 public class QuickContextPopupDialog extends PopupDialog
-		implements IInformationControl, IInformationControlExtension, IInformationControlExtension2, DisposeListener {
+implements IInformationControl, IInformationControlExtension, IInformationControlExtension2, DisposeListener {
 
 	public static final String ID_VIEWER = "org.eclipse.mylyn.context.ui.navigator.context.quick"; //$NON-NLS-1$
 
@@ -341,10 +342,7 @@ public class QuickContextPopupDialog extends PopupDialog
 		// Create the widget
 		fFilterText = new Text(parent, SWT.NONE);
 		// Set the font
-		GC gc = new GC(parent);
-		gc.setFont(parent.getFont());
-		FontMetrics fontMetrics = gc.getFontMetrics();
-		gc.dispose();
+		FontMetrics fontMetrics = FontUtils.getFontMetrics(parent);
 		// Create the layout
 		GridData data = new GridData(GridData.FILL_HORIZONTAL);
 		data.heightHint = Dialog.convertHeightInCharsToPixels(fontMetrics, 1);
@@ -371,11 +369,8 @@ public class QuickContextPopupDialog extends PopupDialog
 				if (e.keyCode == 0x0D) {
 					// Return key was pressed
 					gotoSelectedElement();
-				} else if (e.keyCode == SWT.ARROW_DOWN) {
+				} else if (e.keyCode == SWT.ARROW_DOWN || e.keyCode == SWT.ARROW_UP) {
 					// Down key was pressed
-					commonViewer.getTree().setFocus();
-				} else if (e.keyCode == SWT.ARROW_UP) {
-					// Up key was pressed
 					commonViewer.getTree().setFocus();
 				} else if (e.character == 0x1B) {
 					// Escape key was pressed

--- a/mylyn.tasks/org.eclipse.mylyn.tasks.ui/src/org/eclipse/mylyn/internal/tasks/ui/Messages.java
+++ b/mylyn.tasks/org.eclipse.mylyn.tasks.ui/src/org/eclipse/mylyn/internal/tasks/ui/Messages.java
@@ -9,6 +9,7 @@
  *
  * Contributors:
  *     Tasktop Technologies - initial API and implementation
+ *     See git history
  *******************************************************************************/
 
 package org.eclipse.mylyn.internal.tasks.ui;
@@ -60,6 +61,8 @@ public class Messages extends NLS {
 	public static String RefactorRepositoryUrlOperation_Repository_URL_update;
 
 	public static String ScheduleDatePicker_Clear;
+
+	public static String ScheduleDatePicker_Sample_Date;
 
 	public static String ScheduleTaskMenuContributor_Cannot_schedule_completed_tasks;
 

--- a/mylyn.tasks/org.eclipse.mylyn.tasks.ui/src/org/eclipse/mylyn/internal/tasks/ui/ScheduleDatePicker.java
+++ b/mylyn.tasks/org.eclipse.mylyn.tasks.ui/src/org/eclipse/mylyn/internal/tasks/ui/ScheduleDatePicker.java
@@ -9,6 +9,7 @@
  *
  * Contributors:
  *     Tasktop Technologies - initial API and implementation
+ *     See git history
  *******************************************************************************/
 
 package org.eclipse.mylyn.internal.tasks.ui;
@@ -19,6 +20,7 @@ import java.util.List;
 
 import org.eclipse.jface.action.MenuManager;
 import org.eclipse.mylyn.commons.ui.CommonImages;
+import org.eclipse.mylyn.commons.ui.FontUtils;
 import org.eclipse.mylyn.commons.workbench.forms.DatePicker;
 import org.eclipse.mylyn.internal.tasks.core.AbstractTask;
 import org.eclipse.mylyn.internal.tasks.core.DateRange;
@@ -72,6 +74,7 @@ public class ScheduleDatePicker extends Composite {
 		}
 
 		initialize((style & SWT.FLAT) > 0 ? SWT.FLAT : 0);
+
 		contributor = new ScheduleTaskMenuContributor() {
 
 			@Override
@@ -95,7 +98,6 @@ public class ScheduleDatePicker extends Composite {
 	}
 
 	private void initialize(int style) {
-
 		GridLayout gridLayout = new GridLayout(3, false);
 		gridLayout.horizontalSpacing = 0;
 		gridLayout.verticalSpacing = 0;
@@ -105,10 +107,9 @@ public class ScheduleDatePicker extends Composite {
 
 		scheduledDateText = new Text(this, style);
 		scheduledDateText.setEditable(false);
-		GridData dateTextGridData = new GridData(SWT.FILL, SWT.FILL, false, false);
-		dateTextGridData.heightHint = 5;
-		dateTextGridData.grabExcessHorizontalSpace = true;
-		dateTextGridData.verticalAlignment = SWT.FILL;
+		GridData dateTextGridData = new GridData(SWT.FILL, SWT.CENTER, true, false);
+		dateTextGridData.widthHint = FontUtils.getStringPixels(scheduledDateText,
+				Messages.ScheduleDatePicker_Sample_Date).x + 5;
 
 		scheduledDateText.setLayoutData(dateTextGridData);
 		scheduledDateText.setText(initialText);
@@ -160,13 +161,13 @@ public class ScheduleDatePicker extends Composite {
 		});
 
 		updateDateText();
-		pack();
 	}
 
 	private void updateClearControlVisibility() {
 		if (clearControl != null && clearControl.getLayoutData() instanceof GridData) {
 			GridData gd = (GridData) clearControl.getLayoutData();
 			gd.exclude = scheduledDate == null;
+			clearControl.setVisible(scheduledDate != null);
 			clearControl.getParent().layout();
 		}
 	}

--- a/mylyn.tasks/org.eclipse.mylyn.tasks.ui/src/org/eclipse/mylyn/internal/tasks/ui/ScheduleDatePicker.java
+++ b/mylyn.tasks/org.eclipse.mylyn.tasks.ui/src/org/eclipse/mylyn/internal/tasks/ui/ScheduleDatePicker.java
@@ -9,6 +9,7 @@
  *
  * Contributors:
  *     Tasktop Technologies - initial API and implementation
+ *     See git history
  *******************************************************************************/
 
 package org.eclipse.mylyn.internal.tasks.ui;
@@ -20,6 +21,7 @@ import java.util.List;
 import org.eclipse.jface.action.MenuManager;
 import org.eclipse.mylyn.commons.ui.CommonImages;
 import org.eclipse.mylyn.commons.workbench.forms.DatePicker;
+import org.eclipse.mylyn.internal.commons.ui.FontUtils;
 import org.eclipse.mylyn.internal.tasks.core.AbstractTask;
 import org.eclipse.mylyn.internal.tasks.core.DateRange;
 import org.eclipse.mylyn.tasks.core.IRepositoryElement;
@@ -72,6 +74,7 @@ public class ScheduleDatePicker extends Composite {
 		}
 
 		initialize((style & SWT.FLAT) > 0 ? SWT.FLAT : 0);
+
 		contributor = new ScheduleTaskMenuContributor() {
 
 			@Override
@@ -95,7 +98,6 @@ public class ScheduleDatePicker extends Composite {
 	}
 
 	private void initialize(int style) {
-
 		GridLayout gridLayout = new GridLayout(3, false);
 		gridLayout.horizontalSpacing = 0;
 		gridLayout.verticalSpacing = 0;
@@ -105,10 +107,9 @@ public class ScheduleDatePicker extends Composite {
 
 		scheduledDateText = new Text(this, style);
 		scheduledDateText.setEditable(false);
-		GridData dateTextGridData = new GridData(SWT.FILL, SWT.FILL, false, false);
-		dateTextGridData.heightHint = 5;
-		dateTextGridData.grabExcessHorizontalSpace = true;
-		dateTextGridData.verticalAlignment = SWT.FILL;
+		GridData dateTextGridData = new GridData(SWT.FILL, SWT.CENTER, true, false);
+		dateTextGridData.widthHint = FontUtils.getStringPixels(scheduledDateText,
+				Messages.ScheduleDatePicker_Sample_Date).x + 5;
 
 		scheduledDateText.setLayoutData(dateTextGridData);
 		scheduledDateText.setText(initialText);
@@ -160,13 +161,13 @@ public class ScheduleDatePicker extends Composite {
 		});
 
 		updateDateText();
-		pack();
 	}
 
 	private void updateClearControlVisibility() {
 		if (clearControl != null && clearControl.getLayoutData() instanceof GridData) {
 			GridData gd = (GridData) clearControl.getLayoutData();
 			gd.exclude = scheduledDate == null;
+			clearControl.setVisible(scheduledDate != null);
 			clearControl.getParent().layout();
 		}
 	}

--- a/mylyn.tasks/org.eclipse.mylyn.tasks.ui/src/org/eclipse/mylyn/internal/tasks/ui/editors/DateAttributeEditor.java
+++ b/mylyn.tasks/org.eclipse.mylyn.tasks.ui/src/org/eclipse/mylyn/internal/tasks/ui/editors/DateAttributeEditor.java
@@ -9,6 +9,7 @@
  *
  * Contributors:
  *     Tasktop Technologies - initial API and implementation
+ *     See git history
  *******************************************************************************/
 
 package org.eclipse.mylyn.internal.tasks.ui.editors;
@@ -96,7 +97,7 @@ public class DateAttributeEditor extends AbstractAttributeEditor {
 
 			});
 
-			GridDataFactory.fillDefaults().hint(120, SWT.DEFAULT).grab(false, false).applyTo(datePicker);
+			GridDataFactory.fillDefaults().hint(120, SWT.DEFAULT).grab(true, false).applyTo(datePicker);
 			datePicker.setData(FormToolkit.KEY_DRAW_BORDER, FormToolkit.TREE_BORDER);
 			toolkit.adapt(datePicker, false, false);
 

--- a/mylyn.tasks/org.eclipse.mylyn.tasks.ui/src/org/eclipse/mylyn/internal/tasks/ui/editors/PlanningPart.java
+++ b/mylyn.tasks/org.eclipse.mylyn.tasks.ui/src/org/eclipse/mylyn/internal/tasks/ui/editors/PlanningPart.java
@@ -9,6 +9,7 @@
  *
  * Contributors:
  *     Tasktop Technologies - initial API and implementation
+ *     See git history
  *******************************************************************************/
 
 package org.eclipse.mylyn.internal.tasks.ui.editors;
@@ -88,8 +89,6 @@ public class PlanningPart extends AbstractLocalEditorPart {
 	private String notesString;
 
 	private RichTextEditor noteEditor;
-
-	private static final int CONTROL_WIDTH = 120;
 
 	private DatePicker dueDatePicker;
 
@@ -225,10 +224,10 @@ public class PlanningPart extends AbstractLocalEditorPart {
 		if (scheduleDatePicker != null && scheduleDatePicker.getScheduledDate() != null) {
 			if (getTask().getScheduledForDate() == null
 					|| getTask().getScheduledForDate() != null
-							&& !scheduleDatePicker.getScheduledDate().equals(getTask().getScheduledForDate())
+					&& !scheduleDatePicker.getScheduledDate().equals(getTask().getScheduledForDate())
 					|| getTask().getScheduledForDate() instanceof DayDateRange) {
 				TasksUiPlugin.getTaskActivityManager()
-						.setScheduledFor(getTask(), scheduleDatePicker.getScheduledDate());
+				.setScheduledFor(getTask(), scheduleDatePicker.getScheduledDate());
 				getTask().setReminded(false);
 			}
 		} else {
@@ -342,7 +341,7 @@ public class PlanningPart extends AbstractLocalEditorPart {
 		noteEditor.setText(notesString);
 
 		noteEditor.getControl()
-				.setLayoutData(EditorUtil.getTextControlLayoutData(page, noteEditor.getViewer().getControl(), true));
+		.setLayoutData(EditorUtil.getTextControlLayoutData(page, noteEditor.getViewer().getControl(), true));
 		noteEditor.getControl().setData(FormToolkit.KEY_DRAW_BORDER, FormToolkit.TREE_BORDER);
 		noteEditor.setReadOnly(false);
 		if (textSupport != null) {
@@ -388,8 +387,8 @@ public class PlanningPart extends AbstractLocalEditorPart {
 			noteEditor.setText(notesString);
 			if (noteEditor.getViewer() != null) {
 				noteEditor.getViewer()
-						.getTextWidget()
-						.setForeground(composite.getShell().getDisplay().getSystemColor(SWT.COLOR_GRAY));
+				.getTextWidget()
+				.setForeground(composite.getShell().getDisplay().getSystemColor(SWT.COLOR_GRAY));
 			}
 		}
 	}
@@ -440,7 +439,7 @@ public class PlanningPart extends AbstractLocalEditorPart {
 						Messages.TaskEditorPlanningPart_Confirm_Activity_Time_Deletion,
 						Messages.TaskEditorPlanningPart_Do_you_wish_to_reset_your_activity_time_on_this_task_)) {
 					MonitorUi.getActivityContextManager()
-							.removeActivityTime(getTask().getHandleIdentifier(), 0l, System.currentTimeMillis());
+					.removeActivityTime(getTask().getHandleIdentifier(), 0l, System.currentTimeMillis());
 				}
 			}
 		});
@@ -489,7 +488,7 @@ public class PlanningPart extends AbstractLocalEditorPart {
 		Composite composite = createComposite(parent, 1, toolkit);
 
 		dueDatePicker = new DatePicker(composite, SWT.FLAT, DatePicker.LABEL_CHOOSE, true, 0);
-		GridDataFactory.fillDefaults().hint(CONTROL_WIDTH, SWT.DEFAULT).applyTo(dueDatePicker);
+		GridDataFactory.fillDefaults().grab(true, false).applyTo(dueDatePicker);
 		dueDatePicker.setBackground(Display.getDefault().getSystemColor(SWT.COLOR_WHITE));
 		dueDatePicker.setData(FormToolkit.KEY_DRAW_BORDER, FormToolkit.TREE_BORDER);
 		if (getTask().getDueDate() != null) {
@@ -550,7 +549,6 @@ public class PlanningPart extends AbstractLocalEditorPart {
 		Composite composite = createComposite(parent, 2, toolkit);
 
 		scheduleDatePicker = new ScheduleDatePicker(composite, getTask(), SWT.FLAT);
-		GridDataFactory.fillDefaults().hint(CONTROL_WIDTH, SWT.DEFAULT).applyTo(scheduleDatePicker);
 		scheduleDatePicker.setData(FormToolkit.KEY_DRAW_BORDER, FormToolkit.TREE_BORDER);
 		toolkit.adapt(scheduleDatePicker, false, false);
 		toolkit.paintBordersFor(composite);
@@ -632,7 +630,7 @@ public class PlanningPart extends AbstractLocalEditorPart {
 				if (date != null) {
 					scheduledLabel.setText(getLabel(date));
 					scheduledLabel
-							.setToolTipText(NLS.bind(Messages.PlanningPart_Scheduled_for_X_Tooltip, date.toString()));
+					.setToolTipText(NLS.bind(Messages.PlanningPart_Scheduled_for_X_Tooltip, date.toString()));
 				} else {
 					scheduledLabel.setText(""); //$NON-NLS-1$
 					scheduledLabel.setToolTipText(null);

--- a/mylyn.tasks/org.eclipse.mylyn.tasks.ui/src/org/eclipse/mylyn/internal/tasks/ui/editors/outline/QuickOutlineDialog.java
+++ b/mylyn.tasks/org.eclipse.mylyn.tasks.ui/src/org/eclipse/mylyn/internal/tasks/ui/editors/outline/QuickOutlineDialog.java
@@ -11,6 +11,7 @@
  *     IBM Corporation - initial API and implementation
  *     Tasktop Technologies - adapted for Mylyn
  *     Frank Becker - adapted for Mylyn Task Editor
+ *     See git history
  *******************************************************************************/
 
 package org.eclipse.mylyn.internal.tasks.ui.editors.outline;
@@ -34,6 +35,7 @@ import org.eclipse.jface.viewers.OpenEvent;
 import org.eclipse.jface.viewers.StructuredSelection;
 import org.eclipse.jface.viewers.TreeViewer;
 import org.eclipse.jface.viewers.Viewer;
+import org.eclipse.mylyn.commons.ui.FontUtils;
 import org.eclipse.mylyn.commons.workbench.DecoratingPatternStyledCellLabelProvider;
 import org.eclipse.mylyn.internal.tasks.ui.editors.TaskEditorOutlineContentProvider;
 import org.eclipse.mylyn.internal.tasks.ui.editors.TaskEditorOutlineModel;
@@ -54,7 +56,6 @@ import org.eclipse.swt.events.SelectionEvent;
 import org.eclipse.swt.events.SelectionListener;
 import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.graphics.FontMetrics;
-import org.eclipse.swt.graphics.GC;
 import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.graphics.Point;
 import org.eclipse.swt.layout.GridData;
@@ -76,7 +77,7 @@ import org.eclipse.ui.forms.editor.IFormPage;
  * @author Steffen Pingel
  */
 public class QuickOutlineDialog extends PopupDialog
-		implements IInformationControl, IInformationControlExtension, IInformationControlExtension2, DisposeListener {
+implements IInformationControl, IInformationControlExtension, IInformationControlExtension2, DisposeListener {
 
 	public final class Filter extends PatternFilter {
 		@Override
@@ -459,10 +460,7 @@ public class QuickOutlineDialog extends PopupDialog
 		// Create the widget
 		filterText = new Text(parent, SWT.NONE);
 		// Set the font
-		GC gc = new GC(parent);
-		gc.setFont(parent.getFont());
-		FontMetrics fontMetrics = gc.getFontMetrics();
-		gc.dispose();
+		FontMetrics fontMetrics = FontUtils.getFontMetrics(parent);
 		// Create the layout
 		GridData data = new GridData(GridData.FILL_HORIZONTAL);
 		data.heightHint = Dialog.convertHeightInCharsToPixels(fontMetrics, 1);
@@ -489,11 +487,8 @@ public class QuickOutlineDialog extends PopupDialog
 				if (e.keyCode == 0x0D) {
 					// Return key was pressed
 					gotoSelectedElement();
-				} else if (e.keyCode == SWT.ARROW_DOWN) {
-					// Down key was pressed
-					viewer.getTree().setFocus();
-				} else if (e.keyCode == SWT.ARROW_UP) {
-					// Up key was pressed
+				} else if (e.keyCode == SWT.ARROW_DOWN || e.keyCode == SWT.ARROW_UP) {
+					// Down/Up key was pressed
 					viewer.getTree().setFocus();
 				} else if (e.character == 0x1B) {
 					// Escape key was pressed

--- a/mylyn.tasks/org.eclipse.mylyn.tasks.ui/src/org/eclipse/mylyn/internal/tasks/ui/editors/outline/QuickOutlineDialog.java
+++ b/mylyn.tasks/org.eclipse.mylyn.tasks.ui/src/org/eclipse/mylyn/internal/tasks/ui/editors/outline/QuickOutlineDialog.java
@@ -11,6 +11,7 @@
  *     IBM Corporation - initial API and implementation
  *     Tasktop Technologies - adapted for Mylyn
  *     Frank Becker - adapted for Mylyn Task Editor
+ *     See git history
  *******************************************************************************/
 
 package org.eclipse.mylyn.internal.tasks.ui.editors.outline;
@@ -35,6 +36,7 @@ import org.eclipse.jface.viewers.StructuredSelection;
 import org.eclipse.jface.viewers.TreeViewer;
 import org.eclipse.jface.viewers.Viewer;
 import org.eclipse.mylyn.commons.workbench.DecoratingPatternStyledCellLabelProvider;
+import org.eclipse.mylyn.internal.commons.ui.FontUtils;
 import org.eclipse.mylyn.internal.tasks.ui.editors.TaskEditorOutlineContentProvider;
 import org.eclipse.mylyn.internal.tasks.ui.editors.TaskEditorOutlineModel;
 import org.eclipse.mylyn.internal.tasks.ui.editors.TaskEditorOutlineNode;
@@ -54,7 +56,6 @@ import org.eclipse.swt.events.SelectionEvent;
 import org.eclipse.swt.events.SelectionListener;
 import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.graphics.FontMetrics;
-import org.eclipse.swt.graphics.GC;
 import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.graphics.Point;
 import org.eclipse.swt.layout.GridData;
@@ -76,7 +77,7 @@ import org.eclipse.ui.forms.editor.IFormPage;
  * @author Steffen Pingel
  */
 public class QuickOutlineDialog extends PopupDialog
-		implements IInformationControl, IInformationControlExtension, IInformationControlExtension2, DisposeListener {
+implements IInformationControl, IInformationControlExtension, IInformationControlExtension2, DisposeListener {
 
 	public final class Filter extends PatternFilter {
 		@Override
@@ -459,10 +460,7 @@ public class QuickOutlineDialog extends PopupDialog
 		// Create the widget
 		filterText = new Text(parent, SWT.NONE);
 		// Set the font
-		GC gc = new GC(parent);
-		gc.setFont(parent.getFont());
-		FontMetrics fontMetrics = gc.getFontMetrics();
-		gc.dispose();
+		FontMetrics fontMetrics = FontUtils.getFontMetrics(parent);
 		// Create the layout
 		GridData data = new GridData(GridData.FILL_HORIZONTAL);
 		data.heightHint = Dialog.convertHeightInCharsToPixels(fontMetrics, 1);
@@ -489,11 +487,8 @@ public class QuickOutlineDialog extends PopupDialog
 				if (e.keyCode == 0x0D) {
 					// Return key was pressed
 					gotoSelectedElement();
-				} else if (e.keyCode == SWT.ARROW_DOWN) {
-					// Down key was pressed
-					viewer.getTree().setFocus();
-				} else if (e.keyCode == SWT.ARROW_UP) {
-					// Up key was pressed
+				} else if (e.keyCode == SWT.ARROW_DOWN || e.keyCode == SWT.ARROW_UP) {
+					// Down/Up key was pressed
 					viewer.getTree().setFocus();
 				} else if (e.character == 0x1B) {
 					// Escape key was pressed

--- a/mylyn.tasks/org.eclipse.mylyn.tasks.ui/src/org/eclipse/mylyn/internal/tasks/ui/messages.properties
+++ b/mylyn.tasks/org.eclipse.mylyn.tasks.ui/src/org/eclipse/mylyn/internal/tasks/ui/messages.properties
@@ -37,6 +37,8 @@ OpenRepositoryTaskJob_Unable_to_open_task=Unable to open task
 RefactorRepositoryUrlOperation_Repository_URL_update=Repository URL update
 
 ScheduleDatePicker_Clear=Clear
+ScheduleDatePicker_Sample_Date=Wednesday - Today
+
 ScheduleTaskMenuContributor_Cannot_schedule_completed_tasks=Cannot schedule completed tasks
 ScheduleTaskMenuContributor_Choose_Date_=Choose Date...
 ScheduleTaskMenuContributor_Future=Future


### PR DESCRIPTION
### Got tired of seeing the DatePicker (and friends) truncated in Windows:
<img width="543" height="87" alt="image" src="https://github.com/user-attachments/assets/23efbc9b-53c6-42d4-bd39-06ed0f048a7d" />
as well as in the JiraConnector in Windows:
<img width="575" height="82" alt="image" src="https://github.com/user-attachments/assets/a2b68ff4-aa01-423d-b652-3aa2fd26ad60" />

Linux/MacOs was better but also had some issues:
<img width="804" height="114" alt="image" src="https://github.com/user-attachments/assets/026d0497-f94a-46b2-833e-0d8865f55a34" />

With these changes it looks like:
<img width="831" height="91" alt="image" src="https://github.com/user-attachments/assets/f8c91109-2063-452d-9a96-70f2f3966993" />
and
<img width="615" height="92" alt="image" src="https://github.com/user-attachments/assets/9a0321f8-20ef-4c8b-ab85-d79bbb676e3c" />
and
<img width="946" height="114" alt="image" src="https://github.com/user-attachments/assets/7e162096-c60d-4e19-b332-226d34e0f1e2" />

### The DatePicker popup was cleaned up a bit as well from:
<img width="398" height="229" alt="image" src="https://github.com/user-attachments/assets/0a611fbd-80a3-4c47-890c-389084aabe92" />
to
<img width="393" height="236" alt="image" src="https://github.com/user-attachments/assets/3d6c787d-a628-42bf-bb56-773b8d366a0e" />


**For some reason that I don't understand, the Mylyn-Runtime.launch version differs slightly in appearance from when Mylyn is installed in an Eclipse instance.**