### PR TITLE
Added -Dpde.addTransitiveDependenciesWithForbiddenAccess=false for #1044

### DIFF
--- a/org.eclipse.mylyn.releng/oomph/Mylyn.setup
+++ b/org.eclipse.mylyn.releng/oomph/Mylyn.setup
@@ -437,6 +437,11 @@
         xsi:type="maven:MavenUpdateTask"
         id="maven.update"
         predecessor="launch.install"/>
+    <setupTask
+        xsi:type="setup:EclipseIniTask"
+        option="-Dpde.addTransitiveDependenciesWithForbiddenAccess"
+        value="=false"
+        vm="true"/>
     <stream
         name="main"
         label="main">


### PR DESCRIPTION
Change in 4.40.0-M1 caused plugin classpath issues.

Need -Dpde.addTransitiveDependenciesWithForbiddenAccess=false in eclipse.ini