### PR TITLE
Disable 'The package xyz is accessible from more than one module' error

### DIFF
--- a/mylyn.builds/org.eclipse.mylyn.builds.tests/.settings/org.eclipse.jdt.core.prefs
+++ b/mylyn.builds/org.eclipse.mylyn.builds.tests/.settings/org.eclipse.jdt.core.prefs
@@ -515,3 +515,4 @@ org.eclipse.jdt.core.formatter.wrap_before_string_concatenation=true
 org.eclipse.jdt.core.formatter.wrap_before_switch_case_arrow_operator=false
 org.eclipse.jdt.core.formatter.wrap_outer_expressions_when_nested=true
 org.eclipse.jdt.core.javaFormatter=org.eclipse.jdt.core.defaultJavaFormatter
+org.eclipse.jdt.core.compiler.ignoreUnnamedModuleForSplitPackage=enabled

--- a/mylyn.builds/org.eclipse.mylyn.builds.ui/.settings/org.eclipse.jdt.core.prefs
+++ b/mylyn.builds/org.eclipse.mylyn.builds.ui/.settings/org.eclipse.jdt.core.prefs
@@ -515,3 +515,4 @@ org.eclipse.jdt.core.formatter.wrap_before_string_concatenation=true
 org.eclipse.jdt.core.formatter.wrap_before_switch_case_arrow_operator=false
 org.eclipse.jdt.core.formatter.wrap_outer_expressions_when_nested=true
 org.eclipse.jdt.core.javaFormatter=org.eclipse.jdt.core.defaultJavaFormatter
+org.eclipse.jdt.core.compiler.ignoreUnnamedModuleForSplitPackage=enabled

--- a/mylyn.builds/org.eclipse.mylyn.jenkins.core/.settings/org.eclipse.jdt.core.prefs
+++ b/mylyn.builds/org.eclipse.mylyn.jenkins.core/.settings/org.eclipse.jdt.core.prefs
@@ -515,3 +515,4 @@ org.eclipse.jdt.core.formatter.wrap_before_string_concatenation=true
 org.eclipse.jdt.core.formatter.wrap_before_switch_case_arrow_operator=false
 org.eclipse.jdt.core.formatter.wrap_outer_expressions_when_nested=true
 org.eclipse.jdt.core.javaFormatter=org.eclipse.jdt.core.defaultJavaFormatter
+org.eclipse.jdt.core.compiler.ignoreUnnamedModuleForSplitPackage=enabled

--- a/mylyn.commons/org.eclipse.mylyn.commons.notifications.feed/.settings/org.eclipse.jdt.core.prefs
+++ b/mylyn.commons/org.eclipse.mylyn.commons.notifications.feed/.settings/org.eclipse.jdt.core.prefs
@@ -515,3 +515,4 @@ org.eclipse.jdt.core.formatter.wrap_before_string_concatenation=true
 org.eclipse.jdt.core.formatter.wrap_before_switch_case_arrow_operator=false
 org.eclipse.jdt.core.formatter.wrap_outer_expressions_when_nested=true
 org.eclipse.jdt.core.javaFormatter=org.eclipse.jdt.core.defaultJavaFormatter
+org.eclipse.jdt.core.compiler.ignoreUnnamedModuleForSplitPackage=enabled

--- a/mylyn.commons/org.eclipse.mylyn.commons.xmlrpc/.settings/org.eclipse.jdt.core.prefs
+++ b/mylyn.commons/org.eclipse.mylyn.commons.xmlrpc/.settings/org.eclipse.jdt.core.prefs
@@ -515,3 +515,4 @@ org.eclipse.jdt.core.formatter.wrap_before_string_concatenation=true
 org.eclipse.jdt.core.formatter.wrap_before_switch_case_arrow_operator=false
 org.eclipse.jdt.core.formatter.wrap_outer_expressions_when_nested=true
 org.eclipse.jdt.core.javaFormatter=org.eclipse.jdt.core.defaultJavaFormatter
+org.eclipse.jdt.core.compiler.ignoreUnnamedModuleForSplitPackage=enabled

--- a/mylyn.docs/wikitext/ui/org.eclipse.mylyn.wikitext.tasks.ui/.settings/org.eclipse.jdt.core.prefs
+++ b/mylyn.docs/wikitext/ui/org.eclipse.mylyn.wikitext.tasks.ui/.settings/org.eclipse.jdt.core.prefs
@@ -515,3 +515,4 @@ org.eclipse.jdt.core.formatter.wrap_before_string_concatenation=true
 org.eclipse.jdt.core.formatter.wrap_before_switch_case_arrow_operator=false
 org.eclipse.jdt.core.formatter.wrap_outer_expressions_when_nested=true
 org.eclipse.jdt.core.javaFormatter=org.eclipse.jdt.core.defaultJavaFormatter
+org.eclipse.jdt.core.compiler.ignoreUnnamedModuleForSplitPackage=enabled

--- a/mylyn.tasks/connectors/bugzilla/org.eclipse.mylyn.bugzilla.core/.settings/org.eclipse.jdt.core.prefs
+++ b/mylyn.tasks/connectors/bugzilla/org.eclipse.mylyn.bugzilla.core/.settings/org.eclipse.jdt.core.prefs
@@ -515,3 +515,4 @@ org.eclipse.jdt.core.formatter.wrap_before_string_concatenation=true
 org.eclipse.jdt.core.formatter.wrap_before_switch_case_arrow_operator=false
 org.eclipse.jdt.core.formatter.wrap_outer_expressions_when_nested=true
 org.eclipse.jdt.core.javaFormatter=org.eclipse.jdt.core.defaultJavaFormatter
+org.eclipse.jdt.core.compiler.ignoreUnnamedModuleForSplitPackage=enabled

--- a/mylyn.tasks/connectors/bugzilla/org.eclipse.mylyn.bugzilla.tests/.settings/org.eclipse.jdt.core.prefs
+++ b/mylyn.tasks/connectors/bugzilla/org.eclipse.mylyn.bugzilla.tests/.settings/org.eclipse.jdt.core.prefs
@@ -515,3 +515,4 @@ org.eclipse.jdt.core.formatter.wrap_before_string_concatenation=true
 org.eclipse.jdt.core.formatter.wrap_before_switch_case_arrow_operator=false
 org.eclipse.jdt.core.formatter.wrap_outer_expressions_when_nested=true
 org.eclipse.jdt.core.javaFormatter=org.eclipse.jdt.core.defaultJavaFormatter
+org.eclipse.jdt.core.compiler.ignoreUnnamedModuleForSplitPackage=enabled

--- a/mylyn.tasks/org.eclipse.mylyn.tasks.tests/.settings/org.eclipse.jdt.core.prefs
+++ b/mylyn.tasks/org.eclipse.mylyn.tasks.tests/.settings/org.eclipse.jdt.core.prefs
@@ -515,3 +515,4 @@ org.eclipse.jdt.core.formatter.wrap_before_string_concatenation=true
 org.eclipse.jdt.core.formatter.wrap_before_switch_case_arrow_operator=false
 org.eclipse.jdt.core.formatter.wrap_outer_expressions_when_nested=true
 org.eclipse.jdt.core.javaFormatter=org.eclipse.jdt.core.defaultJavaFormatter
+org.eclipse.jdt.core.compiler.ignoreUnnamedModuleForSplitPackage=enabled

--- a/org.eclipse.mylyn.releng/oomph/Mylyn.setup
+++ b/org.eclipse.mylyn.releng/oomph/Mylyn.setup
@@ -437,11 +437,6 @@
         xsi:type="maven:MavenUpdateTask"
         id="maven.update"
         predecessor="launch.install"/>
-    <setupTask
-        xsi:type="setup:EclipseIniTask"
-        option="-Dpde.addTransitiveDependenciesWithForbiddenAccess"
-        value="=false"
-        vm="true"/>
     <stream
         name="main"
         label="main">


### PR DESCRIPTION
- Add org.eclipse.jdt.core.compiler.ignoreUnnamedModuleForSplitPackage=enabled to projects with javax.xml errors to suppress those errors.
- Remove -Dpde.addTransitiveDependenciesWithForbiddenAccess=false because it's no longer needed.

https://github.com/eclipse-mylyn/org.eclipse.mylyn/issues/1044