### PR TITLE
Need mojibake with Bugzilla 5.x for attachment name #860

### DIFF
--- a/mylyn.tasks/connectors/bugzilla/org.eclipse.mylyn.bugzilla.core/src/org/eclipse/mylyn/internal/bugzilla/core/SaxMultiBugReportContentHandler.java
+++ b/mylyn.tasks/connectors/bugzilla/org.eclipse.mylyn.bugzilla.core/src/org/eclipse/mylyn/internal/bugzilla/core/SaxMultiBugReportContentHandler.java
@@ -14,6 +14,11 @@
 
 package org.eclipse.mylyn.internal.bugzilla.core;
 
+import java.nio.ByteBuffer;
+import java.nio.charset.CharacterCodingException;
+import java.nio.charset.CharsetDecoder;
+import java.nio.charset.CodingErrorAction;
+import java.nio.charset.StandardCharsets;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
@@ -392,7 +397,7 @@ public class SaxMultiBugReportContentHandler extends DefaultHandler {
 				break;
 			case FILENAME:
 				if (attachment != null) {
-					attachment.setFileName(parsedText);
+					attachment.setFileName(recoverMojibakeFilename(parsedText));
 				}
 				break;
 			case CTYPE:
@@ -782,6 +787,36 @@ public class SaxMultiBugReportContentHandler extends DefaultHandler {
 		}
 
 		parseAttachment(taskComment);
+	}
+
+	/**
+	 * Recovers a filename that was stored as mojibake due to Bugzilla 5.x interpreting UTF-8 bytes in the
+	 * Content-Disposition header as ISO-8859-1 (Latin-1). When the client sends a UTF-8 encoded filename,
+	 * Bugzilla 5.x reads those bytes as individual Latin-1 characters and stores/returns them that way.
+	 * <p>
+	 * Recovery: get the ISO-8859-1 bytes of the returned string and try to re-decode as UTF-8. If the result
+	 * is valid UTF-8 and differs from the input, the input was mojibake and the recovered value is returned.
+	 * Otherwise the original string is returned unchanged.
+	 * <p>
+	 * This is safe because legitimate Latin-1 filenames rarely have byte patterns that form valid UTF-8
+	 * multi-byte sequences (e.g. "Ñoño" → bytes 0xD1 0x6F 0xF1 0x6F which are NOT valid UTF-8).
+	 */
+	public static String recoverMojibakeFilename(String filename) {
+		if (filename == null || filename.isEmpty()) {
+			return filename;
+		}
+		try {
+			byte[] latin1Bytes = filename.getBytes(StandardCharsets.ISO_8859_1);
+			CharsetDecoder utf8Decoder = StandardCharsets.UTF_8.newDecoder()
+					.onMalformedInput(CodingErrorAction.REPORT)
+					.onUnmappableCharacter(CodingErrorAction.REPORT);
+			String recovered = utf8Decoder.decode(ByteBuffer.wrap(latin1Bytes)).toString();
+			// Only use the recovered value if it actually differs (non-ASCII was present)
+			return recovered.equals(filename) ? filename : recovered;
+		} catch (CharacterCodingException e) {
+			// The ISO-8859-1 bytes are not valid UTF-8, so the filename is not mojibake
+			return filename;
+		}
 	}
 
 	/** determines attachment id from comment */

--- a/mylyn.tasks/connectors/bugzilla/org.eclipse.mylyn.bugzilla.tests/src/org/eclipse/mylyn/bugzilla/tests/AllBugzillaTests.java
+++ b/mylyn.tasks/connectors/bugzilla/org.eclipse.mylyn.bugzilla.tests/src/org/eclipse/mylyn/bugzilla/tests/AllBugzillaTests.java
@@ -15,6 +15,7 @@
 
 package org.eclipse.mylyn.bugzilla.tests;
 
+import org.eclipse.mylyn.bugzilla.tests.core.BugzillaAttachmentNameTest;
 import org.eclipse.mylyn.bugzilla.tests.core.BugzillaXmlRpcClientTest;
 import org.eclipse.mylyn.bugzilla.tests.ui.BugzillaHyperlinkDetectorTest;
 import org.eclipse.mylyn.bugzilla.tests.ui.BugzillaRepositorySettingsPageTest;
@@ -33,7 +34,7 @@ import org.junit.platform.suite.api.Suite;
  */
 @Suite
 @SelectClasses({ BugzillaTaskHyperlinkDetectorTest.class, BugzillaHyperlinkDetectorTest.class,
-	AllBugzillaHeadlessStandaloneTests.class,
+		AllBugzillaHeadlessStandaloneTests.class, BugzillaAttachmentNameTest.class,
 	// not local
 	BugzillaTaskEditorTest.class, BugzillaSearchPageTest.class, BugzillaRepositorySettingsPageTest.class,
 	// needs fixture

--- a/mylyn.tasks/connectors/bugzilla/org.eclipse.mylyn.bugzilla.tests/src/org/eclipse/mylyn/bugzilla/tests/BugzillaAttachmentHandlerTest.java
+++ b/mylyn.tasks/connectors/bugzilla/org.eclipse.mylyn.bugzilla.tests/src/org/eclipse/mylyn/bugzilla/tests/BugzillaAttachmentHandlerTest.java
@@ -326,12 +326,6 @@ public class BugzillaAttachmentHandlerTest extends AbstractBugzillaTest {
 
 	@Test
 	public void testAttachmentWithUnicode() throws Exception {
-		// Skip if running against Bugzilla version > 5.1
-		assumeFalse(
-				fixture.getBugzillaVersion().compareTo(BugzillaVersion.BUGZILLA_5_1) > 0,
-				"Disabled with Bugzilla version > 5.1: Strange unicode characters in returned attachment filename"
-				); // FIXME Unicode characters in filename from Bugzilla  don't match
-
 		testAttachmentWithSpecialCharacters(
 				"\u00E7" + // LATIN SMALL LETTER C WITH CEDILLA
 						"\u00F1" + // LATIN SMALL LETTER N WITH TILDE
@@ -355,6 +349,14 @@ public class BugzillaAttachmentHandlerTest extends AbstractBugzillaTest {
 	@Test
 	public void testAttachmentWithSpecialCharacters() throws Exception {
 		testAttachmentWithSpecialCharacters("~`!@#$%^&()_-+={[}];',");
+	}
+
+	@Test
+	public void testAttachmentWithNonMojibakedCharacters() throws Exception {
+		// A filename with genuine Latin-1 characters (not Mojibake): é (U+00E9) encodes as
+		// 0xE9 in Latin-1, which is an invalid UTF-8 start byte — conversion fails and the
+		// original is returned unchanged.
+		testAttachmentWithSpecialCharacters("résumé.txt");
 	}
 
 	private void testAttachmentWithSpecialCharacters(String specialCharacters) throws Exception {

--- a/mylyn.tasks/connectors/bugzilla/org.eclipse.mylyn.bugzilla.tests/src/org/eclipse/mylyn/bugzilla/tests/core/BugzillaAttachmentNameTest.java
+++ b/mylyn.tasks/connectors/bugzilla/org.eclipse.mylyn.bugzilla.tests/src/org/eclipse/mylyn/bugzilla/tests/core/BugzillaAttachmentNameTest.java
@@ -1,0 +1,46 @@
+/*******************************************************************************
+ * Copyright (c) 2026 George Lindholm
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html.
+ *
+ * Contributors:
+ *      See git history
+ *******************************************************************************/
+
+package org.eclipse.mylyn.bugzilla.tests.core;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.eclipse.mylyn.internal.bugzilla.core.SaxMultiBugReportContentHandler;
+import org.junit.jupiter.api.Test;
+
+@SuppressWarnings("nls")
+public class BugzillaAttachmentNameTest {
+	@Test
+	public void testUnicodeAttachmentName() {
+		String mojibakedFilename = "test-Ã§Ã±Â¥â¬Â£Â½Â¼Î²Î¸å°åãã¡ï½³ã.txt";
+		String encodedName = SaxMultiBugReportContentHandler
+				.recoverMojibakeFilename(mojibakedFilename);
+		assertEquals("test-çñ¥€£½¼βθ台北ゖァｳ゗.txt", encodedName);
+	}
+
+	@Test
+	public void testLatin1AttachmentName() {
+		String filename = "test-screenshot.txt";
+		String encodedName = SaxMultiBugReportContentHandler.recoverMojibakeFilename(filename);
+		assertEquals(filename, encodedName);
+	}
+
+	@Test
+	public void testNonMojibakedLatin1AttachmentName() {
+		// A filename with genuine Latin-1 characters (not Mojibake): é (U+00E9) encodes as
+		// 0xE9 in Latin-1, which is an invalid UTF-8 start byte — conversion fails and the
+		// original is returned unchanged.
+		String original = "résumé.txt";
+		String result = SaxMultiBugReportContentHandler.recoverMojibakeFilename(original);
+		assertEquals(original, result);
+	}
+
+}


### PR DESCRIPTION
Threw Copilot at the problem:
```
Bugzilla 5.x uses a Perl MIME multipart parser (from CGI.pm) to read uploaded form data. This parser does not support RFC 5987 filename* in multipart body Content-Disposition headers — it only understands the plain filename parameter. So Bugzilla 5.x still read the raw UTF-8 bytes as Latin-1 and stored the mojibake.

Root cause (confirmed by the failure output)

expected: testçñ¥€£½¼βθ台北ゖァｳ゗...txt
was: testÃ§Ã±Â¥â¬Â£Â½Â¼Î²Î¸å°åãã¡ï½³ã...txt

This is byte-for-byte mojibake: every non-ASCII character in the original has its UTF-8 bytes present in the returned string interpreted as individual Latin-1 characters. E.g., ç (U+00E7) → UTF-8 bytes 0xC3 0xA7 → Latin-1 chars Ã§ (U+00C3 U+00A7).

The fix: SaxMultiBugReportContentHandler.java

When parsing the <filename> element, the new recoverMojibakeFilename() method:

	1. Takes the returned string's bytes as ISO-8859-1
	2. Tries to decode those bytes as strict UTF-8 (failing on any invalid byte sequence)
	3. If the decode succeeds and the result differs from the input → it was mojibake → use the recovered string
	4. If the decode fails (invalid UTF-8) → filename was not mojibake → use original

This is safe because legitimate Latin-1 filenames almost never have byte patterns that form valid UTF-8 multi-byte sequences. For example:

	•  "Ñoño.txt" → ISO-8859-1 bytes [D1 6F F1 6F ...] → 0xD1 needs a UTF-8 continuation but 0x6F (o) is not one → invalid UTF-8 → no recovery applied ✓
	•  "testÃ§.txt" (mojibake) → ISO-8859-1 bytes [... C3 A7 ...] → valid UTF-8 sequence → recovered to testç.txt ✓
	•  Pure ASCII filenames → recovery produces identical string → original returned unchanged 

```

Task-Url: https://github.com/eclipse-mylyn/org.eclipse.mylyn/issues/860