### PR TITLE
Added support for Admonition Blocks

### DIFF
--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.asciidoc.tests/src/test/java/org/eclipse/mylyn/internal/wikitext/asciidoc/tests/AsciiDocAdmonitionBlockTest.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.asciidoc.tests/src/test/java/org/eclipse/mylyn/internal/wikitext/asciidoc/tests/AsciiDocAdmonitionBlockTest.java
@@ -1,0 +1,175 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Johannes Kepler University Linz
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Alois Zoitl - initial API and implementation
+ *******************************************************************************/
+
+package org.eclipse.mylyn.internal.wikitext.asciidoc.tests;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+@SuppressWarnings("nls")
+class AsciiDocAdmonitionBlockTest extends AsciiDocLanguageTestBase {
+
+	private static Stream<Arguments> admonitionProvider() {
+		return Stream.of(
+				Arguments.of("TIP", "Tip"), //
+				Arguments.of("NOTE", "Note"), //
+				Arguments.of("WARNING", "Warning"), //
+				Arguments.of("IMPORTANT", "Important"), //
+				Arguments.of("CAUTION", "Caution") //
+				);
+	}
+
+	@ParameterizedTest(name = "Basic admonition block test (title, single line content): {0}")
+	@MethodSource("admonitionProvider")
+	void fullBlockWithOneLine(String type, String label) {
+		String input = String.format("""
+				[%s]
+				.This is the headline of a %s
+				====
+				This is a simple single line content for an admonition block.
+				====
+				""", type, label);
+
+		String html = parseToHtml(input);
+
+		String expected = String.format("""
+				<div class="admonitionblock %s"><table><tr><td class="icon"><div class="title">%s</div></td>
+				<td class="content">
+				<div class="title">This is the headline of a %s</div>
+				<div class="paragraph">
+				<p>This is a simple single line content for an admonition block.</p>
+				</div></td></tr></table></div>
+				""", type.toLowerCase(), label, label);
+
+		assertEquals(expected.trim(), html.trim());
+	}
+
+	@ParameterizedTest(name = "Admonition block test with no title: {0}")
+	@MethodSource("admonitionProvider")
+	void blockWithNoTitle(String type, String label) {
+		String input = String.format("""
+				[%s]
+				====
+				This is a simple single line content for an admonition block.
+				====
+				""", type, label);
+
+		String html = parseToHtml(input);
+
+		String expected = String.format("""
+				<div class="admonitionblock %s"><table><tr><td class="icon"><div class="title">%s</div></td>
+				<td class="content">
+				<div class="paragraph">
+				<p>This is a simple single line content for an admonition block.</p>
+				</div></td></tr></table></div>
+				""", type.toLowerCase(), label, label);
+
+		assertEquals(expected.trim(), html.trim());
+	}
+
+	@Test
+	void multiParapgraphAdmonitionBlock() {
+		String input = """
+				[NOTE]
+				====
+				This is the first pragraph as content of an admonition block.
+
+				This is the second pragraph as content of an admonition block.
+				====
+				""";
+
+		String html = parseToHtml(input);
+
+		String expected = """
+				<div class="admonitionblock note"><table><tr><td class="icon"><div class="title">Note</div></td>
+				<td class="content">
+				<div class="paragraph">
+				<p>This is the first pragraph as content of an admonition block.</p>
+				<p>This is the second pragraph as content of an admonition block.</p>
+				</div></td></tr></table></div>
+				""";
+
+		assertEquals(expected.trim(), html.trim());
+	}
+
+	@Test
+	void listConentAdmonitionBlock() {
+		String input = """
+				[NOTE]
+				====
+				This is the first pragraph as content of an admonition block.
+
+				. first line of a numbered list
+				. second line of a numbered list
+				. third line of a numbered list
+
+				This is the second pragraph as content of an admonition block.
+
+				And here another one!
+				====
+				""";
+
+		String html = parseToHtml(input);
+
+		String expected = """
+				<div class="admonitionblock note"><table><tr><td class="icon"><div class="title">Note</div></td>
+				<td class="content">
+				<div class="paragraph">
+				<p>This is the first pragraph as content of an admonition block.</p>
+				<ol style="list-style-type:decimal;"><li>first line of a numbered list</li><li>second line of a numbered list</li><li>third line of a numbered list</li></ol><p>This is the second pragraph as content of an admonition block.</p>
+				<p>And here another one!</p>
+				</div></td></tr></table></div>
+				""";
+
+		assertEquals(expected.trim(), html.trim());
+	}
+
+	@Test
+	void nestedListConentAdmonitionBlock() {
+		String input = """
+				[NOTE]
+				====
+				some text above
+				. one
+				. two
+				.* nested unorderd list
+				.** nested in nested
+				.* another nested unordered list item
+				.*. subordered list
+				.*. subordered list item
+				. three
+				some text below.
+				====
+				""";
+
+		String html = parseToHtml(input);
+
+		String expected = """
+				<div class="admonitionblock note"><table><tr><td class="icon"><div class="title">Note</div></td>
+				<td class="content">
+				<div class="paragraph">
+				<p>some text above</p>
+				<ol style="list-style-type:decimal;"><li>one</li><li>two<ul><li>nested unorderd list<ul><li>nested in nested</li></ul></li><li>another nested unordered list item<ol style="list-style-type:lower-alpha;"><li>subordered list</li><li>subordered list item</li></ol></li></ul></li><li>three some text below.</li></ol></div></td></tr></table></div>
+				""";
+
+		assertEquals(expected.trim(), html.trim());
+	}
+
+}

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.asciidoc/src/main/java/org/eclipse/mylyn/wikitext/asciidoc/AsciiDocLanguage.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.asciidoc/src/main/java/org/eclipse/mylyn/wikitext/asciidoc/AsciiDocLanguage.java
@@ -24,6 +24,7 @@ import java.util.Map;
 import org.eclipse.mylyn.wikitext.asciidoc.internal.AsciiDocContentState;
 import org.eclipse.mylyn.wikitext.asciidoc.internal.AsciiDocDocumentBuilder;
 import org.eclipse.mylyn.wikitext.asciidoc.internal.AsciiDocIdGenerationStrategy;
+import org.eclipse.mylyn.wikitext.asciidoc.internal.block.AdmonitionBlock;
 import org.eclipse.mylyn.wikitext.asciidoc.internal.block.AdmonitionParagraphBlock;
 import org.eclipse.mylyn.wikitext.asciidoc.internal.block.AttributeDefinitionBlock;
 import org.eclipse.mylyn.wikitext.asciidoc.internal.block.CodeBlock;
@@ -166,6 +167,9 @@ public class AsciiDocLanguage extends AbstractMarkupLanguage {
 
 	@Override
 	protected void addStandardBlocks(List<Block> blocks, List<Block> paragraphBreakingBlocks) {
+
+		blocks.add(new AdmonitionBlock());
+
 		ListBlock listBlock = new ListBlock();
 		blocks.add(listBlock);
 		paragraphBreakingBlocks.add(listBlock);
@@ -195,6 +199,7 @@ public class AsciiDocLanguage extends AbstractMarkupLanguage {
 		blocks.add(codeBlock);
 		blocks.add(commentBlock);
 		blocks.add(hrBlock);
+
 		blocks.add(new AdmonitionParagraphBlock());
 
 		paragraphBreakingBlocks.add(codeBlock);

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.asciidoc/src/main/java/org/eclipse/mylyn/wikitext/asciidoc/internal/block/AdmonitionBlock.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.asciidoc/src/main/java/org/eclipse/mylyn/wikitext/asciidoc/internal/block/AdmonitionBlock.java
@@ -1,0 +1,198 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Johannes Kepler University Linz
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Alois Zoitl - initial API and implementation
+ *******************************************************************************/
+
+package org.eclipse.mylyn.wikitext.asciidoc.internal.block;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.eclipse.mylyn.wikitext.parser.Attributes;
+import org.eclipse.mylyn.wikitext.parser.DocumentBuilder.BlockType;
+import org.eclipse.mylyn.wikitext.parser.markup.Block;
+
+/**
+ * AsciiDoc Admonition block
+ */
+public class AdmonitionBlock extends Block {
+
+	private static final Pattern PATTERN = Pattern.compile(
+			"^\\[(NOTE|TIP|IMPORTANT|WARNING|CAUTION)\\]\\s*$" //$NON-NLS-1$
+			);
+
+	private static final String DELIMITER = "===="; //$NON-NLS-1$
+
+	private int blockLineCount = 0;
+	private boolean hasTitle;
+
+	@Override
+	public boolean canStart(String line, int lineOffset) {
+		if (lineOffset == 0 && PATTERN.matcher(line).matches()) {
+			hasTitle = false;
+			blockLineCount = 0;
+			return true;
+		}
+		return false;
+	}
+
+	@Override
+	protected int processLineContent(String line, int offset) {
+		if (blockLineCount == 0) {
+			return handleFirstLine(line, offset);
+		} else if (blockLineCount == 1) {
+			return handleSecondLine(line, offset);
+		} else if (blockLineCount == 2 && hasTitle) {
+			if (isDelimiter(line, offset)) {
+				emitContentParagraphStart();
+				blockLineCount++;
+				return -1;
+			}
+			setClosed(true);
+			return 0;
+		}
+
+		if (isDelimiter(line, offset)) {
+			// closing delimiter
+			setClosed(true);
+			return -1;
+		}
+
+		return 0; // indicate that a nested block should handle the content
+	}
+
+	@Override
+	public boolean beginNesting() {
+		if (hasTitle) {
+			return blockLineCount > 2;
+		}
+		return blockLineCount > 1;
+	}
+
+	@Override
+	public int findCloseOffset(String line, int lineOffset) {
+		if (beginNesting() && isDelimiter(line, lineOffset)) {
+			return 0;
+		}
+		return -1;
+	}
+
+	@Override
+	public boolean canResume(String line, int lineOffset) {
+		return isDelimiter(line, lineOffset);
+	}
+
+	@Override
+	public void setClosed(boolean closed) {
+		if (closed && !isClosed()) {
+			performClosing();
+			builder.characters("\n"); //$NON-NLS-1$
+		}
+		super.setClosed(closed);
+	}
+
+	private int handleFirstLine(String line, int offset) {
+		if (offset != 0) {
+			// admonitions always start at the beginning
+			return 0;
+		}
+
+		Matcher matcher = PATTERN.matcher(line);
+		if (!matcher.matches()) {
+			return 0;
+		}
+		String admonitionType = matcher.group(1);
+
+		emitAdminitionHeader(admonitionType);
+		emitAdmonitionTitle(admonitionType);
+		builder.characters("\n"); //$NON-NLS-1$
+		emitContentStart();
+		blockLineCount++;
+		return -1;
+	}
+
+	private int handleSecondLine(String line, int offset) {
+		if (line.charAt(0) == '.') {
+			Attributes titleAtt = new Attributes();
+			titleAtt.setCssClass("title"); //$NON-NLS-1$
+			builder.beginBlock(BlockType.DIV, titleAtt);
+			builder.characters(line.substring(1));
+			builder.endBlock();
+			builder.characters("\n"); //$NON-NLS-1$
+			blockLineCount++;
+			hasTitle = true;
+			return -1;
+		}
+
+		if (isDelimiter(line, offset)) {
+			emitContentParagraphStart();
+			blockLineCount++;
+			return -1;
+		}
+
+		setClosed(true);
+		return 0;
+	}
+
+
+	private boolean isDelimiter(String line, int offset) {
+		return offset == 0 && DELIMITER.equals(line.trim());
+	}
+
+	private void emitAdmonitionTitle(String admonitionType) {
+		Attributes iconAtt = new Attributes();
+		iconAtt.setCssClass("icon"); //$NON-NLS-1$
+		builder.beginBlock(BlockType.TABLE_CELL_NORMAL, iconAtt);
+		Attributes titleAtt = new Attributes();
+		titleAtt.setCssClass("title"); //$NON-NLS-1$
+		builder.beginBlock(BlockType.DIV, titleAtt);
+		builder.characters(admonitionType.substring(0, 1).toUpperCase());
+		builder.characters(admonitionType.substring(1).toLowerCase());
+		builder.endBlock();
+		builder.endBlock(); // end of icon/header cell
+	}
+
+	private void emitAdminitionHeader(String admonitionType) {
+		Attributes attributes = new Attributes();
+		attributes.setCssClass("admonitionblock " + admonitionType.toLowerCase()); //$NON-NLS-1$
+		builder.beginBlock(BlockType.DIV, attributes);
+		builder.beginBlock(BlockType.TABLE, new Attributes());
+		builder.beginBlock(BlockType.TABLE_ROW, new Attributes());
+	}
+
+	private void emitContentStart() {
+		Attributes contentAtt = new Attributes();
+		contentAtt.setCssClass("content"); //$NON-NLS-1$
+		builder.beginBlock(BlockType.TABLE_CELL_NORMAL, contentAtt);
+		builder.characters("\n"); //$NON-NLS-1$
+	}
+
+	private void emitContentParagraphStart() {
+		Attributes contentAtt = new Attributes();
+		contentAtt.setCssClass("paragraph"); //$NON-NLS-1$
+		builder.beginBlock(BlockType.DIV, contentAtt);
+		builder.characters("\n"); //$NON-NLS-1$
+	}
+
+	private void performClosing() {
+		if (beginNesting()) {
+			//only when we are in the begin nesting state this block has been added
+			builder.endBlock(); // </div> for content paragraph
+		}
+		builder.endBlock(); // </td>
+		builder.endBlock(); // </tr>
+		builder.endBlock(); // </table>
+		builder.endBlock(); // </div>
+	}
+
+
+}

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.asciidoc/src/main/java/org/eclipse/mylyn/wikitext/asciidoc/internal/block/UnderlinedHeadingBlock.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.asciidoc/src/main/java/org/eclipse/mylyn/wikitext/asciidoc/internal/block/UnderlinedHeadingBlock.java
@@ -55,18 +55,11 @@ public class UnderlinedHeadingBlock extends Block implements ReadAheadBlock {
 			return false;
 		} else {
 			int expectedLength = line.trim().length() - lineOffset;
-			if (checkNextLine(expectedLength, nextLine, h1pattern, 1)) {
-				return true;
-			} else if (checkNextLine(expectedLength, nextLine, h2pattern, 2)) {
-				return true;
-			} else if (checkNextLine(expectedLength, nextLine, h3pattern, 3)) {
-				return true;
-			} else if (checkNextLine(expectedLength, nextLine, h4pattern, 4)) {
-				return true;
-			} else if (checkNextLine(expectedLength, nextLine, h5pattern, 5)) {
-				return true;
-			}
-			return false;
+			return checkNextLine(expectedLength, nextLine, h1pattern, 1)
+					|| checkNextLine(expectedLength, nextLine, h2pattern, 2)
+					|| checkNextLine(expectedLength, nextLine, h3pattern, 3)
+					|| checkNextLine(expectedLength, nextLine, h4pattern, 4)
+					|| checkNextLine(expectedLength, nextLine, h5pattern, 5);
 		}
 	}
 
@@ -112,12 +105,19 @@ public class UnderlinedHeadingBlock extends Block implements ReadAheadBlock {
 			builder.beginHeading(level, attributes);
 			builder.characters(line.trim());
 		} else {
-			builder.endHeading();
 			setClosed(true);
 		}
 
 		blockLineCount++;
 		return -1;
+	}
+
+	@Override
+	public void setClosed(boolean closed) {
+		if (!isClosed() && closed && blockLineCount != 0) {
+			builder.endHeading();
+		}
+		super.setClosed(closed);
 	}
 
 	protected AsciiDocContentState getAsciiDocState() {

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.asciidoc/src/main/java/org/eclipse/mylyn/wikitext/asciidoc/internal/util/ReadAheadDispatcher.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.asciidoc/src/main/java/org/eclipse/mylyn/wikitext/asciidoc/internal/util/ReadAheadDispatcher.java
@@ -94,6 +94,10 @@ public class ReadAheadDispatcher extends Block {
 		super.setParser(parser);
 	}
 
+	public Block getDispatchedBlock() {
+		return dispatchedBlock;
+	}
+
 	@Override
 	public Block clone() {
 		ReadAheadDispatcher clone = (ReadAheadDispatcher) super.clone();


### PR DESCRIPTION
Admonition blocks now also generate the correct preview. The generated HMTL is corresponding the a default AsciiDocktor output. So that it can later be styled with an appropriate CSS file.