### PR TITLE
Clean up Jenkins UI #77

### DIFF
--- a/mylyn.builds/org.eclipse.mylyn.builds.ui/src/org/eclipse/mylyn/internal/builds/ui/editor/TimestampToStringConverter.java
+++ b/mylyn.builds/org.eclipse.mylyn.builds.ui/src/org/eclipse/mylyn/internal/builds/ui/editor/TimestampToStringConverter.java
@@ -8,24 +8,27 @@
  * SPDX-License-Identifier: EPL-2.0
  *
  *     Tasktop Technologies - initial API and implementation
+ *     See git history
  *******************************************************************************/
 
 package org.eclipse.mylyn.internal.builds.ui.editor;
 
-import java.util.Date;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
 
 import org.eclipse.core.databinding.conversion.IConverter;
-import org.eclipse.core.internal.databinding.conversion.DateConversionSupport;
 
 /**
  * @author Steffen Pingel
  */
-public class TimestampToStringConverter extends DateConversionSupport implements IConverter {
+public class TimestampToStringConverter implements IConverter<Long, String> {
+	private static final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSS Z"); //$NON-NLS-1$
 
 	@Override
-	public Object convert(Object source) {
+	public String convert(Long source) {
 		if (source != null) {
-			return format(new Date((Long) source));
+			return Instant.ofEpochMilli(source).atZone(ZoneId.systemDefault()).format(formatter);
 		}
 		return ""; //$NON-NLS-1$
 	}

--- a/mylyn.builds/org.eclipse.mylyn.builds.ui/src/org/eclipse/mylyn/internal/builds/ui/history/BuildHistoryPage.java
+++ b/mylyn.builds/org.eclipse.mylyn.builds.ui/src/org/eclipse/mylyn/internal/builds/ui/history/BuildHistoryPage.java
@@ -138,6 +138,10 @@ public class BuildHistoryPage extends HistoryPage {
 										build.setServer(plan.getServer());
 									}
 									viewer.setInput(builds);
+									for (TreeColumn column : viewer.getTree().getColumns()) {
+										column.pack();
+										column.setWidth(column.getWidth() + 10);
+									}
 								}
 							}
 						});

--- a/mylyn.builds/org.eclipse.mylyn.builds.ui/src/org/eclipse/mylyn/internal/builds/ui/view/BuildsView.java
+++ b/mylyn.builds/org.eclipse.mylyn.builds.ui/src/org/eclipse/mylyn/internal/builds/ui/view/BuildsView.java
@@ -462,7 +462,7 @@ public class BuildsView extends ViewPart implements IShowInTarget {
 		summaryColumn.setText(Messages.BuildsView_Summary);
 		summaryColumn.setWidth(220);
 
-		TreeViewerColumn lastBuiltViewerColumn = new TreeViewerColumn(viewer, SWT.RIGHT);
+		TreeViewerColumn lastBuiltViewerColumn = new TreeViewerColumn(viewer, SWT.LEFT);
 		lastBuiltViewerColumn.setLabelProvider(new RelativeBuildTimeLabelProvider());
 		TreeColumn lastBuiltColumn = lastBuiltViewerColumn.getColumn();
 		lastBuiltColumn.setText(Messages.BuildsView_LastBuilt);


### PR DESCRIPTION
Clean up the Jenkins UI slightly:

Make the detail start at date more understandable:
from:
<img width="366" height="38" alt="image" src="https://github.com/user-attachments/assets/13181ab6-f874-47bb-9a29-6b4c550a7264" />
to:
<img width="472" height="36" alt="image" src="https://github.com/user-attachments/assets/14698b53-f685-4adb-88c2-f75d065c79f1" />

Autosize the history columns:
from:
<img width="562" height="124" alt="image" src="https://github.com/user-attachments/assets/7c4a123b-cae2-435f-a417-40592ab68dc4" />
to:
<img width="1117" height="181" alt="image" src="https://github.com/user-attachments/assets/26361a8a-3657-493c-b4c0-6a2f93c514df" />


Task-Url: https://github.com/eclipse-mylyn/org.eclipse.mylyn/issues/77