### PR TITLE
Unstable Jenkins CI server #1111

### DIFF
--- a/mylyn.builds/org.eclipse.mylyn.jenkins.tests/src/org/eclipse/mylyn/jenkins/tests/AbstractFixtureTest.java
+++ b/mylyn.builds/org.eclipse.mylyn.jenkins.tests/src/org/eclipse/mylyn/jenkins/tests/AbstractFixtureTest.java
@@ -11,7 +11,7 @@
 
 package org.eclipse.mylyn.jenkins.tests;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import java.util.List;
 import java.util.concurrent.TimeUnit;
@@ -43,16 +43,20 @@ public abstract class AbstractFixtureTest {
 	protected String info;
 
 	static Stream<Arguments> fixtureProvider(boolean defaultOnly) {
-		if (discoveredFixtures[defaultOnly ? 1 : 0] == null) {
+		final int idx = defaultOnly ? 1 : 0;
+		if (discoveredFixtures[idx] == null) {
 			TestConfiguration defFixture = TestConfiguration.getDefault();
-			discoveredFixtures[defaultOnly ? 1 : 0] = (List<JenkinsFixture>) defFixture.discover(JenkinsFixture.class,
-					"jenkins", defaultOnly);
-			assertTrue(discoveredFixtures[defaultOnly ? 1 : 0].size() > 0, "No fixtures discovered");
-			for (JenkinsFixture fixture : discoveredFixtures[defaultOnly ? 1 : 0]) {
+			try {
+				discoveredFixtures[idx] = (List<JenkinsFixture>) defFixture.discover(JenkinsFixture.class, "jenkins",
+						defaultOnly);
+			} catch (RuntimeException e) {
+				System.err.println("Error discovering Jenkins fixtures: " + e.getMessage());
+			}
+			assumeTrue(discoveredFixtures[idx] != null && discoveredFixtures[idx].size() > 0, "No fixtures discovered");
+			for (JenkinsFixture fixture : discoveredFixtures[idx]) {
 				System.out.println("Discovered fixture: " + fixture.getInfo());
 			}
 		}
-		return discoveredFixtures[defaultOnly ? 1 : 0].stream()
-				.map(fixture -> Arguments.of(fixture, fixture.getInfo()));
+		return discoveredFixtures[idx].stream().map(fixture -> Arguments.of(fixture, fixture.getInfo()));
 	}
 }


### PR DESCRIPTION
Skip CI unit test if no Jenkins fixture are found.

May not be the best solution, but it stops PR builds from failing due to infrastructure problems.

Task-Url: https://github.com/eclipse-mylyn/org.eclipse.mylyn/issues/1111