### PR TITLE
Replace IOUtils, part 2 #1098

### DIFF
--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark.tests/META-INF/MANIFEST.MF
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark.tests/META-INF/MANIFEST.MF
@@ -11,6 +11,7 @@ Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=17))"
 Import-Package: net.bytebuddy;version="[1.18.0,2.0.0)",
  net.bytebuddy.agent;version="[1.18.0,2.0.0)",
  org.apache.commons.lang3;version="[3.14.0,4.0.0)",
+ org.eclipse.mylyn.internal.commons.core,
  org.eclipse.mylyn.wikitext.parser;version="[4.2,5)",
  org.eclipse.mylyn.wikitext.parser.builder;version="[4.2,5)",
  org.eclipse.mylyn.wikitext.parser.builder.event;version="4.12.0",

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark.tests/src/test/java/org/eclipse/mylyn/wikitext/commonmark/internal/spec/tests/CommonMarkSpecTest.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark.tests/src/test/java/org/eclipse/mylyn/wikitext/commonmark/internal/spec/tests/CommonMarkSpecTest.java
@@ -24,10 +24,8 @@ import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.InputStreamReader;
 import java.io.StringReader;
 import java.net.URI;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
@@ -36,8 +34,8 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.eclipse.mylyn.internal.commons.core.FileUtil;
 import org.eclipse.mylyn.wikitext.commonmark.CommonMarkLanguage;
 import org.eclipse.mylyn.wikitext.util.LocationTrackingReader;
 import org.eclipse.mylyn.wikitext.util.WikiToStringStyle;
@@ -174,12 +172,13 @@ public class CommonMarkSpecTest {
 		assertTrue(tmpFolder.exists(), tmpFolder.getAbsolutePath());
 		File spec = new File(tmpFolder, String.format("spec%s.txt", SPEC_VERSION));
 		if (!spec.exists()) {
-			try (FileOutputStream out = new FileOutputStream(spec)) {
-				IOUtils.copy(COMMONMARK_SPEC_URI.toURL(), out);
+			try (FileOutputStream out = new FileOutputStream(spec);
+					InputStream in = COMMONMARK_SPEC_URI.toURL().openStream()) {
+				in.transferTo(out);
 			}
 		}
 		try (InputStream in = new FileInputStream(spec)) {
-			return IOUtils.toString(new InputStreamReader(in, StandardCharsets.UTF_8));
+			return FileUtil.readFile(in);
 		}
 	}
 

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark/META-INF/MANIFEST.MF
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.commonmark/META-INF/MANIFEST.MF
@@ -11,8 +11,7 @@ Bundle-Name: Mylyn WikiText CommonMark
 Bundle-Vendor: Eclipse Mylyn
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=17))"
-Import-Package: org.apache.commons.io;version="[2.16.0,3.0.0)",
- org.apache.commons.lang3.builder;version="[3.14.0,4.0.0)",
+Import-Package: org.apache.commons.lang3.builder;version="[3.14.0,4.0.0)",
  org.eclipse.mylyn.wikitext.parser;version="[4.2,5)",
  org.eclipse.mylyn.wikitext.parser.builder;version="[4.2,5)",
  org.eclipse.mylyn.wikitext.parser.markup;version="[4.2,5)",

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.confluence.tests/META-INF/MANIFEST.MF
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.confluence.tests/META-INF/MANIFEST.MF
@@ -8,7 +8,7 @@ Bundle-Vendor: Eclipse Mylyn
 Fragment-Host: org.eclipse.mylyn.wikitext.confluence
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=17))"
-Import-Package: org.apache.commons.io;version="[2.16.0,3.0.0)",
+Import-Package: org.eclipse.mylyn.internal.commons.core,
  org.eclipse.mylyn.wikitext.html;version="4.12.0",
  org.eclipse.mylyn.wikitext.parser;version="[4.2,5)",
  org.eclipse.mylyn.wikitext.parser.builder;version="[4.2,5)",

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.confluence.tests/src/test/java/org/eclipse/mylyn/wikitext/confluence/tests/ConfluenceLanguageTest.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.confluence.tests/src/test/java/org/eclipse/mylyn/wikitext/confluence/tests/ConfluenceLanguageTest.java
@@ -15,7 +15,6 @@
  *******************************************************************************/
 package org.eclipse.mylyn.wikitext.confluence.tests;
 
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -26,10 +25,9 @@ import java.io.StringReader;
 import java.io.StringWriter;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.nio.charset.StandardCharsets;
 import java.util.regex.Pattern;
 
-import org.apache.commons.io.IOUtils;
+import org.eclipse.mylyn.internal.commons.core.FileUtil;
 import org.eclipse.mylyn.wikitext.confluence.ConfluenceLanguage;
 import org.eclipse.mylyn.wikitext.parser.builder.DocBookDocumentBuilder;
 import org.eclipse.mylyn.wikitext.parser.builder.HtmlDocumentBuilder;
@@ -1307,8 +1305,7 @@ public class ConfluenceLanguageTest extends AbstractMarkupGenerationTest<Conflue
 	 */
 	@Test
 	public void testHangOnBug318695() throws IOException {
-		String content = IOUtils.toString(ConfluenceLanguageTest.class.getResource("resources/bug318695.confluence"),
-				StandardCharsets.UTF_8);
+		String content = FileUtil.readFile(ConfluenceLanguageTest.class, "resources/bug318695.confluence");
 		parser.setBuilder(new HtmlDocumentBuilder(new StringWriter()));
 		parser.parse(new StringReader(content));
 		// if we reach here we didn't hang.
@@ -1319,8 +1316,7 @@ public class ConfluenceLanguageTest extends AbstractMarkupGenerationTest<Conflue
 	 */
 	@Test
 	public void stackOverflowWithLargeContentOnBug424387() throws IOException {
-		String content = IOUtils.toString(ConfluenceLanguageTest.class.getResource("resources/bug424387.confluence"),
-				StandardCharsets.UTF_8);
+		String content = FileUtil.readFile(ConfluenceLanguageTest.class, "resources/bug424387.confluence");
 		parser.setBuilder(new HtmlDocumentBuilder(new StringWriter()));
 		parser.parse(new StringReader(content));
 		// if we reach here we didn't hang.
@@ -1331,8 +1327,7 @@ public class ConfluenceLanguageTest extends AbstractMarkupGenerationTest<Conflue
 	 */
 	@Test
 	public void stackOverflowWithLargeContentInTable() throws IOException {
-		String content = IOUtils.toString(ConfluenceLanguageTest.class.getResource("resources/bug533397.confluence"),
-				StandardCharsets.UTF_8);
+		String content = FileUtil.readFile(ConfluenceLanguageTest.class, "resources/bug533397.confluence");
 		parser.setBuilder(new HtmlDocumentBuilder(new StringWriter()));
 		parser.parse(new StringReader(content));
 		// if we reach here we didn't hang.

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.html.tests/META-INF/MANIFEST.MF
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.html.tests/META-INF/MANIFEST.MF
@@ -8,7 +8,7 @@ Bundle-Vendor: Eclipse Mylyn
 Fragment-Host: org.eclipse.mylyn.wikitext.html
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=17))"
-Import-Package: org.apache.commons.io;version="[2.16.0,3.0.0)",
+Import-Package: org.eclipse.mylyn.internal.commons.core,
  org.eclipse.mylyn.wikitext.parser;version="[4.2,5)",
  org.eclipse.mylyn.wikitext.parser.builder;version="[4.2,5)",
  org.eclipse.mylyn.wikitext.parser.builder.event;version="4.12.0",

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.html.tests/src/test/java/org/eclipse/mylyn/wikitext/html/tests/HtmlLanguageTest.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.html.tests/src/test/java/org/eclipse/mylyn/wikitext/html/tests/HtmlLanguageTest.java
@@ -15,7 +15,6 @@
 
 package org.eclipse.mylyn.wikitext.html.tests;
 
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -24,10 +23,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.io.IOException;
 import java.io.StringWriter;
 import java.io.Writer;
-import java.net.URL;
-import java.nio.charset.StandardCharsets;
-
-import org.apache.commons.io.IOUtils;
+import org.eclipse.mylyn.internal.commons.core.FileUtil;
 import org.eclipse.mylyn.wikitext.html.HtmlLanguage;
 import org.eclipse.mylyn.wikitext.parser.Attributes;
 import org.eclipse.mylyn.wikitext.parser.DocumentBuilder;
@@ -165,8 +161,7 @@ public class HtmlLanguageTest {
 	private String loadResourceContent(String resourceName) {
 		try {
 			String fileName = HtmlLanguageTest.class.getSimpleName() + '_' + resourceName;
-			URL resource = HtmlLanguageTest.class.getResource(fileName);
-			return convertToUnixLineEndings(IOUtils.toString(resource, StandardCharsets.UTF_8));
+			return convertToUnixLineEndings(FileUtil.readFile(HtmlLanguageTest.class, fileName));
 		} catch (IOException e) {
 			throw new RuntimeException(e);
 		}

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.mediawiki.tests/META-INF/MANIFEST.MF
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.mediawiki.tests/META-INF/MANIFEST.MF
@@ -8,8 +8,8 @@ Bundle-Vendor: Eclipse Mylyn
 Fragment-Host: org.eclipse.mylyn.wikitext.mediawiki
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=17))"
-Import-Package: org.apache.commons.io;version="[2.16.0,3.0.0)",
- org.apache.commons.lang3;version="[3.14.0,4.0.0)",
+Import-Package: org.apache.commons.lang3;version="[3.14.0,4.0.0)",
+ org.eclipse.mylyn.internal.commons.core,
  org.eclipse.mylyn.wikitext.parser.builder;version="4.12.0",
  org.eclipse.mylyn.wikitext.parser.markup;version="[4.2,5)",
  org.eclipse.mylyn.wikitext.parser.outline;version="[4.2,5)",

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.mediawiki.tests/src/test/java/org/eclipse/mylyn/wikitext/mediawiki/internal/tests/MediaWikiLanguageTest.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.mediawiki.tests/src/test/java/org/eclipse/mylyn/wikitext/mediawiki/internal/tests/MediaWikiLanguageTest.java
@@ -15,7 +15,6 @@
  *******************************************************************************/
 package org.eclipse.mylyn.wikitext.mediawiki.internal.tests;
 
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -23,7 +22,6 @@ import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.IOException;
 import java.io.StringWriter;
-import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
@@ -31,8 +29,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Set;
 import java.util.regex.Pattern;
-
-import org.apache.commons.io.IOUtils;
+import org.eclipse.mylyn.internal.commons.core.FileUtil;
 import org.eclipse.mylyn.wikitext.mediawiki.MediaWikiLanguage;
 import org.eclipse.mylyn.wikitext.mediawiki.Template;
 import org.eclipse.mylyn.wikitext.parser.builder.DocBookDocumentBuilder;
@@ -1492,7 +1489,7 @@ public class MediaWikiLanguageTest extends AbstractMarkupGenerationTest<MediaWik
 	}
 
 	private String readFully(String resource) throws IOException {
-		return IOUtils.toString(MediaWikiLanguageTest.class.getResource(resource), StandardCharsets.UTF_8);
+		return FileUtil.readFile(MediaWikiLanguageTest.class, resource);
 	}
 
 	private void assertContainsPattern(String html, Pattern pattern) {

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.mediawiki/META-INF/MANIFEST.MF
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.mediawiki/META-INF/MANIFEST.MF
@@ -7,7 +7,7 @@ Bundle-Name: Mylyn WikiText MediaWiki
 Bundle-Vendor: Eclipse Mylyn
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=17))"
-Import-Package: org.apache.commons.io;version="[2.16.0,3.0.0)",
+Import-Package: org.eclipse.mylyn.internal.commons.core,
  org.eclipse.mylyn.wikitext.parser;version="[4.2,5)",
  org.eclipse.mylyn.wikitext.parser.markup;version="[4.2,5)",
  org.eclipse.mylyn.wikitext.parser.markup.block;version="[4.2,5)",

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.mediawiki/src/main/java/org/eclipse/mylyn/wikitext/mediawiki/WikiTemplateResolver.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.mediawiki/src/main/java/org/eclipse/mylyn/wikitext/mediawiki/WikiTemplateResolver.java
@@ -15,14 +15,15 @@
 package org.eclipse.mylyn.wikitext.mediawiki;
 
 import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.text.MessageFormat;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-
-import org.apache.commons.io.IOUtils;
+import org.eclipse.mylyn.internal.commons.core.FileUtil;
 
 /**
  * compute the contents of a template based on
@@ -72,7 +73,7 @@ public class WikiTemplateResolver extends TemplateResolver {
 	}
 
 	protected String readContent(URL url) throws IOException {
-		return IOUtils.toString(url, StandardCharsets.UTF_8);
+		return FileUtil.readFile(url);
 	}
 
 	private URL computeRawUrl(String path) {
@@ -82,8 +83,8 @@ public class WikiTemplateResolver extends TemplateResolver {
 				qualifiedUrl += "/"; //$NON-NLS-1$
 			}
 			qualifiedUrl += "index.php?title=" + URLEncoder.encode(path, StandardCharsets.UTF_8) + "&action=raw"; //$NON-NLS-1$ //$NON-NLS-2$
-			return new URL(qualifiedUrl);
-		} catch (IOException e) {
+			return new URI(qualifiedUrl).toURL();
+		} catch (IOException | URISyntaxException e) {
 			Logger.getLogger(WikiTemplateResolver.class.getName())
 			.log(Level.WARNING,
 					MessageFormat.format("Cannot compute raw URL for {0}: {1}", path, e.getMessage()), e); //$NON-NLS-1$

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.tests/META-INF/MANIFEST.MF
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.tests/META-INF/MANIFEST.MF
@@ -7,7 +7,7 @@ Bundle-Name: Mylyn WikiText Integration Tests
 Bundle-Vendor: Eclipse Mylyn
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Require-Bundle: org.eclipse.mylyn.wikitext.textile
-Import-Package: org.apache.commons.io;version="[2.16.0,3.0.0)",
+Import-Package: org.eclipse.mylyn.internal.commons.core,
  org.eclipse.mylyn.wikitext.confluence;version="[4.3.0,5.0.0)",
  org.eclipse.mylyn.wikitext.internal.parser.html,
  org.eclipse.mylyn.wikitext.mediawiki;version="[4.3.0,5.0.0)",

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.tests/src/test/java/org/eclipse/mylyn/wikitext/parser/builder/tests/HtmlDocumentBuilderTest.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.tests/src/test/java/org/eclipse/mylyn/wikitext/parser/builder/tests/HtmlDocumentBuilderTest.java
@@ -15,7 +15,6 @@
 
 package org.eclipse.mylyn.wikitext.parser.builder.tests;
 
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -24,10 +23,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.io.StringWriter;
-import java.net.URL;
-import java.nio.charset.StandardCharsets;
-
-import org.apache.commons.io.IOUtils;
+import org.eclipse.mylyn.internal.commons.core.FileUtil;
 import org.eclipse.mylyn.wikitext.parser.Attributes;
 import org.eclipse.mylyn.wikitext.parser.DocumentBuilder.BlockType;
 import org.eclipse.mylyn.wikitext.parser.DocumentBuilder.SpanType;
@@ -410,8 +406,7 @@ public class HtmlDocumentBuilderTest {
 	private String loadResourceContent(String resourceName) {
 		try {
 			String fileName = HtmlDocumentBuilderTest.class.getSimpleName() + '_' + resourceName + ".xml";
-			URL resource = HtmlDocumentBuilderTest.class.getResource(fileName);
-			return convertToUnixLineEndings(IOUtils.toString(resource, StandardCharsets.UTF_8));
+			return convertToUnixLineEndings(FileUtil.readFile(HtmlDocumentBuilderTest.class, fileName));
 		} catch (IOException e) {
 			throw new RuntimeException(e);
 		}

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.tests/src/test/java/org/eclipse/mylyn/wikitext/parser/builder/tests/SplittingHtmlDocumentBuilderTest.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.tests/src/test/java/org/eclipse/mylyn/wikitext/parser/builder/tests/SplittingHtmlDocumentBuilderTest.java
@@ -26,7 +26,7 @@ import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.nio.charset.StandardCharsets;
 
-import org.apache.commons.io.IOUtils;
+import org.eclipse.mylyn.internal.commons.core.FileUtil;
 import org.eclipse.mylyn.wikitext.parser.MarkupParser;
 import org.eclipse.mylyn.wikitext.parser.builder.HtmlDocumentBuilder;
 import org.eclipse.mylyn.wikitext.splitter.DefaultSplittingStrategy;
@@ -102,9 +102,9 @@ public class SplittingHtmlDocumentBuilderTest {
 
 	private void assertFileContents(String resource, File outputFile) throws IOException {
 		String resourcePath = "resources/SplittingHtmlDocumentBuilderTest_" + resource;
-		String resourceContents = convertToUnixLineEndings(IOUtils
-				.toString(SplittingHtmlDocumentBuilderTest.class.getResource(resourcePath), StandardCharsets.UTF_8));
-		String actualContents = IOUtils.toString(outputFile.toURI().toURL(), StandardCharsets.UTF_8);
+		String resourceContents = convertToUnixLineEndings(
+				FileUtil.readFile(SplittingHtmlDocumentBuilderTest.class, resourcePath));
+		String actualContents = FileUtil.readFile(outputFile);
 		assertEquals(resourceContents, actualContents, format("Resource {0} differs", resourcePath));
 	}
 

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.tests/src/test/java/org/eclipse/mylyn/wikitext/parser/builder/tests/XslfoDocumentBuilderIntegrationTest.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.tests/src/test/java/org/eclipse/mylyn/wikitext/parser/builder/tests/XslfoDocumentBuilderIntegrationTest.java
@@ -16,7 +16,6 @@
 
 package org.eclipse.mylyn.wikitext.parser.builder.tests;
 
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -24,10 +23,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.io.IOException;
 import java.io.StringWriter;
 import java.net.URL;
-import java.nio.charset.StandardCharsets;
 import java.util.regex.Pattern;
 
-import org.apache.commons.io.IOUtils;
+import org.eclipse.mylyn.internal.commons.core.FileUtil;
 import org.eclipse.mylyn.wikitext.mediawiki.MediaWikiLanguage;
 import org.eclipse.mylyn.wikitext.parser.MarkupParser;
 import org.eclipse.mylyn.wikitext.parser.builder.XslfoDocumentBuilder;
@@ -310,7 +308,7 @@ public class XslfoDocumentBuilderIntegrationTest {
 		URL resource = XslfoDocumentBuilderIntegrationTest.class.getResource(
 				"resources/" + XslfoDocumentBuilderIntegrationTest.class.getSimpleName() + "_" + resourceName);
 		try {
-			return IOUtils.toString(resource, StandardCharsets.UTF_8);
+			return FileUtil.readFile(resource);
 		} catch (IOException e) {
 			throw new RuntimeException(e);
 		}

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.toolkit/META-INF/MANIFEST.MF
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.toolkit/META-INF/MANIFEST.MF
@@ -7,8 +7,8 @@ Bundle-Name: Mylyn WikiText Toolkit
 Bundle-Vendor: Eclipse Mylyn
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=17))"
-Import-Package: org.apache.commons.io;version="[2.16.0,3.0.0)",
- org.apache.commons.lang3;version="[3.14.0,4.0.0)",
+Import-Package: org.apache.commons.lang3;version="[3.14.0,4.0.0)",
+ org.eclipse.mylyn.internal.commons.core,
  org.eclipse.mylyn.wikitext.parser;version="[4.2,5)",
  org.eclipse.mylyn.wikitext.parser.builder;version="[4.2,5)",
  org.eclipse.mylyn.wikitext.parser.markup;version="[4.2,5)",

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.toolkit/src/main/java/org/eclipse/mylyn/wikitext/toolkit/TestResources.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.toolkit/src/main/java/org/eclipse/mylyn/wikitext/toolkit/TestResources.java
@@ -19,8 +19,7 @@ import static java.util.Objects.requireNonNull;
 import java.io.IOException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
-
-import org.apache.commons.io.IOUtils;
+import org.eclipse.mylyn.internal.commons.core.FileUtil;
 
 /**
  * @since 3.0
@@ -32,7 +31,7 @@ public class TestResources {
 		try {
 			URL url = relativeToClass.getResource(path);
 			requireNonNull(url, String.format("Resource %s not found relative to %s", path, relativeToClass.getName()));
-			return convertToUnixLineEndings(IOUtils.toString(url, StandardCharsets.UTF_8));
+			return convertToUnixLineEndings(FileUtil.readFile(url));
 		} catch (IOException e) {
 			throw new RuntimeException(e);
 		}

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext/src/main/java/org/eclipse/mylyn/wikitext/parser/css/AnySelector.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext/src/main/java/org/eclipse/mylyn/wikitext/parser/css/AnySelector.java
@@ -9,6 +9,7 @@
  *
  * Contributors:
  *     David Green - initial API and implementation
+ *     See git history
  *******************************************************************************/
 
 package org.eclipse.mylyn.wikitext.parser.css;
@@ -26,4 +27,18 @@ public class AnySelector extends Selector {
 		return true;
 	}
 
+	@Override
+	public boolean equals(Object obj) {
+		return obj instanceof AnySelector;
+	}
+
+	@Override
+	public int hashCode() {
+		return AnySelector.class.hashCode();
+	}
+
+	@Override
+	public String toString() {
+		return "*"; //$NON-NLS-1$
+	}
 }

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext/src/main/java/org/eclipse/mylyn/wikitext/parser/css/Block.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext/src/main/java/org/eclipse/mylyn/wikitext/parser/css/Block.java
@@ -15,6 +15,7 @@ package org.eclipse.mylyn.wikitext.parser.css;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * An abstraction for a block of CSS rules
@@ -43,5 +44,21 @@ public class Block {
 
 	public List<CssRule> getRules() {
 		return rules;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj) {
+			return true;
+		}
+		if (!(obj instanceof Block other)) {
+			return false;
+		}
+		return Objects.equals(selector, other.selector) && Objects.equals(rules, other.rules);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(selector, rules);
 	}
 }

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext/src/main/java/org/eclipse/mylyn/wikitext/parser/css/CompositeSelector.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext/src/main/java/org/eclipse/mylyn/wikitext/parser/css/CompositeSelector.java
@@ -9,11 +9,14 @@
  *
  * Contributors:
  *     David Green - initial API and implementation
+ *     See git history
  *******************************************************************************/
 
 package org.eclipse.mylyn.wikitext.parser.css;
 
 import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
 
 /**
  * A selector that can select based on a set of delegates.
@@ -59,4 +62,25 @@ public class CompositeSelector extends Selector {
 		return delegates;
 	}
 
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj) {
+			return true;
+		}
+		if (!(obj instanceof CompositeSelector other)) {
+			return false;
+		}
+		return and == other.and && Objects.equals(delegates, other.delegates);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(and, delegates);
+	}
+
+	@Override
+	public String toString() {
+		String separator = and ? "" : ", "; //$NON-NLS-1$//$NON-NLS-2$
+		return delegates.stream().map(Selector::toString).collect(Collectors.joining(separator));
+	}
 }

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext/src/main/java/org/eclipse/mylyn/wikitext/parser/css/CssClassSelector.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext/src/main/java/org/eclipse/mylyn/wikitext/parser/css/CssClassSelector.java
@@ -9,9 +9,12 @@
  *
  * Contributors:
  *     David Green - initial API and implementation
+ *     See git history
  *******************************************************************************/
 
 package org.eclipse.mylyn.wikitext.parser.css;
+
+import java.util.Objects;
 
 /**
  * a selector that selects elements based on their having a CSS class
@@ -21,6 +24,7 @@ package org.eclipse.mylyn.wikitext.parser.css;
  * @since 3.0
  */
 public class CssClassSelector extends Selector {
+
 	private final String cssClass;
 
 	public CssClassSelector(String cssClass) {
@@ -34,5 +38,26 @@ public class CssClassSelector extends Selector {
 
 	public String getCssClass() {
 		return cssClass;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj) {
+			return true;
+		}
+		if (!(obj instanceof CssClassSelector other)) {
+			return false;
+		}
+		return Objects.equals(cssClass, other.cssClass);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(cssClass);
+	}
+
+	@Override
+	public String toString() {
+		return "." + cssClass; //$NON-NLS-1$
 	}
 }

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext/src/main/java/org/eclipse/mylyn/wikitext/parser/css/CssRule.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext/src/main/java/org/eclipse/mylyn/wikitext/parser/css/CssRule.java
@@ -9,9 +9,12 @@
  *
  * Contributors:
  *     David Green - initial API and implementation
+ *     See git history
  *******************************************************************************/
 
 package org.eclipse.mylyn.wikitext.parser.css;
+
+import java.util.Objects;
 
 /**
  * A rule (name and value) as defined by CSS
@@ -59,4 +62,19 @@ public class CssRule {
 		this.valueOffset = valueOffset;
 	}
 
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj) {
+			return true;
+		}
+		if (!(obj instanceof CssRule other)) {
+			return false;
+		}
+		return Objects.equals(name, other.name) && Objects.equals(value, other.value);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(name, value);
+	}
 }

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext/src/main/java/org/eclipse/mylyn/wikitext/parser/css/DescendantSelector.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext/src/main/java/org/eclipse/mylyn/wikitext/parser/css/DescendantSelector.java
@@ -9,9 +9,12 @@
  *
  * Contributors:
  *     David Green - initial API and implementation
+ *     See git history
  *******************************************************************************/
 
 package org.eclipse.mylyn.wikitext.parser.css;
+
+import java.util.Objects;
 
 /**
  * @author David Green
@@ -41,4 +44,24 @@ public class DescendantSelector extends Selector {
 		return ancestorSelector;
 	}
 
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj) {
+			return true;
+		}
+		if (!(obj instanceof DescendantSelector other)) {
+			return false;
+		}
+		return Objects.equals(ancestorSelector, other.ancestorSelector);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(ancestorSelector);
+	}
+
+	@Override
+	public String toString() {
+		return ancestorSelector.toString() + " *"; //$NON-NLS-1$
+	}
 }

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext/src/main/java/org/eclipse/mylyn/wikitext/parser/css/IdSelector.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext/src/main/java/org/eclipse/mylyn/wikitext/parser/css/IdSelector.java
@@ -9,9 +9,12 @@
  *
  * Contributors:
  *     David Green - initial API and implementation
+ *     See git history
  *******************************************************************************/
 
 package org.eclipse.mylyn.wikitext.parser.css;
+
+import java.util.Objects;
 
 /**
  * A selector that selects elements having an id equal to a specific value.
@@ -36,4 +39,24 @@ public class IdSelector extends Selector {
 		return id;
 	}
 
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj) {
+			return true;
+		}
+		if (!(obj instanceof IdSelector other)) {
+			return false;
+		}
+		return Objects.equals(id, other.id);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(id);
+	}
+
+	@Override
+	public String toString() {
+		return "#" + id; //$NON-NLS-1$
+	}
 }

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext/src/main/java/org/eclipse/mylyn/wikitext/parser/css/NameSelector.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext/src/main/java/org/eclipse/mylyn/wikitext/parser/css/NameSelector.java
@@ -9,9 +9,12 @@
  *
  * Contributors:
  *     David Green - initial API and implementation
+ *     see git history
  *******************************************************************************/
 
 package org.eclipse.mylyn.wikitext.parser.css;
+
+import java.util.Objects;
 
 /**
  * a selector that selects elements based on their {@link ElementInfo#getLocalName() name}
@@ -20,6 +23,7 @@ package org.eclipse.mylyn.wikitext.parser.css;
  * @since 3.0
  */
 public class NameSelector extends Selector {
+
 	private final String name;
 
 	public NameSelector(String name) {
@@ -32,6 +36,27 @@ public class NameSelector extends Selector {
 	}
 
 	public String getName() {
+		return name;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj) {
+			return true;
+		}
+		if (!(obj instanceof NameSelector other)) {
+			return false;
+		}
+		return Objects.equals(name, other.name);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(name);
+	}
+
+	@Override
+	public String toString() {
 		return name;
 	}
 }

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext/src/main/java/org/eclipse/mylyn/wikitext/parser/css/Stylesheet.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext/src/main/java/org/eclipse/mylyn/wikitext/parser/css/Stylesheet.java
@@ -9,6 +9,7 @@
  *
  * Contributors:
  *     David Green - initial API and implementation
+ *     See git history
  *******************************************************************************/
 
 package org.eclipse.mylyn.wikitext.parser.css;
@@ -16,6 +17,8 @@ package org.eclipse.mylyn.wikitext.parser.css;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
 
 /**
  * An abstraction for a CSS stylesheet.
@@ -48,5 +51,32 @@ public class Stylesheet {
 
 	void add(Block block) {
 		blocks.add(block);
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj) {
+			return true;
+		}
+		if (!(obj instanceof Stylesheet other)) {
+			return false;
+		}
+		return Objects.equals(blocks, other.blocks);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(blocks);
+	}
+
+	@Override
+	public String toString() {
+		return blocks.stream()
+				.map(block -> block.getSelector().toString() + " { " //$NON-NLS-1$
+						+ block.getRules().stream()
+						.map(r -> r.name + ": " + r.value) //$NON-NLS-1$
+						.collect(Collectors.joining("; ")) //$NON-NLS-1$
+						+ " }") //$NON-NLS-1$
+				.collect(Collectors.joining("\n")); //$NON-NLS-1$
 	}
 }


### PR DESCRIPTION
Replace some more IOUtils usage

Should commons.core.FileUtil be referenced like this???

Task-Url: https://github.com/eclipse-mylyn/org.eclipse.mylyn/issues/1098