### PR TITLE
JUnit4 uses #1125

### DIFF
--- a/mylyn.context/org.eclipse.mylyn.context.sdk.java/META-INF/MANIFEST.MF
+++ b/mylyn.context/org.eclipse.mylyn.context.sdk.java/META-INF/MANIFEST.MF
@@ -25,6 +25,5 @@ Require-Bundle: org.eclipse.core.resources;bundle-version="0.0.0",
  org.eclipse.ui.ide;bundle-version="0.0.0"
 Export-Package: org.eclipse.mylyn.context.sdk.java;x-internal:=true,
  org.eclipse.mylyn.context.sdk.java.search;x-internal:=true
-Import-Package: junit.framework,
- org.junit.jupiter.api;version="[6.0.0,7.0.0)"
+Import-Package: org.junit.jupiter.api;version="[6.0.0,7.0.0)"
 Bundle-RequiredExecutionEnvironment: JavaSE-21

--- a/mylyn.context/org.eclipse.mylyn.context.sdk.java/src/org/eclipse/mylyn/context/sdk/java/search/SearchPluginTestHelper.java
+++ b/mylyn.context/org.eclipse.mylyn.context.sdk.java/src/org/eclipse/mylyn/context/sdk/java/search/SearchPluginTestHelper.java
@@ -13,6 +13,10 @@
 
 package org.eclipse.mylyn.context.sdk.java.search;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
 import java.io.IOException;
 import java.util.Date;
 import java.util.List;
@@ -25,13 +29,11 @@ import org.eclipse.mylyn.context.sdk.util.search.ISearchPluginTest;
 import org.eclipse.mylyn.internal.context.core.IActiveSearchListener;
 import org.eclipse.mylyn.internal.context.core.IActiveSearchOperation;
 
-import junit.framework.TestCase;
-
 /**
  * @author Shawn Minto
  */
 @SuppressWarnings("nls")
-public class SearchPluginTestHelper extends TestCase {
+public class SearchPluginTestHelper {
 
 	private final ISearchPluginTest test;
 
@@ -59,8 +61,8 @@ public class SearchPluginTestHelper extends TestCase {
 				}
 			}
 		}
-		assertNotNull("Results Null", results);
-		assertEquals("Wrong number search results", expected, size);
+		assertNotNull(results, "Results Null");
+		assertEquals(expected, size, "Wrong number search results");
 		notifier.clearContext();
 	}
 
@@ -81,8 +83,8 @@ public class SearchPluginTestHelper extends TestCase {
 			}
 		}
 
-		assertNotNull("Results Null", results);
-		assertEquals("Wrong number search results", expected, size);
+		assertNotNull(results, "Results Null");
+		assertEquals(expected, size, "Wrong number search results");
 		notifier.clearContext();
 	}
 
@@ -98,8 +100,8 @@ public class SearchPluginTestHelper extends TestCase {
 				}
 			}
 		}
-		assertNotNull("Results Null", results);
-		assertEquals("Wrong number search results", expected, size);
+		assertNotNull(results, "Results Null");
+		assertEquals(expected, size, "Wrong number search results");
 		notifier.clearContext();
 	}
 
@@ -108,14 +110,14 @@ public class SearchPluginTestHelper extends TestCase {
 		notifier.mockRaiseInterest(handle, kind);
 
 		List<?> results = test.search(dos, searchNode);
-		assertNull("Results Not Null", results);
+		assertNull(results, "Results Not Null");
 		notifier.clearContext();
 	}
 
 	public void searchResultsNull(ActiveSearchNotifier notifier, IInteractionElement searchNode, int dos)
 			throws IOException, CoreException {
 		List<?> results = test.search(dos, searchNode);
-		assertNull("Results Not Null", results);
+		assertNull(results, "Results Not Null");
 		notifier.clearContext();
 	}
 

--- a/mylyn.releng/org.eclipse.mylyn.parent/pom.xml
+++ b/mylyn.releng/org.eclipse.mylyn.parent/pom.xml
@@ -367,6 +367,7 @@
           <artifactId>tycho-surefire-plugin</artifactId>
           <version>${tycho-version}</version>
           <configuration>
+          	<providerHint>junit6</providerHint>
             <skip>${test.skip}</skip>
             <useUIThread>${test.useUIThread}</useUIThread>
             <useUIHarness>true</useUIHarness>


### PR DESCRIPTION
Another JUnit4 use outside test bundle.

Noticed that org.eclipse.mylyn.context.sdk.java/org.eclipse.mylyn.context.sdk.util has some test utility classes:
- AbstractContextTest
- AbstractResourceContextTest
- AbstractJavaContextTest

 I don't think they belong there


Also noticed that surefire was using junit4 for some bundles
- org.eclipse.mylyn.debug.tests
- org.eclipse.mylyn.ide.tests
- org.eclipse.mylyn.java.tests
- org.eclipse.mylyn.team.tests
- org.eclipse.mylyn.tests
```
[INFO] --- tycho-surefire:5.0.3:test (default-test) @ org.eclipse.mylyn.debug.tests ---
[INFO] Selected test framework junit (4.0.0) with provider junit4 [4.0.0,5.0.0)
```

I have no idea why surefire is using juni4 for these.

Task-Url: https://github.com/eclipse-mylyn/org.eclipse.mylyn/issues/1125