### PR TITLE
add 'build-helper-maven-plugin' version to parent pom #654

### DIFF
--- a/mylyn.docs/pom.xml
+++ b/mylyn.docs/pom.xml
@@ -40,12 +40,7 @@
     <build>
         <pluginManagement>
             <plugins>
-                <plugin>
-                    <groupId>org.codehaus.mojo</groupId>
-                    <artifactId>build-helper-maven-plugin</artifactId>
-                    <version>3.6.1</version>
-                </plugin>
-                <plugin>
+                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>versions-maven-plugin</artifactId>
                     <version>2.21.0</version>

--- a/mylyn.releng/org.eclipse.mylyn.parent/pom.xml
+++ b/mylyn.releng/org.eclipse.mylyn.parent/pom.xml
@@ -465,6 +465,11 @@
                 <local>true</local>
             </configuration>
         </plugin>
+		<plugin>
+			<groupId>org.codehaus.mojo</groupId>
+			<artifactId>build-helper-maven-plugin</artifactId>
+			<version>3.6.1</version>
+		</plugin>
       </plugins>
     </pluginManagement>
   </build>


### PR DESCRIPTION
Maven complains about missing 'build-helper-maven-plugin' version for jenkins.core

Task-Url: https://github.com/eclipse-mylyn/org.eclipse.mylyn/issues/654