### PR TITLE
[#1162] Resolve `@since` warnings for `org.eclipse.mylyn.jenkins.core`

### DIFF
--- a/mylyn.builds/org.eclipse.mylyn.jenkins.core/META-INF/MANIFEST.MF
+++ b/mylyn.builds/org.eclipse.mylyn.jenkins.core/META-INF/MANIFEST.MF
@@ -14,9 +14,9 @@ Require-Bundle: org.eclipse.core.runtime;bundle-version="0.0.0",
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Bundle-Localization: plugin
-Export-Package: org.eclipse.mylyn.internal.hudson.model,
- org.eclipse.mylyn.internal.jenkins.core,
- org.eclipse.mylyn.internal.jenkins.core.client;x-friends:="org.eclipse.mylyn.jenkins.ui",
+Export-Package: org.eclipse.mylyn.internal.hudson.model;x-friends:="org.eclipse.mylyn.jenkins.tests",
+ org.eclipse.mylyn.internal.jenkins.core;x-friends:="org.eclipse.mylyn.jenkins.tests,org.eclipse.mylyn.jenkins.ui",
+ org.eclipse.mylyn.internal.jenkins.core.client;x-friends:="org.eclipse.mylyn.jenkins.ui,org.eclipse.mylyn.jenkins.tests",
  org.eclipse.mylyn.jenkins.core;x-friends:="org.eclipse.mylyn.jenkins.ui"
 Bundle-Activator: org.eclipse.mylyn.internal.jenkins.core.JenkinsCorePlugin
 Import-Package: com.google.gson;version="2.9.1",


### PR DESCRIPTION
* internal packages should not be a part of API

Fixes #1162 