### PR TITLE
Simplify/improve the target platform and the update site

### DIFF
--- a/mylyn.commons/org.eclipse.mylyn.commons.notifications.feed/META-INF/MANIFEST.MF
+++ b/mylyn.commons/org.eclipse.mylyn.commons.notifications.feed/META-INF/MANIFEST.MF
@@ -8,10 +8,11 @@ Bundle-Vendor: %Bundle-Vendor
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Export-Package: org.eclipse.mylyn.commons.notifications.feed;x-internal:=true,
  org.eclipse.mylyn.internal.commons.notifications.feed;x-internal:=true
-Import-Package: com.sun.xml.bind;version="2.3.3",
- javax.activation;version="1.2.2",
- javax.xml.bind;version="2.3.3",
- javax.xml.bind.annotation;version="2.3.3"
+Import-Package: jakarta.xml.bind;version="[4.0.0,5.0.0)",
+ jakarta.xml.bind.annotation;version="[4.0.0,5.0.0)",
+ org.glassfish.hk2.osgiresourcelocator;version="1.0.3",
+ org.glassfish.jaxb.core;version="[4.0.0,5.0.0)",
+ org.glassfish.jaxb.runtime;version="[4.0.0,5.0.0)"
 Require-Bundle: org.eclipse.core.runtime;bundle-version="0.0.0",
  org.eclipse.mylyn.commons.core;bundle-version="4.4.0",
  org.eclipse.mylyn.commons.notifications.core;bundle-version="4.4.0"

--- a/mylyn.commons/org.eclipse.mylyn.commons.notifications.feed/src/org/eclipse/mylyn/internal/commons/notifications/feed/FeedReader.java
+++ b/mylyn.commons/org.eclipse.mylyn.commons.notifications.feed/src/org/eclipse/mylyn/internal/commons/notifications/feed/FeedReader.java
@@ -19,9 +19,6 @@ import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
 
-import javax.xml.bind.JAXBContext;
-import javax.xml.bind.JAXBElement;
-import javax.xml.bind.Unmarshaller;
 import javax.xml.transform.stream.StreamSource;
 
 import org.eclipse.core.runtime.IAdaptable;
@@ -30,6 +27,10 @@ import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.mylyn.commons.notifications.core.IFilterable;
 import org.eclipse.mylyn.commons.notifications.core.NotificationEnvironment;
+
+import jakarta.xml.bind.JAXBContext;
+import jakarta.xml.bind.JAXBElement;
+import jakarta.xml.bind.Unmarshaller;
 
 /**
  * @author Steffen Pingel

--- a/mylyn.commons/org.eclipse.mylyn.commons.notifications.feed/src/org/eclipse/mylyn/internal/commons/notifications/feed/RSS.java
+++ b/mylyn.commons/org.eclipse.mylyn.commons.notifications.feed/src/org/eclipse/mylyn/internal/commons/notifications/feed/RSS.java
@@ -14,9 +14,9 @@ package org.eclipse.mylyn.internal.commons.notifications.feed;
 
 import java.util.ArrayList;
 
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlElementWrapper;
-import javax.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlElementWrapper;
+import jakarta.xml.bind.annotation.XmlRootElement;
 
 @XmlRootElement(name = "rss")
 public class RSS {

--- a/mylyn.commons/org.eclipse.mylyn.commons.notifications.feed/src/org/eclipse/mylyn/internal/commons/notifications/feed/RSSItem.java
+++ b/mylyn.commons/org.eclipse.mylyn.commons.notifications.feed/src/org/eclipse/mylyn/internal/commons/notifications/feed/RSSItem.java
@@ -15,7 +15,7 @@ package org.eclipse.mylyn.internal.commons.notifications.feed;
 import java.util.ArrayList;
 import java.util.List;
 
-import javax.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlElement;
 
 public class RSSItem {
 

--- a/org.eclipse.mylyn-site/category.xml
+++ b/org.eclipse.mylyn-site/category.xml
@@ -106,13 +106,11 @@
    <bundle id="com.google.gwt.servlet"/>
    <bundle id="com.google.gwtjsonrpc"/>
    <bundle id="com.google.gwtorm"/>
-   <bundle id="com.sun.xml.bind"/>
-   <bundle id="jakarta.xml.bind"/>
-   <bundle id="javax.activation" version="1.2.2.v20221203-1659"/>
-   <bundle id="javax.activation" version="2.0.0.v20221203-1659"/>
+   <bundle id="com.googlecode.javaewah.JavaEWAH"/>
+   <bundle id="com.sun.xml.bind.jaxb-osgi"/>
+   <bundle id="jakarta.activation-api"/>
    <bundle id="org.apache.ant"/>
    <bundle id="org.apache.commons.commons-collections4"/>
-   <bundle id="org.apache.commons.commons-logging"/>
    <bundle id="org.apache.commons.commons-codec"/>
    <bundle id="org.apache.commons.httpclient"/>
    <bundle id="org.apache.commons.lang3"/>
@@ -128,15 +126,14 @@
    <bundle id="org.apache.tika.core"/>
    <bundle id="org.apache.xerces"/>
    <bundle id="org.apache.xml.resolver"/>
-   <bundle id="org.apache.xmlrpc.client"/>
-   <bundle id="org.apache.xmlrpc.common"/>
-   <bundle id="org.apache.xmlrpc.server"/>
+   <bundle id="com.evolvedbinary.thirdparty.org.apache.xmlrpc.xmlrpc-client"/>
+   <bundle id="com.evolvedbinary.thirdparty.org.apache.xmlrpc.xmlrpc-client"/>
    <bundle id="org.apache.ws.commons.util"/>
    <bundle id="org.apiguardian.api"/>
-   <bundle id="org.glassfish.hk2.osgi-resource-locator"/>
    <bundle id="org.jsoup"/>
    <bundle id="org.eclipse.ecf.discovery"/>
    <bundle id="org.eclipse.ecf.provider.jmdns"/>
+   <bundle id="org.glassfish.hk2.osgi-resource-locator"/>
    <category-def name="org.eclipse.mylyn.docs.category" label="Mylyn Docs">
       <description>
          Mylyn Docs

--- a/org.eclipse.mylyn-target/org.eclipse.mylyn.target.target
+++ b/org.eclipse.mylyn-target/org.eclipse.mylyn.target.target
@@ -1,108 +1,108 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde version="3.8"?>
-<!--
- *******************************************************************************
- * Copyright (c) 2022, 2026 Contributors to the Eclipse Foundation
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License 2.0 which is available at
- * https://www.eclipse.org/legal/epl-2.0/.
- *
- * SPDX-License-Identifier: EPL-2.0
- *
- * Contributors:
- *   See git history
- *******************************************************************************
---><target name="org.eclipse.mylyn.target">
-	<locations>
-		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<repository location="https://download.eclipse.org/cbi/updates/license/"/>
-			<unit id="org.eclipse.license.feature.group" version="0.0.0"/>
-		</location>
-		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<repository location="https://download.eclipse.org/eclipse/updates/4.41-I-builds/"/>
-			<unit id="org.eclipse.equinox.sdk.feature.group" version="0.0.0"/>
-			<unit id="org.eclipse.equinox.p2.sdk.feature.group" version="0.0.0"/>
-			<unit id="org.eclipse.sdk.feature.group" version="0.0.0"/>
-		</location>
-		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<repository location="https://download.eclipse.org/egit/github/updates/"/>
-			<unit id="org.eclipse.egit.github.core" version="0.0.0"/>
-		</location>
-		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<repository location="https://download.eclipse.org/egit/updates-7.7/"/>
-			<unit id="org.eclipse.egit.feature.group" version="0.0.0"/>
-			<unit id="org.eclipse.jgit.feature.group" version="0.0.0"/>
-			<unit id="org.eclipse.jgit.lfs.feature.group" version="0.0.0"/>
-		</location>
-		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<repository location="https://download.eclipse.org/modeling/emf/emf/builds/release/2.46.0/"/>
-			<unit id="org.eclipse.emf.sdk.feature.group" version="0.0.0"/>
-		</location>
-		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<repository location="https://download.eclipse.org/rt/ecf/3.16.8/site.p2/3.16.8.v20260415-2025/"/>
-			<unit id="org.eclipse.ecf.remoteservice.sdk.feature.feature.group" version="0.0.0"/>
-		</location>
-		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<repository location="https://download.eclipse.org/tools/cdt/builds/12.5/cdt-12.5.0-rc2/"/>
-			<unit id="org.eclipse.cdt.platform.feature.group" version="0.0.0"/>
-			<unit id="org.eclipse.cdt.sdk.feature.group" version="0.0.0"/>
-		</location>
-		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<repository location="https://download.eclipse.org/tools/orbit/downloads/drops/R20180206163158/repository/"/>
-			<unit id="com.google.gerrit.common" version="0.0.0"/>
-			<unit id="com.google.gerrit.prettify" version="0.0.0"/>
-			<unit id="com.google.gerrit.reviewdb" version="0.0.0"/>
-			<unit id="com.thoughtworks.qdox" version="0.0.0"/>
-		</location>
-		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<repository location="https://download.eclipse.org/tools/orbit/downloads/drops/R20221123021534/repository/"/>
-			<unit id="jakarta.servlet" version="0.0.0"/>
-			<unit id="org.apache.xmlrpc.client" version="0.0.0"/>
-			<unit id="org.apache.xmlrpc.common" version="0.0.0"/>
-			<unit id="org.apache.xmlrpc.server" version="0.0.0"/>
-		</location>
-		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<repository location="https://download.eclipse.org/tools/orbit/downloads/drops/R20230531010532/repository/"/>
-			<unit id="com.sun.xml.bind" version="2.3.3.v20221203-1659"/>
-			<unit id="jakarta.xml.bind" version="2.3.3.v20221203-1659"/>
-			<unit id="javax.activation" version="1.2.2.v20221203-1659"/>
-			<unit id="javax.activation" version="2.0.0.v20221203-1659"/>
-		</location>
-		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<repository location="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/2026-09/"/>
-			<unit id="junit-jupiter-api" version="[6.0.0,7.0.0)"/>
-			<unit id="junit-jupiter-engine" version="[6.0.0,7.0.0)"/>
-			<unit id="junit-jupiter-migrationsupport" version="[6.0.0,7.0.0)"/>
-			<unit id="junit-jupiter-params" version="[6.0.0,7.0.0)"/>
-			<unit id="junit-platform-commons" version="[6.0.0,7.0.0)"/>
-			<unit id="junit-platform-engine" version="[6.0.0,7.0.0)"/>
-			<unit id="junit-platform-launcher" version="[6.0.0,7.0.0)"/>
-			<unit id="junit-platform-suite-api" version="[6.0.0,7.0.0)"/>
-			<unit id="junit-platform-suite-engine" version="[6.0.0,7.0.0)"/>
-			<unit id="org.apiguardian.api" version="0.0.0"/>
-			<unit id="org.glassfish.hk2.osgi-resource-locator" version="0.0.0"/>
-			<unit id="com.sun.xml.bind.jaxb-core" version="0.0.0"/>
-			<unit id="org.glassfish.jaxb.runtime" version="0.0.0"/>
-			<unit id="org.apache.commons.commons-collections4" version="0.0.0"/>
-			<unit id="org.apache.commons.commons-logging" version="0.0.0"/>
-			<unit id="org.apache.commons.lang3" version="0.0.0"/>
-			<unit id="org.apache.commons.text" version="0.0.0"/>
-			<unit id="org.apache.httpcomponents.httpclient" version="0.0.0"/>
-			<unit id="org.apache.lucene.analysis-common" version="0.0.0"/>
-			<unit id="org.apache.lucene.core" version="0.0.0"/>
-			<unit id="org.apache.lucene.facet" version="0.0.0"/>
-			<unit id="org.apache.lucene.queries" version="0.0.0"/>
-			<unit id="org.apache.lucene.queryparser" version="0.0.0"/>
-			<unit id="org.apache.lucene.sandbox" version="0.0.0"/>
-			<unit id="org.apache.xerces" version="0.0.0"/>
-			<unit id="org.apache.tika.core" version="0.0.0"/>
-			<unit id="com.github.ben-manes.caffeine" version="0.0.0"/>
-			<unit id="com.google.gson" version="0.0.0"/>
-			<unit id="org.hamcrest" version="0.0.0"/>
-			<unit id="org.jsoup" version="0.0.0"/>
-			<unit id="org.mockito.mockito-core" version="0.0.0"/>
-			<unit id="org.objenesis" version="0.0.0"/>
-		</location>
-	</locations>
+<target name="Generated from Mylyn">
+  <locations>
+    <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+      <repository location="https://download.eclipse.org/cbi/updates/license"/>
+      <unit id="org.eclipse.license.feature.group" version="0.0.0"/>
+    </location>
+    <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+      <repository location="https://download.eclipse.org/eclipse/updates/4.41-I-builds"/>
+      <unit id="org.eclipse.equinox.p2.ui.discovery" version="0.0.0"/>
+      <unit id="org.eclipse.sdk.feature.group" version="0.0.0"/>
+      <unit id="org.eclipse.terminal.control" version="0.0.0"/>
+    </location>
+    <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+      <repository location="https://download.eclipse.org/egit/github/updates"/>
+      <unit id="org.eclipse.egit.github.core" version="0.0.0"/>
+    </location>
+    <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+      <repository location="https://download.eclipse.org/egit/updates-7.7"/>
+      <unit id="org.eclipse.egit.feature.group" version="0.0.0"/>
+    </location>
+    <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+      <repository location="https://download.eclipse.org/modeling/emf/emf/builds/release/2.46.0/"/>
+      <unit id="org.eclipse.emf.databinding.edit" version="0.0.0"/>
+      <unit id="org.eclipse.emf.ecore.xmi" version="0.0.0"/>
+    </location>
+    <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+      <repository location="https://download.eclipse.org/rt/ecf/3.16.8/site.p2/3.16.8.v20260415-2025"/>
+      <unit id="org.eclipse.ecf.provider.filetransfer.httpclient5" version="0.0.0"/>
+      <unit id="org.eclipse.ecf.provider.filetransfer.httpclientjava" version="0.0.0"/>
+      <unit id="org.eclipse.ecf.provider.jmdns" version="0.0.0"/>
+    </location>
+    <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+      <repository location="https://download.eclipse.org/tools/cdt/builds/12.5/cdt-12.5.0-rc2"/>
+      <unit id="org.eclipse.cdt.platform.feature.group" version="0.0.0"/>
+    </location>
+    <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+      <repository location="https://download.eclipse.org/tools/orbit/downloads/drops/R20180206163158/repository"/>
+      <unit id="com.google.gerrit.common" version="0.0.0"/>
+    </location>
+    <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+      <repository location="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/2026-09"/>
+      <unit id="bcpg" version="0.0.0"/>
+      <unit id="bcpkix" version="0.0.0"/>
+      <unit id="biz.aQute.resolve" version="0.0.0"/>
+      <unit id="com.evolvedbinary.thirdparty.org.apache.xmlrpc.xmlrpc-client" version="0.0.0"/>
+      <unit id="com.evolvedbinary.thirdparty.org.apache.xmlrpc.xmlrpc-server" version="0.0.0"/>
+      <unit id="com.github.ben-manes.caffeine" version="0.0.0"/>
+      <unit id="com.github.weisj.jsvg" version="0.0.0"/>
+      <unit id="com.google.gson" version="0.0.0"/>
+      <unit id="com.googlecode.javaewah.JavaEWAH" version="0.0.0"/>
+      <unit id="com.ibm.icu" version="0.0.0"/>
+      <unit id="com.jcraft.jsch" version="0.0.0"/>
+      <unit id="com.sun.jna.platform" version="0.0.0"/>
+      <unit id="com.sun.xml.bind.jaxb-osgi" version="0.0.0"/>
+      <unit id="jakarta.annotation-api" version="0.0.0"/>
+      <unit id="jakarta.inject.jakarta.inject-api" version="0.0.0"/>
+      <unit id="junit-jupiter-migrationsupport" version="0.0.0"/>
+      <unit id="junit-jupiter-params" version="0.0.0"/>
+      <unit id="junit-platform-runner" version="0.0.0"/>
+      <unit id="junit-platform-suite-engine" version="0.0.0"/>
+      <unit id="junit-vintage-engine" version="0.0.0"/>
+      <unit id="org.apache.ant" version="0.0.0"/>
+      <unit id="org.apache.commons.commons-collections4" version="0.0.0"/>
+      <unit id="org.apache.commons.commons-compress" version="0.0.0"/>
+      <unit id="org.apache.commons.httpclient" version="0.0.0"/>
+      <unit id="org.apache.commons.text" version="0.0.0"/>
+      <unit id="org.apache.felix.gogo.runtime" version="0.0.0"/>
+      <unit id="org.apache.httpcomponents.client5.httpclient5" version="0.0.0"/>
+      <unit id="org.apache.httpcomponents.httpclient" version="0.0.0"/>
+      <unit id="org.apache.lucene.analysis-smartcn" version="0.0.0"/>
+      <unit id="org.apache.lucene.queryparser" version="0.0.0"/>
+      <unit id="org.apache.tika.core" version="0.0.0"/>
+      <unit id="org.apache.xerces" version="0.0.0"/>
+      <unit id="org.apiguardian.api" version="0.0.0"/>
+      <unit id="org.bndtools.headless.build.plugin.gradle" version="0.0.0"/>
+      <unit id="org.bndtools.templates.template" version="0.0.0"/>
+      <unit id="org.bndtools.templating" version="0.0.0"/>
+      <unit id="org.commonmark.ext-gfm-tables" version="0.0.0"/>
+      <unit id="org.eclipse.orbit.xml-apis-ext" version="0.0.0"/>
+      <unit id="org.freemarker.freemarker" version="0.0.0"/>
+      <unit id="org.glassfish.hk2.osgi-resource-locator" version="0.0.0"/>
+      <unit id="org.jsoup" version="0.0.0"/>
+      <unit id="org.mockito.mockito-core" version="0.0.0"/>
+      <unit id="org.mortbay.jasper.mortbay-apache-jsp" version="0.0.0"/>
+      <unit id="org.osgi.annotation.bundle" version="0.0.0"/>
+      <unit id="org.osgi.annotation.versioning" version="0.0.0"/>
+      <unit id="org.osgi.namespace.contract" version="0.0.0"/>
+      <unit id="org.osgi.namespace.extender" version="0.0.0"/>
+      <unit id="org.osgi.namespace.service" version="0.0.0"/>
+      <unit id="org.osgi.service.component.annotations" version="0.0.0"/>
+      <unit id="org.osgi.service.device" version="0.0.0"/>
+      <unit id="org.osgi.service.event" version="0.0.0"/>
+      <unit id="org.osgi.service.http.whiteboard" version="0.0.0"/>
+      <unit id="org.osgi.service.metatype.annotations" version="0.0.0"/>
+      <unit id="org.osgi.service.prefs" version="0.0.0"/>
+      <unit id="org.osgi.service.provisioning" version="0.0.0"/>
+      <unit id="org.osgi.service.upnp" version="0.0.0"/>
+      <unit id="org.osgi.service.useradmin" version="0.0.0"/>
+      <unit id="org.osgi.service.wireadmin" version="0.0.0"/>
+      <unit id="org.osgi.util.position" version="0.0.0"/>
+      <unit id="org.osgi.util.xml" version="0.0.0"/>
+      <unit id="org.sat4j.pb" version="0.0.0"/>
+      <unit id="org.tukaani.xz" version="0.0.0"/>
+    </location>
+  </locations>
 </target>

--- a/org.eclipse.mylyn.releng/oomph/Mylyn.setup
+++ b/org.eclipse.mylyn.releng/oomph/Mylyn.setup
@@ -216,28 +216,151 @@
       </content>
     </setupTask>
     <setupTask
-        xsi:type="projects:ProjectsImportTask"
-        id="mylyn.project.import"
-        predecessor="git.clone.mylyn mylyn.wikitest.help.devguide.create mylyn.wikitest.help.userguide.create">
-      <sourceLocator
-          rootFolder="${git.clone.mylyn.location}"
-          locateNestedProjects="true">
-        <excludedPath>mylyn.builds/org.eclipse.mylyn.jenkins.tests/testdata</excludedPath>
-        <excludedPath>mylyn.reviews/tbr</excludedPath>
-        <excludedPath>mylyn.docs/epub</excludedPath>
-        <excludedPath>org.eclipse.mylar.tests</excludedPath>
-        <excludedPath>mylyn.versions/org.eclipse.mylyn.versions.tests/target/work/data</excludedPath>
-        <excludedPath>mylyn.context/org.eclipse.mylyn.java.tests/target/work/data</excludedPath>
-        <excludedPath>mylyn.tasks/org.eclipse.mylyn.tasks.tests/target</excludedPath>
-      </sourceLocator>
-      <description>Import Releng Project</description>
+        xsi:type="setup:CompoundTask"
+        disabled="true"
+        name="Target Platform">
+      <setupTask
+          xsi:type="pde:TargetPlatformTask"
+          id="org.eclipse.mylyn.target"
+          predecessor="mylyn.workingsets"
+          name="org.eclipse.mylyn.target">
+        <description>Active Mylyn Target Platform</description>
+      </setupTask>
+      <setupTask
+          xsi:type="projects:ProjectsImportTask"
+          id="mylyn.project.import"
+          predecessor="git.clone.mylyn mylyn.wikitest.help.devguide.create mylyn.wikitest.help.userguide.create">
+        <sourceLocator
+            rootFolder="${git.clone.mylyn.location}"
+            locateNestedProjects="true">
+          <excludedPath>mylyn.builds/org.eclipse.mylyn.jenkins.tests/testdata</excludedPath>
+          <excludedPath>mylyn.reviews/tbr</excludedPath>
+          <excludedPath>mylyn.docs/epub</excludedPath>
+          <excludedPath>org.eclipse.mylar.tests</excludedPath>
+          <excludedPath>mylyn.versions/org.eclipse.mylyn.versions.tests/target/work/data</excludedPath>
+          <excludedPath>mylyn.context/org.eclipse.mylyn.java.tests/target/work/data</excludedPath>
+          <excludedPath>mylyn.tasks/org.eclipse.mylyn.tasks.tests/target</excludedPath>
+        </sourceLocator>
+        <description>Import Releng Project</description>
+      </setupTask>
     </setupTask>
     <setupTask
-        xsi:type="pde:TargetPlatformTask"
-        id="org.eclipse.mylyn.target"
-        predecessor="mylyn.workingsets"
-        name="org.eclipse.mylyn.target">
-      <description>Active Mylyn Target Platform</description>
+        xsi:type="setup:CompoundTask"
+        name="Targlets">
+      <setupTask
+          xsi:type="setup:VariableTask"
+          name="eclipse.target.platform"
+          value="${eclipse.target.platform.latest}"
+          storageURI="scope://Workspace"/>
+      <setupTask
+          xsi:type="setup.targlets:TargletTask">
+        <targlet
+            name="Mylyn"
+            includeBinaryEquivalents="false">
+          <annotation
+              source="http:/www.eclipse.org/oomph/targlets/TargetDefinitionGenerator">
+            <detail
+                key="location">
+              <value>${git.clone.mylyn.location/org.eclipse.mylyn-target/org.eclipse.mylyn.target.target}</value>
+            </detail>
+            <detail
+                key="extraUnits">
+              <value>org.eclipse.license.feature.group</value>
+            </detail>
+            <detail
+                key="singleLocation">
+              <value>false</value>
+            </detail>
+            <detail
+                key="sortLocations">
+              <value>true</value>
+            </detail>
+            <detail
+                key="unitsFirst">
+              <value>false</value>
+            </detail>
+            <detail
+                key="includeAllPlatforms">
+              <value>false</value>
+            </detail>
+            <detail
+                key="includeSource">
+              <value>true</value>
+            </detail>
+            <detail
+                key="ignoreJavaRequirements">
+              <value>false</value>
+            </detail>
+            <detail
+                key="generateVersions">
+              <value></value>
+            </detail>
+          </annotation>
+          <requirement
+              name="org.eclipse.sdk.feature.group"/>
+          <requirement
+              name="*"/>
+          <requirement
+              name="org.apache.commons.compress"
+              optional="true"
+              max="0"/>
+          <requirement
+              name="com.ibm.icu.base"
+              optional="true"
+              max="0"/>
+          <requirement
+              name="org.apache.xmlrpc.client"
+              optional="true"
+              max="0"/>
+          <requirement
+              name="org.apache.xmlrpc.server"
+              optional="true"
+              max="0"/>
+          <requirement
+              name="org.freemarker"
+              optional="true"
+              max="0"/>
+          <requirement
+              name="javaewah"
+              optional="true"
+              max="0"/>
+          <requirement
+              name="org.apache.commons.logging"
+              optional="true"
+              max="0"/>
+          <sourceLocator
+              rootFolder="${git.clone.mylyn.location}"
+              locateNestedProjects="true">
+            <predicate
+                xsi:type="predicates:OrPredicate">
+              <operand
+                  xsi:type="predicates:NotPredicate">
+                <operand
+                    xsi:type="predicates:NamePredicate"
+                    pattern=".*epub.*|.*builds\.sample.*|.*mylar\.tests.*|New Name"/>
+              </operand>
+            </predicate>
+          </sourceLocator>
+          <repositoryList>
+            <repository
+                url="https://download.eclipse.org/cbi/updates/license"/>
+            <repository
+                url="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/2026-09"/>
+            <repository
+                url="https://download.eclipse.org/egit/github/updates"/>
+            <repository
+                url="https://download.eclipse.org/egit/updates-7.7"/>
+            <repository
+                url="https://download.eclipse.org/modeling/emf/emf/builds/release/2.46.0/"/>
+            <repository
+                url="https://download.eclipse.org/rt/ecf/3.16.8/site.p2/3.16.8.v20260415-2025"/>
+            <repository
+                url="https://download.eclipse.org/tools/cdt/builds/12.5/cdt-12.5.0-rc2"/>
+            <repository
+                url="https://download.eclipse.org/tools/orbit/downloads/drops/R20180206163158/repository"/>
+          </repositoryList>
+        </targlet>
+      </setupTask>
     </setupTask>
     <setupTask
         xsi:type="setup.targlets:TargletTask"


### PR DESCRIPTION
- Convert org.eclipse.mylyn.commons.notifications.feed to jakarta.xml.bind like org.eclipse.mylyn.jenkins.core.
- Generate a new org.eclipse.mylyn.target.target with fewer old Orbit update sites.
- Modify the category.xml to include updated Orbit dependencies.