### PR TITLE
follow up for #1149 (reuse wikitext in 4diac)

### DIFF
--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.asciidoc/META-INF/MANIFEST.MF
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.asciidoc/META-INF/MANIFEST.MF
@@ -15,7 +15,7 @@ Import-Package: org.eclipse.mylyn.wikitext.parser;version="[4.2,5)",
  org.eclipse.mylyn.wikitext.parser.markup.token;version="[4.2,5)",
  org.eclipse.mylyn.wikitext.parser.outline;version="[4.2,5)",
  org.eclipse.mylyn.wikitext.util;version="[4.2,5)"
-Export-Package: org.eclipse.mylyn.wikitext.asciidoc;version="4.12.0";x-internal:=true;uses:="org.eclipse.mylyn.wikitext.parser,org.eclipse.mylyn.wikitext.parser.markup",
+Export-Package: org.eclipse.mylyn.wikitext.asciidoc;version="4.12.0";uses:="org.eclipse.mylyn.wikitext.parser,org.eclipse.mylyn.wikitext.parser.markup",
  org.eclipse.mylyn.wikitext.asciidoc.internal.block;version="4.12.0";x-internal:=true;
   uses:="org.eclipse.mylyn.wikitext.asciidoc.internal,
    org.eclipse.mylyn.wikitext.asciidoc.internal.util,

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.asciidoc/src/main/java/org/eclipse/mylyn/wikitext/asciidoc/AsciiDocLanguage.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.asciidoc/src/main/java/org/eclipse/mylyn/wikitext/asciidoc/AsciiDocLanguage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2024 Stefan Seelmann and others.
+ * Copyright (c) 2012, 2026 Stefan Seelmann and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -71,7 +71,7 @@ import org.eclipse.mylyn.wikitext.parser.markup.token.PatternLineBreakReplacemen
  *
  * @author Stefan Seelmann
  * @author Max Rydahl Andersen
- * @since 3.0
+ * @since 4.12
  */
 public class AsciiDocLanguage extends AbstractMarkupLanguage {
 

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.asciidoc/src/main/java/org/eclipse/mylyn/wikitext/asciidoc/AsciiDocMarkupLanguageConfiguration.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.asciidoc/src/main/java/org/eclipse/mylyn/wikitext/asciidoc/AsciiDocMarkupLanguageConfiguration.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2024 Jeremie Bresson and others.
+ * Copyright (c) 2017, 2026 Jeremie Bresson and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -24,14 +24,13 @@ import org.eclipse.mylyn.wikitext.parser.markup.MarkupLanguageConfiguration;
  * Extended configuration for the AsciiDoc markup language
  *
  * @author Jeremie Bresson
- * @since 3.0.0
+ * @since 4.12
  */
 public class AsciiDocMarkupLanguageConfiguration extends MarkupLanguageConfiguration {
 
 	private Map<String, String> initialAttributes = Collections.emptyMap();
 
 	/**
-	 * @since 3.0.0
 	 * @return initial attributes (key, values)
 	 */
 	public Map<String, String> getInitialAttributes() {
@@ -39,7 +38,6 @@ public class AsciiDocMarkupLanguageConfiguration extends MarkupLanguageConfigura
 	}
 
 	/**
-	 * @since 3.0.0
 	 * @param initialAttributes
 	 *            initial attributes (key, values)
 	 */

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.html/META-INF/MANIFEST.MF
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.html/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Automatic-Module-Name: org.eclipse.mylyn.wikitext.html
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.eclipse.mylyn.wikitext.html
 Bundle-Version: 4.12.0.qualifier
-Export-Package: org.eclipse.mylyn.wikitext.html;version="4.12.0";x-internal:=true,
+Export-Package: org.eclipse.mylyn.wikitext.html;version="4.12.0",
  org.eclipse.mylyn.wikitext.html.internal;x-internal:=true
 Bundle-Name: Mylyn WikiText HTML
 Bundle-Vendor: Eclipse Mylyn

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.html/src/main/java/org/eclipse/mylyn/wikitext/html/HtmlLanguage.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.html/src/main/java/org/eclipse/mylyn/wikitext/html/HtmlLanguage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2014 Tasktop Technologies and others.
+ * Copyright (c) 2013, 2026 Tasktop Technologies and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -9,6 +9,7 @@
  *
  * Contributors:
  *     David Green - initial API and implementation
+ *     Alexander Fedorov (ArSysOp) - ongoing support
  *******************************************************************************/
 
 package org.eclipse.mylyn.wikitext.html;
@@ -113,7 +114,7 @@ import org.xml.sax.SAXException;
  * @see HtmlParser
  * @see HtmlLanguageBuilder
  * @see #builder()
- * @since 3.0
+ * @since 4.12
  */
 public class HtmlLanguage extends MarkupLanguage {
 

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.markdown/.settings/.api_filters
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.markdown/.settings/.api_filters
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<component id="org.eclipse.mylyn.wikitext.markdown" version="2">
+    <resource path="META-INF/MANIFEST.MF">
+        <filter comment="internal class in inheritance chain has been promoted to an API" id="923795461">
+            <message_arguments>
+                <message_argument value="4.12.0"/>
+                <message_argument value="4.11.0"/>
+            </message_arguments>
+        </filter>
+        <filter comment="internal class in inheritance chain has been promoted to an API" id="934281281">
+            <message_arguments>
+                <message_argument value="org.eclipse.mylyn.wikitext.markdown"/>
+                <message_argument value="5.11.0"/>
+                <message_argument value="4.11.0"/>
+            </message_arguments>
+        </filter>
+    </resource>
+</component>

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext/src/main/java/org/eclipse/mylyn/wikitext/parser/markup/AbstractMarkupLanguage.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext/src/main/java/org/eclipse/mylyn/wikitext/parser/markup/AbstractMarkupLanguage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2009, 2024 David Green and others.
+ * Copyright (c) 2009, 2026 David Green and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -36,7 +36,7 @@ import org.eclipse.mylyn.wikitext.util.LocationTrackingReader;
  * a standard implementation of a markup language usually extends this class, which provides default support for common functionality.
  *
  * @author David Green
- * @since 3.0
+ * @since 4.12
  */
 public abstract class AbstractMarkupLanguage extends MarkupLanguage {
 

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext/src/main/java/org/eclipse/mylyn/wikitext/parser/markup/Block.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext/src/main/java/org/eclipse/mylyn/wikitext/parser/markup/Block.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2007, 2021 David Green and others.
+ * Copyright (c) 2007, 2026 David Green and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -10,6 +10,7 @@
  * Contributors:
  *     David Green - initial API and implementation
  *     Jeremie Bresson - Bug 381912
+ *     Alexander Fedorov (ArSysOp) - ongoing support
  *******************************************************************************/
 package org.eclipse.mylyn.wikitext.parser.markup;
 
@@ -19,7 +20,7 @@ import org.eclipse.mylyn.wikitext.parser.DocumentBuilder;
  * A markup block that may span multiple lines. Implements {@link Cloneable} for the template design pattern.
  *
  * @author David Green
- * @since 3.0
+ * @since 4.12
  */
 public abstract class Block extends Processor {
 	private boolean closed;

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext/src/main/java/org/eclipse/mylyn/wikitext/parser/markup/DefaultIdGenerationStrategy.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext/src/main/java/org/eclipse/mylyn/wikitext/parser/markup/DefaultIdGenerationStrategy.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2007, 2009 David Green and others.
+ * Copyright (c) 2007, 2026 David Green and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -9,6 +9,7 @@
  *
  * Contributors:
  *     David Green - initial API and implementation
+ *     Alexander Fedorov (ArSysOp) - ongoing support
  *******************************************************************************/
 
 package org.eclipse.mylyn.wikitext.parser.markup;
@@ -17,7 +18,7 @@ package org.eclipse.mylyn.wikitext.parser.markup;
  * A default ID generation strategy which removes all non-alphanumeric characters from the heading text to produce an id.
  *
  * @author David Green
- * @since 3.0
+ * @since 4.12
  */
 public class DefaultIdGenerationStrategy extends IdGenerationStrategy {
 

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext/src/main/java/org/eclipse/mylyn/wikitext/parser/markup/IdGenerationStrategy.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext/src/main/java/org/eclipse/mylyn/wikitext/parser/markup/IdGenerationStrategy.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2007, 2011 David Green and others.
+ * Copyright (c) 2007, 2026 David Green and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -9,6 +9,7 @@
  *
  * Contributors:
  *     David Green - initial API and implementation
+ *     Alexander Fedorov (ArSysOp) - ongoing support
  *******************************************************************************/
 
 package org.eclipse.mylyn.wikitext.parser.markup;
@@ -17,7 +18,7 @@ package org.eclipse.mylyn.wikitext.parser.markup;
  * A strategy for generating IDs from text, follows the Strategy design pattern.
  *
  * @author David Green
- * @since 3.0
+ * @since 4.12
  */
 public abstract class IdGenerationStrategy {
 	/**

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext/src/main/java/org/eclipse/mylyn/wikitext/parser/markup/MarkupLanguageProvider.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext/src/main/java/org/eclipse/mylyn/wikitext/parser/markup/MarkupLanguageProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2022 Tasktop Technologies and others.
+ * Copyright (c) 2013, 2026 Tasktop Technologies and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -26,7 +26,7 @@ import org.eclipse.mylyn.wikitext.util.ServiceLocator;
  * A provider of {@link MarkupLanguage}.
  *
  * @see ServiceLocator
- * @since 3.0
+ * @since 4.12
  */
 public abstract class MarkupLanguageProvider {
 

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext/src/main/java/org/eclipse/mylyn/wikitext/parser/markup/PatternBasedElement.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext/src/main/java/org/eclipse/mylyn/wikitext/parser/markup/PatternBasedElement.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2007, 2011 David Green and others.
+ * Copyright (c) 2007, 2026 David Green and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -9,6 +9,7 @@
  *
  * Contributors:
  *     David Green - initial API and implementation
+ *     Alexander Fedorov (ArSysOp) - ongoing support
  *******************************************************************************/
 package org.eclipse.mylyn.wikitext.parser.markup;
 
@@ -17,7 +18,7 @@ package org.eclipse.mylyn.wikitext.parser.markup;
  * factory for processors that can process the markup element. Implementations of this class must be thread-safe (generally stateless).
  *
  * @author David Green
- * @since 3.0
+ * @since 4.12
  */
 public abstract class PatternBasedElement implements Cloneable {
 

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext/src/main/java/org/eclipse/mylyn/wikitext/parser/markup/PatternBasedElementProcessor.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext/src/main/java/org/eclipse/mylyn/wikitext/parser/markup/PatternBasedElementProcessor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2007, 2011 David Green and others.
+ * Copyright (c) 2007, 2026 David Green and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -9,6 +9,7 @@
  *
  * Contributors:
  *     David Green - initial API and implementation
+ *     Alexander Fedorov (ArSysOp) - ongoing support
  *******************************************************************************/
 package org.eclipse.mylyn.wikitext.parser.markup;
 
@@ -20,10 +21,10 @@ import java.util.regex.Matcher;
  * A processor that is capable of processing a specific type of markup element
  *
  * @author David Green
- * @since 3.0
+ * @since 4.12
  */
 public abstract class PatternBasedElementProcessor extends Processor
-		implements org.eclipse.mylyn.wikitext.parser.util.Matcher {
+implements org.eclipse.mylyn.wikitext.parser.util.Matcher {
 
 	protected int lineStartOffset;
 


### PR DESCRIPTION
see #1149
* make `org.eclipse.mylyn.wikitext.asciidoc` accessible
* make `org.eclipse.mylyn.wikitext.html` accessible