### PR TITLE
Adjust unit test "timeout" value based on load average #1185

### DIFF
--- a/mylyn.commons/org.eclipse.mylyn.commons.activity.tests/META-INF/MANIFEST.MF
+++ b/mylyn.commons/org.eclipse.mylyn.commons.activity.tests/META-INF/MANIFEST.MF
@@ -10,6 +10,7 @@ Require-Bundle: org.eclipse.core.runtime;bundle-version="0.0.0",
  org.eclipse.mylyn.commons.sdk.util.junit5;bundle-version="4.12.0"
 Export-Package: org.eclipse.mylyn.commons.activity.tests;x-internal:=true
 Import-Package: org.apiguardian.api;version="[1.1.0,2.0.0)",
+ org.assertj.core.api;version="[3.27.0,4.0.0)",
  org.junit.jupiter.api;version="[6.0.0,7.0.0)",
  org.junit.jupiter.api.condition;version="[6.0.0,7.0.0)",
  org.junit.jupiter.api.extension;version="[6.0.0,7.0.0)",

--- a/mylyn.commons/org.eclipse.mylyn.commons.activity.tests/src/org/eclipse/mylyn/commons/activity/tests/MonitorUserActivityJobTest.java
+++ b/mylyn.commons/org.eclipse.mylyn.commons.activity.tests/src/org/eclipse/mylyn/commons/activity/tests/MonitorUserActivityJobTest.java
@@ -13,9 +13,13 @@
 
 package org.eclipse.mylyn.commons.activity.tests;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.lang.management.ManagementFactory;
+import java.lang.management.OperatingSystemMXBean;
 
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.NullProgressMonitor;
@@ -44,6 +48,11 @@ public class MonitorUserActivityJobTest {
 
 	@Test
 	public void testInactivityTimeout() throws Exception {
+		// Unstable on Mac, maybe this will help
+		OperatingSystemMXBean osBean = ManagementFactory.getOperatingSystemMXBean();
+		double loadAvg = osBean.getSystemLoadAverage();
+		long expectedActiveTime = (long) (40 * (loadAvg < 0.0 ? 1.0 : loadAvg > 1.0 ? loadAvg : 1.0));
+
 		callback.lastEventTime = System.currentTimeMillis() - 201;
 		job.setInactivityTimeout(200);
 		job.run();
@@ -58,8 +67,8 @@ public class MonitorUserActivityJobTest {
 		job.run();
 		long slept = System.currentTimeMillis() - callback.lastEventTime;
 		assertTrue(job.isActive());
-		assertTrue(callback.activeTime > 5 && callback.activeTime < 40,
-				"expected less than 5 < activeTime < 40, got " + callback.activeTime + " (slept " + slept + " ms)");
+		assertThat(callback.activeTime).as("loadAvg=%.1f, slept=%dms", loadAvg, slept)
+		.isBetween(5L, expectedActiveTime);
 	}
 
 	@Test

--- a/org.eclipse.mylyn-target/org.eclipse.mylyn.target.target
+++ b/org.eclipse.mylyn-target/org.eclipse.mylyn.target.target
@@ -29,6 +29,7 @@
     </location>
     <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
       <repository location="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/milestone/latest"/>
+      <unit id="assertj-core" version="0.0.0"/>
       <unit id="com.evolvedbinary.thirdparty.org.apache.xmlrpc.xmlrpc-client" version="0.0.0"/>
       <unit id="com.evolvedbinary.thirdparty.org.apache.xmlrpc.xmlrpc-server" version="0.0.0"/>
       <unit id="com.github.ben-manes.caffeine" version="0.0.0"/>


### PR DESCRIPTION
Test failed twice in MacOS. See if adjusting expected time based on load average helps


Task-Url: https://github.com/eclipse-mylyn/org.eclipse.mylyn/issues/1185