### PR TITLE
Add a dark theme css to wikitext #1202

### DIFF
--- a/mylyn.docs/wikitext/ui/org.eclipse.mylyn.wikitext.ui/META-INF/MANIFEST.MF
+++ b/mylyn.docs/wikitext/ui/org.eclipse.mylyn.wikitext.ui/META-INF/MANIFEST.MF
@@ -7,6 +7,7 @@ Bundle-Vendor: %Bundle-Vendor.0
 Require-Bundle: org.eclipse.mylyn.wikitext;bundle-version="4.4.0",
  org.eclipse.mylyn.wikitext.osgi;bundle-version="4.4.0",
  org.eclipse.core.runtime,
+ org.eclipse.e4.ui.css.swt.theme;bundle-version="[0.15.0,1.0.0)",
  org.eclipse.jface.text,
  org.eclipse.ui;bundle-version="3.6.0",
  org.eclipse.ui.editors,

--- a/mylyn.docs/wikitext/ui/org.eclipse.mylyn.wikitext.ui/css/dark.css
+++ b/mylyn.docs/wikitext/ui/org.eclipse.mylyn.wikitext.ui/css/dark.css
@@ -1,0 +1,188 @@
+/*******************************************************************************
+ * Copyright (c) 2026 George Lindholm
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     See git history
+ *******************************************************************************/
+:root {
+	font-family: Arial, Helvetica, sans-serif;
+	color: #e0e0e0;
+	background-color: #1e1e1e;
+}
+
+html, body {
+	height: 100%;
+	 margin: 0;
+	 font-family: var(--font-stack);
+	 color: var(--fg);
+	 background-color:
+	 var(--bg); }
+
+h1 {
+	font-size: 120%;
+	font-weight: bold;
+	color: #7eb8f7;
+}
+
+h2 {
+	font-size: 110%;
+	font-weight: bold;
+	color: #7eb8f7;
+}
+
+h3 {
+	font-size: 105%;
+	font-weight: bold;
+	color: #7eb8f7;
+}
+
+h4 {
+	font-weight: bold;
+	color: #7eb8f7;
+}
+
+h5 {
+	font-size: 90%;
+	font-weight: bold;
+	color: #7eb8f7;
+}
+
+h6 {
+	font-size: 80%;
+	font-weight: bold;
+	color: #7eb8f7;
+}
+
+b {
+	font-weight: bold;
+}
+
+strong {
+	font-weight: bold;
+}
+
+i {
+	font-style: italic;
+}
+
+cite {
+	font-style: italic;
+}
+
+em {
+	font-style: italic;
+}
+
+mark {
+	background-color: #6b5900;
+	color: #ffe066;
+}
+
+var {
+	font-style: italic;
+}
+
+dfn {
+	font-style: italic;
+}
+
+code {
+	font-family: monospace;
+	color: #9999ff;
+}
+
+pre {
+	font-family: monospace;
+}
+
+/* Java stack traces
+pre.javaStackTrace {
+	font-family: monospace;
+}
+*/
+
+/* sections beginning with -- Error Details --
+pre.eclipseErrorDetails {
+	font-family: monospace;
+}
+*/
+
+ins {
+	text-decoration: underline;
+}
+
+del {
+	text-decoration: line-through;
+}
+
+sup {
+	font-size: smaller;
+	vertical-align: super;
+}
+
+a {
+	text-decoration: underline;
+	color: #6ab0f5;
+}
+
+sup a {
+	text-decoration: none;
+}
+
+sub {
+	font-size: smaller;
+	vertical-align: sub;
+}
+
+dt {
+	font-weight: bold;
+}
+
+blockquote {
+	color: #7aadda;
+}
+
+tt {
+	font-family: monospace;
+}
+
+q {
+	color: #7aadda;
+}
+
+h1.editorPreview, h2.editorPreview, h3.editorPreview, h4.editorPreview {
+  padding-bottom: 0.3em;
+  font-size: 1.75em;
+  border-bottom: 1px solid #444;
+}
+
+pre.editorPreview {
+  padding: 16px;
+  overflow: auto;
+  line-height: 1.45;
+  background-color: #2d2d2d;
+  border-radius: 3px;
+}
+
+table.editorPreview {
+  border-collapse: collapse;
+  border-spacing: 0;
+  border-color: #555;
+}
+
+tr.editorPreview td.editorPreview {
+  border: 1px solid #444;
+  padding: 6px 13px;
+}
+
+tr.editorPreview th.editorPreview {
+  border: 1px solid #444;
+  padding: 6px 13px;
+  background-color: #2a2a2a;
+}

--- a/mylyn.docs/wikitext/ui/org.eclipse.mylyn.wikitext.ui/css/default.css
+++ b/mylyn.docs/wikitext/ui/org.eclipse.mylyn.wikitext.ui/css/default.css
@@ -1,3 +1,15 @@
+/*******************************************************************************
+ * Copyright (c) 2007, 2026 David Green and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     See git history
+ *******************************************************************************/
 * {
 	 font-family:  Arial, Helvetica, sans-serif;
 }
@@ -89,7 +101,7 @@ pre.eclipseErrorDetails {
 	font-family: monospace;
 }
 */
- 
+
 ins {
 	text-decoration: underline;
 }
@@ -126,7 +138,7 @@ blockquote {
 }
 
 tt {
-	font-family: monospace;	
+	font-family: monospace;
 }
 
 q {
@@ -146,13 +158,13 @@ pre.editorPreview {
   background-color: #f7f7f7;
   border-radius: 3px;
 }
-  
+
 table.editorPreview {
   border-collapse: collapse;
   border-spacing: 0;
   border-color: grey;
 }
-  
+
 tr.editorPreview td.editorPreview {
   border:1px solid #ddd;
   padding: 6px 13px;

--- a/mylyn.docs/wikitext/ui/org.eclipse.mylyn.wikitext.ui/src/org/eclipse/mylyn/internal/wikitext/ui/viewer/HtmlTextPresentationParser.java
+++ b/mylyn.docs/wikitext/ui/org.eclipse.mylyn.wikitext.ui/src/org/eclipse/mylyn/internal/wikitext/ui/viewer/HtmlTextPresentationParser.java
@@ -10,6 +10,7 @@
  * Contributors:
  *     David Green - initial API and implementation
  *     Alexander Fedorov (ArSysOp) - ongoing support
+ *     See git history
  *******************************************************************************/
 package org.eclipse.mylyn.internal.wikitext.ui.viewer;
 
@@ -34,6 +35,8 @@ import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.parsers.SAXParser;
 import javax.xml.parsers.SAXParserFactory;
 
+import org.eclipse.e4.ui.css.swt.theme.IThemeEngine;
+import org.eclipse.e4.ui.css.swt.theme.IThemeManager;
 import org.eclipse.jface.text.Position;
 import org.eclipse.jface.text.TextPresentation;
 import org.eclipse.jface.text.source.Annotation;
@@ -57,6 +60,10 @@ import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.graphics.Font;
 import org.eclipse.swt.graphics.GC;
 import org.eclipse.swt.graphics.Point;
+import org.eclipse.swt.widgets.Display;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.FrameworkUtil;
+import org.osgi.framework.ServiceReference;
 import org.xml.sax.Attributes;
 import org.xml.sax.ContentHandler;
 import org.xml.sax.InputSource;
@@ -328,7 +335,27 @@ public class HtmlTextPresentationParser {
 	}
 
 	public static InputStream getDefaultStylesheetContent() {
-		return HtmlTextPresentationParser.class.getResourceAsStream("default.css"); //$NON-NLS-1$
+		/**
+		 * FIXME: Using the theme extension in plugin.xml causes the css to bleed into other mylyn components
+		 */
+		if (isDarkThemeActive()) {
+			return HtmlTextPresentationParser.class.getResourceAsStream("/css/dark.css"); //$NON-NLS-1$
+		} else {
+			return HtmlTextPresentationParser.class.getResourceAsStream("/css/default.css"); //$NON-NLS-1$
+		}
+	}
+
+	public static boolean isDarkThemeActive() {
+		BundleContext context = FrameworkUtil.getBundle(HtmlTextPresentationParser.class).getBundleContext();
+		ServiceReference<IThemeManager> ref = context.getServiceReference(IThemeManager.class);
+		if (ref != null) {
+			IThemeManager manager = context.getService(ref);
+			IThemeEngine engine = manager.getEngineForDisplay(Display.getCurrent());
+			if (engine != null && engine.getActiveTheme() != null) {
+				return engine.getActiveTheme().getId().toLowerCase().contains("dark"); //$NON-NLS-1$
+			}
+		}
+		return false;
 	}
 
 	public TextPresentation getPresentation() {


### PR DESCRIPTION
Hack to add a dark theme to wikitext.
@azoitl 

<table>
<th>
<tr>
<td>Current</td>
<td>New</td>
</tr>
</td>
</th>
<tr>
<td><img width="141" height="129" alt="Screenshot 2026-07-26 013015" src="https://github.com/user-attachments/assets/61af4677-88f3-4c57-9cdd-4fb494a5c019" /></td>
<td><img width="144" height="146" alt="Screenshot 2026-07-26 103302" src="https://github.com/user-attachments/assets/5c91b973-e20d-4b93-8858-f7001576b573" />
</td>
</tr>
<tr>
<td><img width="1030" height="1691" alt="Screenshot 2026-07-26 012656" src="https://github.com/user-attachments/assets/39d76a12-f7b1-46b7-9326-be5078ec8814" /></td>
<td><img width="1077" height="1681" alt="Screenshot 2026-07-26 104356" src="https://github.com/user-attachments/assets/71b0bfad-7660-4a9e-b24b-248522810c3e" /></td>
</tr>
<tr>
<td><img width="213" height="1327" alt="Screenshot 2026-07-26 141042" src="https://github.com/user-attachments/assets/0ac5abb7-d4f1-4142-8dd3-a2913bb2c596" />
</td>
<td><img width="182" height="1302" alt="Screenshot 2026-07-26 144253" src="https://github.com/user-attachments/assets/24c5aa37-eaeb-4bee-a610-8394d1a1cfc3" /></td>
</tr>
</table>

Task-Url: https://github.com/eclipse-mylyn/org.eclipse.mylyn/issues/1202




