### PR TITLE
Open browser view when clicking links in markup editor asynchronously

### DIFF
--- a/mylyn.docs/wikitext/ui/org.eclipse.mylyn.wikitext.ui/src/org/eclipse/mylyn/internal/wikitext/ui/editor/MarkupEditor.java
+++ b/mylyn.docs/wikitext/ui/org.eclipse.mylyn.wikitext.ui/src/org/eclipse/mylyn/internal/wikitext/ui/editor/MarkupEditor.java
@@ -400,21 +400,33 @@ public class MarkupEditor extends TextEditor implements IShowInTarget, IShowInSo
 						// workaround end
 
 						event.doit = false;
-						if (tryToOpenAsWorkspaceFile(event.location)) {
-							return;
-						}
-						try {
-							PlatformUI.getWorkbench()
-									.getBrowserSupport()
-									.createBrowser("org.eclipse.ui.browser") //$NON-NLS-1$
-									.openURL(new URL(event.location));
-						} catch (Exception e) {
-							new URLHyperlink(new Region(0, 1), event.location).open();
-						}
+						executeAsync(() -> {
+							if (tryToOpenAsWorkspaceFile(event.location)) {
+								return;
+							}
+							try {
+								PlatformUI.getWorkbench()
+										.getBrowserSupport()
+										.createBrowser("org.eclipse.ui.browser") //$NON-NLS-1$
+										.openURL(new URL(event.location));
+							} catch (Exception e) {
+								new URLHyperlink(new Region(0, 1), event.location).open();
+							}
+						});
 					} else {
-						tryToOpenAsWorkspaceFile(event.location);
+						executeAsync(() -> tryToOpenAsWorkspaceFile(event.location));
 					}
 				}
+
+				private static void executeAsync(Runnable runnable) {
+					PlatformUI.getWorkbench().getDisplay().asyncExec(() -> {
+						if (!PlatformUI.isWorkbenchRunning()) {
+							return;
+						}
+						runnable.run();
+					});
+				}
+
 			});
 			previewTab.setControl(browser);
 		} catch (SWTError e) {


### PR DESCRIPTION
Opening a new browser view when clicking links in markup editor current happens synchronously. First, this makes the application less responsive than necessary as the UI loop will be blocked until the browser is created. Second, when using Windows with its Edge/WebView2 browser runtime, this can lead to a deadlock because a browser is created from within the (navigation) callback of another browser.

This change extracts the browser creation when clicking links in a markup editor into an asynchronous execution scheduled on the workbench display to avoid any UI deadlocks and potentially improve responsiveness.

Fixes https://github.com/eclipse-mylyn/org.eclipse.mylyn/issues/1208