### PR TITLE
Correctly Handle Empty Admonition Block Title Lines

### DIFF
--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.asciidoc/src/main/java/org/eclipse/mylyn/wikitext/asciidoc/internal/block/AdmonitionBlock.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.asciidoc/src/main/java/org/eclipse/mylyn/wikitext/asciidoc/internal/block/AdmonitionBlock.java
@@ -121,6 +121,12 @@ public class AdmonitionBlock extends Block {
 	}
 
 	private int handleSecondLine(String line, int offset) {
+		if (line.isEmpty()) {
+			//user may started a line assume title
+			blockLineCount++;
+			hasTitle = true;
+			return -1;
+		}
 		if (line.charAt(0) == '.') {
 			Attributes titleAtt = new Attributes();
 			titleAtt.setCssClass("title"); //$NON-NLS-1$

--- a/mylyn.docs/wikitext/ui/org.eclipse.mylyn.wikitext.asciidoc.ui/plugin.xml
+++ b/mylyn.docs/wikitext/ui/org.eclipse.mylyn.wikitext.asciidoc.ui/plugin.xml
@@ -45,11 +45,11 @@
          <template name="CAUTION" description="%template.admonition.caution" content="\nCAUTION: ${text}\n\n" block="true"/>
          <template name="WARNING" description="%template.admonition.warning" content="\nWARNING: ${text}\n\n" block="true"/>
 
-         <template name="NOTE Block" description="%template.admonition.noteblock" content="\n[NOTE]\n====\n${text}\n====\n" block="true"/>
-         <template name="TIP Block" description="%template.admonition.tipblock" content="\n[TIP]\n====\n${text}\n====\n" block="true"/>
-         <template name="IMPORTANT Block" description="%template.admonition.importantblock" content="\n[IMPORTANT]\n====\n${text}\n====\n" block="true"/>
-         <template name="CAUTION Block" description="%template.admonition.cautionblock" content="\n[CAUTION]\n====\n${text}\n====\n" block="true"/>
-         <template name="WARNING Block" description="%template.admonition.warningblock" content="\n[WARNING]\n====\n${text}\n====\n" block="true"/>
+         <template name="NOTE Block" description="%template.admonition.noteblock" content="\n[NOTE]\n.${title}\n====\n${text}\n====\n" block="true"/>
+         <template name="TIP Block" description="%template.admonition.tipblock" content="\n[TIP]\n.${title}\n====\n${text}\n====\n" block="true"/>
+         <template name="IMPORTANT Block" description="%template.admonition.importantblock" content="\n[IMPORTANT]\n.${title}\n====\n${text}\n====\n" block="true"/>
+         <template name="CAUTION Block" description="%template.admonition.cautionblock" content="\n[CAUTION]\n.${title}\n====\n${text}\n====\n" block="true"/>
+         <template name="WARNING Block" description="%template.admonition.warningblock" content="\n[WARNING]\n.${title}\n====\n${text}\n====\n" block="true"/>
 
          <template name="include" description="%template.include" content="\ninclude::${path}[]\n\n" block="true"/>
 


### PR DESCRIPTION
Empty title lines for admonitions lead to exceptions.

Furthermore the admonition block template was missing a title place holder.