### PR TITLE
[#1220] Invalid `@since` 3.0 tag for `HtmlLanguageBuilder`

### DIFF
--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.html/src/main/java/org/eclipse/mylyn/wikitext/html/HtmlLanguageBuilder.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext.html/src/main/java/org/eclipse/mylyn/wikitext/html/HtmlLanguageBuilder.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2021 Tasktop Technologies and others.
+ * Copyright (c) 2013, 2026 Tasktop Technologies and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -42,7 +42,7 @@ import org.eclipse.mylyn.wikitext.parser.markup.MarkupLanguage;
  *
  * @author david.green
  * @see HtmlLanguage#builder()
- * @since 3.0
+ * @since 4.12
  */
 public class HtmlLanguageBuilder {
 	private String name;


### PR DESCRIPTION
* update tag to 4.12

Fixes #1220