### PR TITLE
[#1222] Invalid `@since` 3.0 tag for `o.e.m.wikitext.parser.markup`

### DIFF
--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext/src/main/java/org/eclipse/mylyn/wikitext/parser/markup/ConfigurationBuilder.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext/src/main/java/org/eclipse/mylyn/wikitext/parser/markup/ConfigurationBuilder.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Tasktop Technologies and others.
+ * Copyright (c) 2011, 2026 Tasktop Technologies and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -9,6 +9,7 @@
  *
  * Contributors:
  *     David Green - initial API and implementation
+ *     Alexander Fedorov (ArSysOp) - ongoing support
  *******************************************************************************/
 
 package org.eclipse.mylyn.wikitext.parser.markup;
@@ -22,7 +23,7 @@ import org.eclipse.mylyn.wikitext.parser.markup.block.JavaStackTraceBlock;
  * A builder for creating {@link MarkupLanguageConfiguration}
  *
  * @author David Green
- * @since 3.0
+ * @since 4.12
  */
 public class ConfigurationBuilder {
 
@@ -48,11 +49,11 @@ public class ConfigurationBuilder {
 	public ConfigurationBuilder repositorySettings() {
 		ConfigurationBuilder builder = create();
 		builder.disableUnwrappedParagraphs()
-				.escapingHtmlAndXml()
-				.newlinesMustCauseLineBreak()
-				.optimizeForRepositoryUsage()
-				.block(new EclipseErrorDetailsBlock())
-				.block(new JavaStackTraceBlock());
+		.escapingHtmlAndXml()
+		.newlinesMustCauseLineBreak()
+		.optimizeForRepositoryUsage()
+		.block(new EclipseErrorDetailsBlock())
+		.block(new JavaStackTraceBlock());
 		return builder;
 	}
 

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext/src/main/java/org/eclipse/mylyn/wikitext/parser/markup/ContentState.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext/src/main/java/org/eclipse/mylyn/wikitext/parser/markup/ContentState.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2007, 2024 David Green and others.
+ * Copyright (c) 2007, 2026 David Green and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -23,7 +23,7 @@ import org.eclipse.mylyn.wikitext.parser.Locator;
  * State related to parsing content, propagated to {@link Block blocks} and other {@link Processor processors} during the parse phase.
  *
  * @author David Green
- * @since 3.0
+ * @since 4.12
  */
 public class ContentState implements Locator {
 	private final Map<String, String> footnoteIdToHtmlId = new HashMap<>();

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext/src/main/java/org/eclipse/mylyn/wikitext/parser/markup/MarkupLanguage.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext/src/main/java/org/eclipse/mylyn/wikitext/parser/markup/MarkupLanguage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2007, 2013 David Green and others.
+ * Copyright (c) 2007, 2026 David Green and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -41,7 +41,7 @@ import org.eclipse.mylyn.wikitext.util.ServiceLocator;
  * </p>
  *
  * @author David Green
- * @since 3.0
+ * @since 4.12
  */
 public abstract class MarkupLanguage implements Cloneable {
 

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext/src/main/java/org/eclipse/mylyn/wikitext/parser/markup/MarkupLanguageConfiguration.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext/src/main/java/org/eclipse/mylyn/wikitext/parser/markup/MarkupLanguageConfiguration.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2009, 2013 David Green and others.
+ * Copyright (c) 2009, 2026 David Green and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -10,6 +10,7 @@
  * Contributors:
  *     David Green - initial API and implementation
  *     Martin Kurz - initial locale support (bug 290961)
+ *     Alexander Fedorov (ArSysOp) - ongoing support
  *******************************************************************************/
 
 package org.eclipse.mylyn.wikitext.parser.markup;
@@ -25,7 +26,7 @@ import org.eclipse.mylyn.wikitext.parser.markup.AbstractMarkupLanguage.PatternBa
  * modifiers, and tokens. Also provides a mechanism for disabling some common markup language features.
  *
  * @author David Green
- * @since 3.0
+ * @since 4.12
  */
 public class MarkupLanguageConfiguration implements Cloneable {
 

--- a/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext/src/main/java/org/eclipse/mylyn/wikitext/parser/markup/Processor.java
+++ b/mylyn.docs/wikitext/core/org.eclipse.mylyn.wikitext/src/main/java/org/eclipse/mylyn/wikitext/parser/markup/Processor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2007, 2013 David Green and others.
+ * Copyright (c) 2007, 2026 David Green and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -9,6 +9,7 @@
  *
  * Contributors:
  *     David Green - initial API and implementation
+ *     Alexander Fedorov (ArSysOp) - ongoing support
  *******************************************************************************/
 package org.eclipse.mylyn.wikitext.parser.markup;
 
@@ -17,7 +18,7 @@ import org.eclipse.mylyn.wikitext.parser.MarkupParser;
 
 /**
  * @author David Green
- * @since 3.0
+ * @since 4.12
  */
 public class Processor implements Cloneable {
 	protected AbstractMarkupLanguage markupLanguage;


### PR DESCRIPTION
* update tag to 4.12

Fixes #1222 